### PR TITLE
ad9361: sample rate setter

### DIFF
--- a/adi/ad9361.py
+++ b/adi/ad9361.py
@@ -131,8 +131,66 @@ class ad9361(rx_tx, context_manager):
         return self._get_iio_attr("voltage0", "sampling_frequency", False)
 
     @sample_rate.setter
-    def sample_rate(self, value):
-        self._set_iio_attr("voltage0", "sampling_frequency", False, value)
+    def sample_rate(self, rate):
+        if (rate < 521e3):
+            raise ValueError("Error: Does not currently support sample rates below 521e3")
+
+        # The following was converted from ad9361_set_bb_rate() in libad9361-iio
+        if (rate <= 20000000):
+            dec = 4
+            fir = [-15,-27,-23,-6,17,33,31,9,-23,-47,-45,-13,34,69,67,21,-49,-102,-99,-32,69,146,143,48,-96,-204,-200,-69,129,278,275,97,-170,
+                -372,-371,-135,222,494,497,187,-288,-654,-665,-258,376,875,902,363,-500,-1201,-1265,-530,699,1748,1906,845,-1089,-2922,-3424,
+                -1697,2326,7714,12821,15921,15921,12821,7714,2326,-1697,-3424,-2922,-1089,845,1906,1748,699,-530,-1265,-1201,-500,363,902,875,
+                376,-258,-665,-654,-288,187,497,494,222,-135,-371,-372,-170,97,275,278,129,-69,-200,-204,-96,48,143,146,69,-32,-99,-102,-49,21,
+                67,69,34,-13,-45,-47,-23,9,31,33,17,-6,-23,-27,-15]
+            taps = 128
+        elif (rate <= 40000000):
+            dec = 2;
+            fir = [-0,0,1,-0,-2,0,3,-0,-5,0,8,-0,-11,0,17,-0,-24,0,33,-0,-45,0,61,-0,-80,0,104,-0,-134,0,169,-0,
+                -213,0,264,-0,-327,0,401,-0,-489,0,595,-0,-724,0,880,-0,-1075,0,1323,-0,-1652,0,2114,-0,-2819,0,4056,-0,-6883,0,20837,32767,
+                20837,0,-6883,-0,4056,0,-2819,-0,2114,0,-1652,-0,1323,0,-1075,-0,880,0,-724,-0,595,0,-489,-0,401,0,-327,-0,264,0,-213,-0,
+                169,0,-134,-0,104,0,-80,-0,61,0,-45,-0,33,0,-24,-0,17,0,-11,-0,8,0,-5,-0,3,0,-2,-0,1,0,-0, 0]
+            taps = 128
+        elif (rate <= 53333333):
+            dec = 2
+            fir = [-4,0,8,-0,-14,0,23,-0,-36,0,52,-0,-75,0,104,-0,-140,0,186,-0,-243,0,314,-0,-400,0,505,-0,-634,0,793,-0,-993,0,1247,-0,-1585,
+                0,2056,-0,-2773,0,4022,-0,-6862,0,20830,32767,20830,0,-6862,-0,4022,0,-2773,-0,2056,0,-1585,-0,1247,0,-993,-0,793,0,-634,-0,505,0,
+                -400,-0,314,0,-243,-0,186,0,-140,-0,104,0,-75,-0,52,0,-36,-0,23,0,-14,-0,8,0,-4,0]
+            taps = 96
+        else:
+            dec = 2
+            fir = [-58,0,83,-0,-127,0,185,-0,-262,0,361,-0,-488,0,648,-0,-853,0,1117,-0,-1466,0,1954,-0,-2689,0,3960,-0,-6825,0,20818,32767,
+                20818,0,-6825,-0,3960,0,-2689,-0,1954,0,-1466,-0,1117,0,-853,-0,648,0,-488,-0,361,0,-262,-0,185,0,-127,-0,83,0,-58,0]
+            taps = 64
+
+        current_rate = self._get_iio_attr("voltage0", "sampling_frequency", False)
+
+        if self._get_iio_attr("out", "voltage_filter_fir_en", False):
+            if (current_rate <= (25000000 // 12)):
+                self._set_iio_attr("voltage0", "sampling_frequency", False, 3000000)
+            self._set_iio_attr("out", "voltage_filter_fir_en", False, 0)
+
+        # Assemble FIR filter config string
+        fir_config_string = ''
+        fir_config_string += "RX 3 GAIN -6 DEC " + str(dec) + "\n"
+        fir_config_string += "TX 3 GAIN 0 INT " + str(dec) + "\n"
+        for i in range(taps):
+            fir_config_string += (str(fir[i]) + "," + str(fir[i]) + "\n")
+        fir_config_string += "\n"
+        self._set_iio_dev_attr_str("filter_fir_config", fir_config_string)
+
+        if (rate <= (25000000 // 12)):
+            readbuf = self._get_iio_dev_attr_str("tx_path_rates")
+            dacrate = int(readbuf.split(' ')[1].split(':')[1])
+            txrate =  int(readbuf.split(' ')[5].split(':')[1])
+            max_rate = (dacrate // txrate) * 16
+            if (max_rate < taps):
+                self._set_iio_attr("voltage0", "sampling_frequency", False, 3000000)
+            self._set_iio_attr("out", "voltage_filter_fir_en", False, 1)
+            self._set_iio_attr("voltage0", "sampling_frequency", False, rate)
+        else:
+            self._set_iio_attr("voltage0", "sampling_frequency", False, rate)
+            self._set_iio_attr("out", "voltage_filter_fir_en", False, 1) 
 
     @property
     def rx_lo(self):


### PR DESCRIPTION
updated sample rate setter to match behavior in ad9361_baseband_auto_rate.c.  Allows Pluto to go down to 521kHz (couldn't go lower than around 2.5MHz prior).  I tested it by tuning to the FM band and "zooming" in and out, and it seemed to work fine, but it wasn't a comprehensive test.  