### PR TITLE
String attribute fixes

### DIFF
--- a/adi/ad9361.py
+++ b/adi/ad9361.py
@@ -81,7 +81,7 @@ class ad9361(rx_tx, context_manager):
     def gain_control_mode(self):
         """gain_control_mode: Mode of receive path AGC. Options are:
         slow_attack, fast_attack, manual"""
-        return self._get_iio_attr("voltage0", "gain_control_mode", False)
+        return self._get_iio_attr_str("voltage0", "gain_control_mode", False)
 
     @gain_control_mode.setter
     def gain_control_mode(self, value):

--- a/adi/ad9371.py
+++ b/adi/ad9371.py
@@ -58,7 +58,7 @@ class ad9371(rx_tx, context_manager):
     def gain_control_mode(self):
         """gain_control_mode: Mode of receive path AGC. Options are:
         automatic, hybrid, manual"""
-        return self._get_iio_attr("voltage0", "gain_control_mode", False)
+        return self._get_iio_attr_str("voltage0", "gain_control_mode", False)
 
     @gain_control_mode.setter
     def gain_control_mode(self, value):

--- a/adi/adrv9009.py
+++ b/adi/adrv9009.py
@@ -69,7 +69,7 @@ class adrv9009(rx_tx, context_manager):
     def gain_control_mode(self):
         """gain_control_mode: Mode of receive path AGC. Options are:
         slow_attack, manual"""
-        return self._get_iio_attr("voltage0", "gain_control_mode", False)
+        return self._get_iio_attr_str("voltage0", "gain_control_mode", False)
 
     @gain_control_mode.setter
     def gain_control_mode(self, value):

--- a/adi/adrv9009_zu11eg.py
+++ b/adi/adrv9009_zu11eg.py
@@ -67,7 +67,7 @@ class adrv9009_zu11eg(adrv9009):
     def gain_control_mode_chip_b(self):
         """gain_control_mode_chip_b: Mode of receive path AGC. Options are:
         slow_attack, manual"""
-        return self._get_iio_attr("voltage0", "gain_control_mode", False, self._ctrl_b)
+        return self._get_iio_attr_str("voltage0", "gain_control_mode", False, self._ctrl_b)
 
     @gain_control_mode_chip_b.setter
     def gain_control_mode_chip_b(self, value):

--- a/test/test_ad9361.py
+++ b/test/test_ad9361.py
@@ -92,6 +92,25 @@ class TestAD9361(unittest.TestCase):
         s = np.sum(np.abs(data))
         del sdr
         self.assertGreater(s, 0, "check non-zero data")
+    
+    @unittest.skipUnless(check_dev("packrf"), "AD9361SDR not attached")
+    def testAD9361GainControlCheck(self):
+        # See if we can get non-zero data from AD9361
+        global URI
+        sdr = ad9361(uri=URI)
+        sdr.gain_control_mode = "manual"
+        current_gain = sdr.rx_hardwaregain
+        if current_gain==73:
+            next_gain = 70
+        else:
+            next_gain = current_gain + 1
+        sdr.rx_hardwaregain = next_gain
+        updated_gain = sdr.rx_hardwaregain
+        del sdr
+        self.assertNotEqual(current_gain, next_gain, "Gain not updating")
+        self.assertNotEqual(current_gain, updated_gain, "Gain not updating")
+        self.assertEqual(next_gain, updated_gain, "Gain not updating")
+
 
     @unittest.skipUnless(check_dev("packrf"), "AD9361SDR not attached")
     def testAD9361DAC(self):

--- a/test/test_adis16460_attr.py
+++ b/test/test_adis16460_attr.py
@@ -47,7 +47,7 @@ def test_adis16460_attribute_single_value(attr, start, stop, tol):
     nums = []
     for k in range(0, 12):
         nums.append(2 ** k)
-    ind = random.randint(0, len(nums))
+    ind = random.randint(0, len(nums)-1)
     val = nums[ind]
     # Check hardware
     setattr(sdr, attr, val)


### PR DESCRIPTION
Fix some string attribute writes which were broken in some of the new type-specific APIs. Added test to catch this case for gain control

Signed-off-by: Travis F. Collins <travis.collins@analog.com>