### PR TITLE
Add observation buffered channel support

### DIFF
--- a/adi/ad9371.py
+++ b/adi/ad9371.py
@@ -32,6 +32,7 @@
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from adi.context_manager import context_manager
+from adi.obs import obs
 from adi.rx_tx import rx_tx
 
 
@@ -41,6 +42,7 @@ class ad9371(rx_tx, context_manager):
     _complex_data = True
     _rx_channel_names = ["voltage0_i", "voltage0_q", "voltage1_i", "voltage1_q"]
     _tx_channel_names = ["voltage0", "voltage1", "voltage2", "voltage3"]
+    _obs_channel_names = ["voltage0_i", "voltage0_q"]
     _device_name = ""
 
     def __init__(self, uri=""):
@@ -53,6 +55,8 @@ class ad9371(rx_tx, context_manager):
         self._txdac = self._ctx.find_device("axi-ad9371-tx-hpc")
 
         rx_tx.__init__(self)
+
+        self.obs = obs(self._ctx, self._rxobs, self._obs_channel_names)
 
     @property
     def gain_control_mode(self):
@@ -130,3 +134,23 @@ class ad9371(rx_tx, context_manager):
     @sn_lo.setter
     def sn_lo(self, value):
         self._set_iio_attr("altvoltage2", "RX_SN_LO_frequency", True, value)
+
+    @property
+    def obs_rf_port_select(self):
+        """obs_rf_port_select: Observation path source. Options are:
+            OFF - SnRx path is disabled
+            ORX1_TX_LO – SnRx operates in observation mode on ORx1 with Tx LO synthesizer
+            ORX2_TX_LO – SnRx operates in observation mode on ORx2 with Tx LO synthesizer
+            INTERNALCALS – enables scheduled Tx calibrations while using SnRx path. The enableTrackingCals function needs to be called in RADIO_OFF state. It sets the calibration mask, which the scheduler will later use to schedule the desired calibrations. This command is issued in RADIO_OFF. Once the AD9371 moves to RADIO_ON state, the internal scheduler will use the enabled calibration mask to schedule calibrations whenever possible, based on the state of the transceiver. The Tx calibrations will not be scheduled until INTERNALCALS is selected and the Tx calibrations are enabled in the cal mask.
+            OBS_SNIFFER – SnRx operates in sniffer mode with latest selected Sniffer Input – for hardware pin control operation. In pin mode, the GPIO pins designated for ORX_MODE would select SNIFFER mode. Then MYKONOS_setSnifferChannel function would choose the channel.
+            ORX1_SN_LO – SnRx operates in observation mode on ORx1 with SNIFFER LO synthesizer
+            ORX2_SN_LO – SnRx operates in observation mode on ORx2 with SNIFFER LO synthesizer
+            SN_A – SnRx operates in sniffer mode on SnRxA with SNIFFER LO synthesizer
+            SN_B – SnRx operates in sniffer mode on SnRxB with SNIFFER LO synthesizer
+            SN_C – SnRx operates in sniffer mode on SnRxC with SNIFFER LO synthesizer
+        """
+        return self._get_iio_attr_str("voltage2", "rf_port_select", False)
+
+    @obs_rf_port_select.setter
+    def obs_rf_port_select(self, value):
+        self._set_iio_attr("voltage2", "rf_port_select", False, value)

--- a/adi/obs.py
+++ b/adi/obs.py
@@ -1,0 +1,48 @@
+# Copyright (C) 2020 Analog Devices, Inc.
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#     - Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     - Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#     - Neither the name of Analog Devices, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#     - The use of this software may or may not infringe the patent rights
+#       of one or more patent holders.  This license does not release you
+#       from the requirement that you obtain separate licenses from these
+#       patent holders to use this software.
+#     - Use of the software either in source or binary form, must be run
+#       on or directly connected to an Analog Devices Inc. component.
+#
+# THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED.
+#
+# IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, INTELLECTUAL PROPERTY
+# RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+from adi.rx_tx import rx
+
+
+class obs(rx):
+    """ Buffer handling for observation devices """
+
+    def __init__(self, ctx, obs_dev, channel_names):
+        self._ctx = ctx
+        self._rxadc = obs_dev
+        self._rx_channel_names = channel_names
+        rx.__init__(self)
+
+    def __del__(self):
+        rx.__del__(self)


### PR DESCRIPTION
Add core components for observation channels and updated AD9371 class to
add this feature. This includes an additional attribute for the
observation path which is required to get data for the AD9371
specifically.

Signed-off-by: Travis F. Collins <travis.collins@analog.com>