### PR TITLE
Add support for AD7124

### DIFF
--- a/adi/ad7124.py
+++ b/adi/ad7124.py
@@ -1,0 +1,116 @@
+# Copyright (C) 2019 Analog Devices, Inc.
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#     - Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     - Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#     - Neither the name of Analog Devices, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#     - The use of this software may or may not infringe the patent rights
+#       of one or more patent holders.  This license does not release you
+#       from the requirement that you obtain separate licenses from these
+#       patent holders to use this software.
+#     - Use of the software either in source or binary form, must be run
+#       on or directly connected to an Analog Devices Inc. component.
+#
+# THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED.
+#
+# IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, INTELLECTUAL PROPERTY
+# RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from decimal import Decimal
+
+import numpy as np
+from adi.attribute import attribute
+from adi.context_manager import context_manager
+from adi.rx_tx import rx
+
+
+class ad7124(rx, context_manager):
+    """ AD7124 ADC """
+
+    _complex_data = False
+    channel = []
+    _device_name = ""
+
+    def __init__(self, uri=""):
+
+        context_manager.__init__(self, uri, self._device_name)
+        self._ctrl = self._ctx.find_device("ad7124-8")
+        self._rxadc = self._ctx.find_device("ad7124-8")
+
+        # dynamically get channels
+        for ch in self._ctrl._channels:
+            name = ch._id
+            self._rx_channel_names.append(name)
+            self.channel.append(self._channel(self._ctrl, name))
+        rx.__init__(self)
+
+    @property
+    def sampling_frequency(self):
+        # only works with the same frequency for all channels
+        return self._get_iio_attr(self.channel[0].name, "sampling_frequency", False)
+
+    @sampling_frequency.setter
+    def sampling_frequency(self, value):
+        for ch in self.channel:
+            self._set_iio_attr(ch.name, "sampling_frequency", False, value)
+        return 1
+
+    @property
+    def scale_available(self):
+        return self._get_iio_attr(self.channel[0].name, "scale_available", False)
+
+    class _channel(attribute):
+        def __init__(self, ctrl, channel_name):
+            self.name = channel_name
+            self._ctrl = ctrl
+
+        @property
+        def raw(self):
+            return self._get_iio_attr(self.name, "raw", False)
+
+        @property
+        def scale(self):
+            return float(self._get_iio_attr_str(self.name, "scale", False))
+
+        @scale.setter
+        def scale(self, value):
+            return self._set_iio_attr(
+                self.name, "scale", False, str(Decimal(value).real)
+            )
+
+        @property
+        def offset(self):
+            return self._get_iio_attr(self.name, "offset", False)
+
+        @offset.setter
+        def offset(self, value):
+            return self._get_iio_attr(self.name, "offset", False, value)
+
+    def to_volts(self, index, val):
+        _scale = self.channel[index].scale
+        _offset = self.channel[index].offset
+
+        ret = None
+
+        if isinstance(val, np.int16):
+            ret = val * _scale + _offset
+
+        if isinstance(val, np.ndarray):
+            ret = [x * _scale + _offset for x in val]
+
+        return ret

--- a/adi/ad7124.py
+++ b/adi/ad7124.py
@@ -45,6 +45,7 @@ class ad7124(rx, context_manager):
     _complex_data = False
     channel = []
     _device_name = ""
+    _rx_data_type = np.int32
 
     def __init__(self, uri=""):
 

--- a/adi/ad7124.py
+++ b/adi/ad7124.py
@@ -69,7 +69,6 @@ class ad7124(rx, context_manager):
     def sampling_frequency(self, value):
         for ch in self.channel:
             self._set_iio_attr(ch.name, "sampling_frequency", False, value)
-        return 1
 
     @property
     def scale_available(self):
@@ -90,7 +89,7 @@ class ad7124(rx, context_manager):
 
         @scale.setter
         def scale(self, value):
