### PR TITLE
Add other python versions to ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
 - '3.6'
 - '3.7'
+- '3.8'
 install:
 - sudo apt-get -qq update
 - sudo apt-get install -y git cmake graphviz libaio-dev libavahi-client-dev libavahi-common-dev
@@ -19,6 +20,7 @@ install:
 script:
 - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then export PYTHONPATH=$PYTHONPATH:'/usr/lib/python3.6/site-packages'; fi
 - if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then export PYTHONPATH=$PYTHONPATH:'/usr/lib/python3.7/site-packages'; fi
+- if [[ $TRAVIS_PYTHON_VERSION == '3.8' ]]; then export PYTHONPATH=$PYTHONPATH:'/usr/lib/python3.8/site-packages'; fi
 - pytest -v
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pyadi-iio: Analog Devices python interfaces for hardware with Industrial I/O drivers
 
 [![Build Status](https://travis-ci.org/analogdevicesinc/pyadi-iio.svg?branch=master)](https://travis-ci.org/analogdevicesinc/pyadi-iio)
-[![PyPI version](https://badge.fury.io/py/pyadi-iio.svg)](https://badge.fury.io/py/pyadi-iio) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/4bd027bfc5774029a30a9e1cedf5a434)](https://www.codacy.com/app/travis.collins/pyadi-iio?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=analogdevicesinc/pyadi-iio&amp;utm_campaign=Badge_Grade)
+[![PyPI version](https://badge.fury.io/py/pyadi-iio.svg)](https://badge.fury.io/py/pyadi-iio) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/4bd027bfc5774029a30a9e1cedf5a434)](https://www.codacy.com/app/travis.collins/pyadi-iio?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=analogdevicesinc/pyadi-iio&amp;utm_campaign=Badge_Grade) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pyadi-iio)
 
 [[Docs](http://analogdevicesinc.github.io/pyadi-iio/)]
 [[Support](http://ez.analog.com)]

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/analogdevicesinc/pyadi-iio",
     packages=setuptools.find_packages(),
+    python_requires='>=3.6',
     install_requires=["numpy"],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
PR explicitly sets supported python versions (3.6+)

Signed-off-by: Travis F. Collins <travis.collins@analog.com>