### PR TITLE
 Added URI argument to use specific board in the pytest.

### DIFF
--- a/test/iio_scanner.py
+++ b/test/iio_scanner.py
@@ -22,6 +22,13 @@ def check_iio(address):
         return False
 
 
+def check_iio_uri(uri):
+    try:
+        return iio.Context(uri)
+    except:
+        return False
+
+
 def dump(obj):
     for attr in dir(obj):
         print("obj.%s = %r" % (attr, getattr(obj, attr)))
@@ -179,17 +186,37 @@ def scan_all(skip_usb=False):
     return boards
 
 
-def find_device(names):
+def get_device(uri):
+    ctx = check_iio_uri(uri)
+    if ctx:
+        board_name = check_board_other(ctx)
+        if board_name:
+            if ctx.name == "local":
+                b = board(board_name, "local:")
+            else:
+                b = board(board_name, uri)
+        return b
+    return None
+
+
+def find_device(names, uri=None):
     skip_usb = False
     if not isinstance(names, list):
         names = [names]
-    # for n in names:
-    #     if n=="adrv9009-dual":
-    #         skip_usb = True
-    for b in scan_all(skip_usb):
+    if uri:
+        b = get_device(uri)
+        if b:
+            boards = [b]
+        else:
+            return (False, [])
+    else:
+        boards = scan_all(skip_usb)
+
+    for b in boards:
         for name in names:
             if b.name == name:
                 return (True, b)
+
     return (False, [])
 
 


### PR DESCRIPTION
Changes:
1. Added a --uri parameter for pytest to target specific boards.
2. Do the ignore_skip checking if check_dev fails. So if check_dev fails, it either skips or fail(if --error_on_filter is passed).


Usage:
1. On specific test file:
pytest <test_filename> --uri=< uri of board >
e.g.:
   pytest test/test_pluto_p.py --uri=ip:192.168.2.2
This should execute tests normally.
2. All tests:
pytest --uri=< uri of board >
e.g.:
   pytest --uri=ip:192.168.2.2
This should skip all the tests that uses a device name that does not match the device name of the Context created from 192.168.2.2. This is the IP of pluto in this case so, only the Pluto related tests will be executed.

You can also use --error_on_filter with --uri. So, instead of skipping, tests that does not match the board pointed by the uri will fail.