-            return self._set_iio_attr(
+            self._set_iio_attr(
                 self.name, "scale", False, str(Decimal(value).real)
             )
 
@@ -100,7 +99,7 @@ class ad7124(rx, context_manager):
 
         @offset.setter
         def offset(self, value):
-            return self._get_iio_attr(self.name, "offset", False, value)
+            self._get_iio_attr(self.name, "offset", False, value)
 
     def to_volts(self, index, val):
         _scale = self.channel[index].scale

--- a/adi/ad7124.py
+++ b/adi/ad7124.py
@@ -61,12 +61,12 @@ class ad7124(rx, context_manager):
         rx.__init__(self)
 
     @property
-    def sampling_frequency(self):
+    def sample_rate(self):
         """Sets sampling frequency of the AD7124"""
         return self._get_iio_attr(self.channel[0].name, "sampling_frequency", False)
 
-    @sampling_frequency.setter
-    def sampling_frequency(self, value):
+    @sample_rate.setter
+    def sample_rate(self, value):
         for ch in self.channel:
             self._set_iio_attr(ch.name, "sampling_frequency", False, value)
 

--- a/adi/ad7124.py
+++ b/adi/ad7124.py
@@ -62,7 +62,7 @@ class ad7124(rx, context_manager):
 
     @property
     def sampling_frequency(self):
-        # only works with the same frequency for all channels
+        """Sets sampling frequency of the AD7124"""
         return self._get_iio_attr(self.channel[0].name, "sampling_frequency", False)
 
     @sampling_frequency.setter
@@ -72,19 +72,23 @@ class ad7124(rx, context_manager):
 
     @property
     def scale_available(self):
+        """Provides all available scale(gain) settings for the AD7124 channels"""
         return self._get_iio_attr(self.channel[0].name, "scale_available", False)
 
     class _channel(attribute):
+        """AD7124 channel"""
         def __init__(self, ctrl, channel_name):
             self.name = channel_name
             self._ctrl = ctrl
 
         @property
         def raw(self):
+            """AD7124 channel raw value"""
             return self._get_iio_attr(self.name, "raw", False)
 
         @property
         def scale(self):
+            """AD7124 channel scale(gain)"""
             return float(self._get_iio_attr_str(self.name, "scale", False))
 
         @scale.setter
@@ -95,6 +99,7 @@ class ad7124(rx, context_manager):
 
         @property
         def offset(self):
+            """AD7124 channel offset"""
             return self._get_iio_attr(self.name, "offset", False)
 
         @offset.setter
@@ -102,6 +107,7 @@ class ad7124(rx, context_manager):
             self._get_iio_attr(self.name, "offset", False, value)
 
     def to_volts(self, index, val):
+        """Converts raw value to SI"""
         _scale = self.channel[index].scale
         _offset = self.channel[index].offset
 

--- a/adi/adis16460.py
+++ b/adi/adis16460.py
@@ -49,7 +49,7 @@ class adis16460(rx, context_manager):
         "accel_z",
     ]
     _device_name = ""
-    _rx_data_type = np.int32
+    _rx_data_type = '>i4'
 
     def __init__(self, uri=""):
 

--- a/adi/rx_tx.py
+++ b/adi/rx_tx.py
@@ -54,6 +54,7 @@ class rx(attribute):
     _rx_channel_names: List[str] = []
     _complex_data = False
     _rx_data_type = np.int16
+    _rx_output_type = 'raw'
     __rxbuf = None
 
     def __init__(self, rx_buffer_size=1024):
@@ -140,8 +141,27 @@ class rx(attribute):
         x = np.frombuffer(data, dtype=self._rx_data_type)
         sig = []
         stride = len(self.rx_enabled_channels)
-        for c in range(stride):
-            sig.append(x[c::stride])
+
+        if self._rx_output_type=='raw':
+            for c in range(stride):
+                sig.append(x[c::stride])
+        elif self._rx_output_type=='SI':
+            rx_scale = []
+            rx_offset = []
+            for i in self.rx_enabled_channels:
+                v = self._rxadc.find_channel(self._rx_channel_names[i])
+                scale = self._get_iio_attr(self._rx_channel_names[i], "scale", False)
+                offset = self._get_iio_attr(self._rx_channel_names[i], "offset", False)
+                rx_scale.append(scale)
+                rx_offset.append(offset)
+
+            for c in range(stride):
+                sig.append(x[c::stride] * rx_scale[c] + rx_offset[c])
+        else:
+            raise Exception(
+                "rx_output_type undefined"
+            )
+
         # Don't return list if a single channel
         if len(self.rx_enabled_channels) == 1:
             return sig[0]

--- a/adi/rx_tx.py
+++ b/adi/rx_tx.py
@@ -150,13 +150,21 @@ class rx(attribute):
             rx_offset = []
             for i in self.rx_enabled_channels:
                 v = self._rxadc.find_channel(self._rx_channel_names[i])
-                scale = self._get_iio_attr(self._rx_channel_names[i], "scale", False)
-                offset = self._get_iio_attr(self._rx_channel_names[i], "offset", False)
+                if "scale" in v.attrs:
+                    scale = self._get_iio_attr(self._rx_channel_names[i], "scale", False)
+                else:
+                    scale = 1.0
+
+                if "offset" in v.attrs:
+                    offset = self._get_iio_attr(self._rx_channel_names[i], "offset", False)
+                else:
+                    offset=0.0
                 rx_scale.append(scale)
                 rx_offset.append(offset)
 
             for c in range(stride):
-                sig.append(x[c::stride] * rx_scale[c] + rx_offset[c])
+                raw=x[c::stride]
+                sig.append( raw * rx_scale[c] + rx_offset[c])
         else:
             raise Exception(
                 "rx_output_type undefined"

--- a/adi/rx_tx.py
+++ b/adi/rx_tx.py
@@ -54,7 +54,7 @@ class rx(attribute):
     _rx_channel_names: List[str] = []
     _complex_data = False
     _rx_data_type = np.int16
-    _rx_output_type = 'raw'
+    rx_output_type = 'raw'
     __rxbuf = None
 
     def __init__(self, rx_buffer_size=1024):
@@ -142,10 +142,10 @@ class rx(attribute):
         sig = []
         stride = len(self.rx_enabled_channels)
 
-        if self._rx_output_type=='raw':
+        if self.rx_output_type=='raw':
             for c in range(stride):
                 sig.append(x[c::stride])
-        elif self._rx_output_type=='SI':
+        elif self.rx_output_type=='SI':
             rx_scale = []
             rx_offset = []
             for i in self.rx_enabled_channels:

--- a/examples/ad7124.py
+++ b/examples/ad7124.py
@@ -46,8 +46,9 @@ ad7124.sampling_frequency = 19200 # sets sample rate for all channels
 ad7124.rx_enabled_channels = [ 0 ] # currently only one enabled channel buffer works at a time
 ad7124.rx_buffer_size = 100
 
-data = ad7124.rx()
 raw = ad7124.channel[0].raw
+data = ad7124.rx()
+
 volt_data = ad7124.to_volts(0, data)
 volt_raw = ad7124.to_volts(0, data[0])
 

--- a/examples/ad7124.py
+++ b/examples/ad7124.py
@@ -41,7 +41,7 @@ ad7124 = adi.ad7124(uri="ip:192.168.1.171")
 
 sc = ad7124.scale_available
 ad7124.channel[0].scale = sc[2]
-ad7124._rx_output_type='SI'
+ad7124.rx_output_type='SI'
 
 ad7124.sample_rate = 19200 # sets sample rate for all channels
 ad7124.rx_enabled_channels = [ 0 ] # currently only one enabled channel buffer works at a time

--- a/examples/ad7124.py
+++ b/examples/ad7124.py
@@ -43,7 +43,7 @@ sc = ad7124.scale_available
 ad7124.channel[0].scale = sc[2]
 ad7124._rx_output_type='SI'
 
-ad7124.sampling_frequency = 19200 # sets sample rate for all channels
+ad7124.sample_rate = 19200 # sets sample rate for all channels
 ad7124.rx_enabled_channels = [ 0 ] # currently only one enabled channel buffer works at a time
 ad7124.rx_buffer_size = 100
 

--- a/examples/ad7124.py
+++ b/examples/ad7124.py
@@ -41,6 +41,7 @@ ad7124 = adi.ad7124(uri="ip:192.168.1.171")
 
 sc = ad7124.scale_available
 ad7124.channel[0].scale = sc[2]
+ad7124._rx_output_type='SI'
 
 ad7124.sampling_frequency = 19200 # sets sample rate for all channels
 ad7124.rx_enabled_channels = [ 0 ] # currently only one enabled channel buffer works at a time

--- a/examples/ad7124.py
+++ b/examples/ad7124.py
@@ -31,23 +31,26 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from adi.ad9361 import *
+import adi
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy import signal
 
-from adi.ad9371 import *
+# Set up AD7124
+ad7124 = adi.ad7124(uri="ip:192.168.1.171")
 
-from adi.adrv9009 import *
+sc = ad7124.scale_available
+ad7124.channel[0].scale = sc[2]
 
-from adi.adrv9009_zu11eg import *
+ad7124.sampling_frequency = 19200 # sets sample rate for all channels
+ad7124.rx_enabled_channels = [ 0 ] # currently only one enabled channel buffer works at a time
+ad7124.rx_buffer_size = 100
 
-from adi.ad9680 import *
+data = ad7124.rx()
+raw = ad7124.channel[0].raw
+volt_data = ad7124.to_volts(0, data)
+volt_raw = ad7124.to_volts(0, data[0])
 
-from adi.ad9144 import *
+print(data)
 
-from adi.daq2 import *
 
-from adi.adis16460 import *
-
-from adi.ad7124 import *
-
-__version__ = "0.0.3"
-name = "Analog Devices Hardware Interfaces"

--- a/examples/adis16460
+++ b/examples/adis16460
@@ -1,0 +1,53 @@
+# Copyright (C) 2019 Analog Devices, Inc.
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#     - Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     - Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#     - Neither the name of Analog Devices, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#     - The use of this software may or may not infringe the patent rights
+#       of one or more patent holders.  This license does not release you
+#       from the requirement that you obtain separate licenses from these
+#       patent holders to use this software.
+#     - Use of the software either in source or binary form, must be run
+#       on or directly connected to an Analog Devices Inc. component.
+#
+# THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED.
+#
+# IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, INTELLECTUAL PROPERTY
+# RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import adi
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy import signal
+
+# Set up AD7124
+adis16460 = adi.adis16460()
+
+adis16460.rx_output_type='SI'
+adis16460.rx_enabled_channels=[4,5]
+adis16460.sample_rate=2048
+adis16460.rx_buffer_size=100
+
+data = adis16460.rx()
+
+# print Y and Z axis acceleration
+print(data)
+
+
+


### PR DESCRIPTION
The AD7124 driver still has some issues, however this should be the API.

A few notes:
- Currently it only works when one channel is enabled.
- There are sample rates for all channels (and they are not shared attributes), however i'm not sure how it is supposed to work when having multiple channels enabled - same buffer, multiple rates. This is why I set the sample rate for all channels
- The scale and scale_available attribute was trickier because the str(float val) gives a value like 4.56+e06 which is incompatible with IIO.
- I'm not sure where the to_volts method should be implemented as it uses different coeficients for different channels.
- I created the channels list on __init__ dynamically. I do this because the number of channels is reconfigurable via devicetree. Does it make sense reffering to channels by index ? Or you should refer to channels by name. A channel name for ad7124 is "input voltageX-voltageY" because the input is always differential.
- The example just gets data from the ADC. I can create some plots when the driver will work properly. It currently gives out junk values.

Signed-off-by: Adrian Suciu <adrian.suciu@analog.com>