### PR TITLE
Support for CN0511

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,17 @@ venv.bak/
 .spyderproject
 .spyproject
 
+# Visual Studio Code project settings
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+
+# Local History for Visual Studio Code
+.history/
+
 # Rope project settings
 .ropeproject
 

--- a/adi/__init__.py
+++ b/adi/__init__.py
@@ -31,6 +31,8 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from adi.ad916x import *
+
 from adi.ad936x import *
 
 from adi.fmcomms5 import *
@@ -58,6 +60,8 @@ from adi.adis16507 import *
 from adi.ad7124 import *
 
 from adi.adxl345 import *
+
+from adi.cn0511 import *
 
 from adi.fmclidar1 import *
 

--- a/adi/ad916x.py
+++ b/adi/ad916x.py
@@ -1,0 +1,237 @@
+# Copyright (C) 2019 Analog Devices, Inc.
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#     - Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     - Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#     - Neither the name of Analog Devices, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#     - The use of this software may or may not infringe the patent rights
+#       of one or more patent holders.  This license does not release you
+#       from the requirement that you obtain separate licenses from these
+#       patent holders to use this software.
+#     - Use of the software either in source or binary form, must be run
+#       on or directly connected to an Analog Devices Inc. component.
+#
+# THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED.
+#
+# IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, INTELLECTUAL PROPERTY
+# RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import iio
+
+from adi.attribute import attribute
+from adi.context_manager import context_manager
+
+
+class ad9166(attribute, context_manager):
+    """ AD916x Vector Signal Generator """
+
+    _complex_data = False
+    channel = []  # type: ignore
+    _tx_channel_names = ["altvoltage0"]  # type: ignore
+    _device_name = ""
+    _temperatureRef = 32.0
+    _temperatureRefCode = 0x8008
+    _temperatureM = (_temperatureRef + 190) / (_temperatureRefCode / 1000)
+
+    def __init__(self, uri=""):
+
+        context_manager.__init__(self, uri, self._device_name)
+        self._ctrl = self._ctx.find_device("ad9166")
+        self._txdac = self._ctx.find_device("ad9166")
+        self._temp_sensor_name = "temp0"
+
+        # dynamically get NCO channels
+        for ch in self._ctrl._channels:
+            if ch.id in self._tx_channel_names:
+                name = ch._id
+                self.channel.append(self._channel(self._ctrl, name))
+
+    @property
+    def sample_rate(self):
+        """ sample_rate: Sets sampling frequency of the AD916x """
+        return self._get_iio_dev_attr("sampling_frequency")
+
+    @sample_rate.setter
+    def sample_rate(self, value):
+        self._set_iio_dev_attr_str("sampling_frequency", value)
+
+    @property
+    def sample_rate_available(self):
+        return [5000000000, 5898240000, 6000000000]
+
+    @property
+    def temperature(self):
+        """ temperature: Returns the AD916x Chip Temperature in Celsius """
+        temp = 0
+        if self.temperature_enable:
+            try:
+                temp = (
+                    self._get_iio_attr(self._temp_sensor_name, "input", False) / 1000.0
+                )
+            except Exception:
+                # Use temporary single point calibration if not calibrated
+                self.temperature_cal = 34.0
+                temp = (
+                    self._get_iio_attr(self._temp_sensor_name, "input", False) / 1000.0
+                )
+            return temp
+        else:
+            return None
+
+    @property
+    def temperature_code(self):
+        """ temperature_code: Returns the AD916x Chip Temperature ADC code """
+        return self._get_iio_attr(self._temp_sensor_name, "raw", False)
+
+    @property
+    def temperature_enable(self):
+        """ temperature_enable: AD9166 Chip Temperature Measurement Enable
+            Options:
+                True: Temperature measurement is enabled
+                False: Temperature measurement is disabled
+        """
+        reg = self._ctrl.reg_read(0x135)
+        if (reg and 0x01) == 0x01:
+            return True
+        else:
+            return False
+
+    @temperature_enable.setter
+    def temperature_enable(self, value=True):
+        if value:
+            self._ctrl.reg_write(0x135, 0xA1)
+        else:
+            self._ctrl.reg_write(0x135, 0xA0)
+
+    @property
+    def temperature_cal(self):
+        """ temperature_cal: AD9166 Chip Temperature single point calibration value. Enter
+         the ambient temperature in degree Celsius.
+        """
+        return None
+
+    @temperature_cal.setter
+    def temperature_cal(self, value=32.0):
+        try:
+            val = int(round(value * 1000))
+            self._set_iio_attr(self._temp_sensor_name, "single_point_calib", False, val)
+        except Exception as ex:
+            raise ex
+
+    @property
+    def nco_enable(self):
+        """ nco_enable: AD9166 NCO Modulation Enable:
+            Options:
+                True: NCO Modulation is enabled
+                False: NCO Modulation is disabled
+        """
+        tmp_reg = self._ctrl.reg_read(0x111) & 0x40
+        if tmp_reg == 0:
+            return False
+        else:
+            return True
+        pass
+
+    @nco_enable.setter
+    def nco_enable(self, value=True):
+        tmp_reg = self._ctrl.reg_read(0x111) & 0xBF
+        if value:
+            # DATAPATH_CFG (0x111) Bit6=1
+            self._ctrl.reg_write(0x111, tmp_reg | 0x40)
+
+        else:
+            # DATAPATH_CFG (0x111) Bit6=0
+            self._ctrl.reg_write(0x111, tmp_reg)
+        pass
+
+    @property
+    def FIR85_enable(self):
+        """ FIR85_enable: AD9166 FIR85 Filter  Enable:
+            Options:
+                True: FIR85 Filter is enabled
+                False: FIR85 Filter is disabled
+        """
+        tmp_reg = self._ctrl.reg_read(0x111) & 0x01
+        if tmp_reg == 0:
+            return False
+        else:
+            return True
+        pass
+
+    @FIR85_enable.setter
+    def FIR85_enable(self, value=True):
+        tmp_reg = self._ctrl.reg_read(0x111) & 0xFE
+        if value:
+            # DATAPATH_CFG (0x111) Bit0=1
+            self._ctrl.reg_write(0x111, tmp_reg | 0x01)
+        else:
+            # DATAPATH_CFG (0x111) Bit0=0
+            self._ctrl.reg_write(0x111, tmp_reg)
+        pass
+
+    class _channel(attribute):
+        """ AD916x channel """
+
+        def __init__(self, ctrl, channel_name):
+            self.name = channel_name
+            self._ctrl = ctrl
+
+        @property
+        def tx_enable(self):
+            """ tx_enable: AD9166 TX Enable
+                Options:
+                    True: TX is enabled (Datapath is connected to DAC)
+                    False: TX is disabled or  (DAC input is zeroed)
+            """
+            tmp_reg = self._ctrl.reg_read(0x03F) & 0x80
+            if tmp_reg == 0:
+                return False
+            else:
+                return True
+            pass
+
+        @tx_enable.setter
+        def tx_enable(self, value=True):
+            # Supports only SPI Data Post Enable/disable.
+            # TODO: Implement other tx enable ways.
+
+            tmp_reg = self._ctrl.reg_read(0x03F) & 0x7F
+            if value:
+                # TX_ENABLE (0x3F) Bit7=1
+                self._ctrl.reg_write(0x03F, tmp_reg | 0x80)
+            else:
+                # TX_ENABLE (0x3F) Bit7=0
+                self._ctrl.reg_write(0x03F, tmp_reg)
+            pass
+
+        @property
+        def frequency(self):
+            """ frequency: AD916x channel nco frequency value in hz."""
+            return self._get_iio_attr(self.name, "nco_frequency", True)
+
+        @frequency.setter
+        def frequency(self, value):
+            return self._set_iio_attr(self.name, "nco_frequency", True, value)
+
+        @property
+        def raw(self):
+            """ raw: AD916x channel raw value. Integer range 0-32767. """
+            return self._get_iio_attr(self.name, "raw", True)
+
+        @raw.setter
+        def raw(self, value):
+            return self._set_iio_attr(self.name, "raw", True, value)

--- a/adi/cn0511.py
+++ b/adi/cn0511.py
@@ -1,0 +1,111 @@
+# Copyright (C) 2019 Analog Devices, Inc.
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#     - Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     - Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#     - Neither the name of Analog Devices, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#     - The use of this software may or may not infringe the patent rights
+#       of one or more patent holders.  This license does not release you
+#       from the requirement that you obtain separate licenses from these
+#       patent holders to use this software.
+#     - Use of the software either in source or binary form, must be run
+#       on or directly connected to an Analog Devices Inc. component.
+#
+# THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED.
+#
+# IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, INTELLECTUAL PROPERTY
+# RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import iio
+
+from adi.ad916x import ad9166
+from adi.context_manager import context_manager
+
+
+class CN0511(ad9166):
+    """ CN0511 Raspberry Pi Hat Signal Generator """
+
+    def __init__(self, uri=""):
+        context_manager.__init__(self, uri, self._device_name)
+        ad9166.__init__(self, uri=uri)
+        self._amp = self._ctx.find_device("ad9166-amp")
+        self._synth = self._ctx.find_device("adf4372")
+
+    @property
+    def amp_enable(self):
+        """ amp_enable: Enable or Disable the CN0511 ad9166 amplifier """
+        return True if (self._get_iio_dev_attr("en", _ctrl=self._amp) == 1) else False
+
+    @amp_enable.setter
+    def amp_enable(self, value=True):
+        if value:
+            val = 1
+        else:
+            val = 0
+        self._set_iio_dev_attr_str("en", val, _ctrl=self._amp)
+
+    @property
+    def pump_current_code(self):
+        """ pump_current_code: CN0511 ADF4372 pump current code. Values allowed:
+        0-15. Represents the pump current."""
+        return (self._synth.reg_read(0x1E) >> 4) & 0x0F
+
+    @pump_current_code.setter
+    def pump_current_code(self, value):
+        if value <= 15 and value >= 0:
+            # Power down first
+            self._synth.reg_write(0x1E, 0x05)
+            # Set new charge pump current (ICP_Iset) value
+            self._synth.reg_write(0x1E, (value & 0x0F) << 4 | 0x08)
+            self._synth.reg_write(0x10, 0x28)
+
+    @property
+    def pump_current_str(self):
+        """ pump_current_str: CN0511 ADF4372 pump current value """
+        return self.pump_current_available[self.pump_current_code]
+
+    @pump_current_str.setter
+    def pump_current_str(self, value):
+        try:
+            code = self.pump_current_available.index(value)
+            self.pump_current_code = code
+        except Exception:
+            pass
+
+    @property
+    def pump_current_available(self):
+        """ pump_current_available: CN0511 available pump currents. Returns the available
+         current setting for the pump. """
+        available = [
+            "0.35 mA",  # CP_CURRENT = 0000
+            "0.70 mA",  # CP_CURRENT = 0001
+            "1.05 mA",  # CP_CURRENT = 0010
+            "1.40 mA",  # CP_CURRENT = 0011
+            "1.75 mA",  # CP_CURRENT = 0100
+            "2.10 mA",  # CP_CURRENT = 0101
+            "2.35 mA",  # CP_CURRENT = 0110
+            "2.80 mA",  # CP_CURRENT = 0111
+            "3.15 mA",  # CP_CURRENT = 1000
+            "3.50 mA",  # CP_CURRENT = 1001
+            "3.85 mA",  # CP_CURRENT = 1010
+            "4.20 mA",  # CP_CURRENT = 1011
+            "4.55 mA",  # CP_CURRENT = 1100
+            "4.90 mA",  # CP_CURRENT = 1101
+            "5.25 mA",  # CP_CURRENT = 1110
+            "5.60 mA",  # CP_CURRENT = 1111
+        ]
+        return available

--- a/examples/cn0511.py
+++ b/examples/cn0511.py
@@ -36,39 +36,44 @@ import time
 import adi
 import numpy as np
 
-uri = "ip:192.168.254.102"
+# Set up CN0511. Replace URI with the actual uri of your CN0511 for remote access.
+uri = "ip:192.168.254.104"
+# uri = "local:"
+# replace ambient temperature value with actual temperature for temperature
+# calibration.
 ambient_temp = 32.0
-# Set up CN0511. Replace URI with the actual uri of your CN0511.
+
 rpi_sig_gen = adi.CN0511(uri=uri)
 
 # enable temperature measurements
 rpi_sig_gen.temperature_enable = True
 
 # calibrate temperature
-rpi_sig_gen.temperature_cal = 34.0  # Ambient
+rpi_sig_gen.temperature_cal = ambient_temp
 
 # Read temperature
 temp = rpi_sig_gen.temperature
-print("Temperature: " + str(temp) + "°C")
+print("Chip Temperature: " + str(temp) + "°C")
 
 # set NCO frequency in Hz
 rpi_sig_gen.nco_enable = True
-rpi_sig_gen.channel[0].frequency = 100000000
-print("Setting Output Frequency to: " + str(rpi_sig_gen.channel[0].frequency) + " Hz")
+rpi_sig_gen.frequency = 1985467370
+print("Output Frequency set to: " + str(rpi_sig_gen.frequency) + " Hz")
 
 # set scale of waveform (0-32767)
-rpi_sig_gen.channel[0].raw = 1000
+rpi_sig_gen.raw = 1000
 print(
-    "Setting Output scale to: "
-    + str(20 * np.log10(rpi_sig_gen.channel[0].raw / (2 ** 15)))
-    + " dBFS"
+    "Output scale set to: " + str(20 * np.log10(rpi_sig_gen.raw / (2 ** 15))) + " dBFS"
 )
 
 # enable transmit
-rpi_sig_gen.channel[0].tx_enable = True
+rpi_sig_gen.tx_enable = True
+print("Output enabled: ", rpi_sig_gen.tx_enable)
 
 # enable amplifier
 rpi_sig_gen.amp_enable = True
+
+print("Amplifier enabled: ", rpi_sig_gen.amp_enable)
 
 print("Sleeping for 15 secs")
 # sleep 15 sec
@@ -76,14 +81,17 @@ for i in range(15):
     print(".", end="", flush=True)
     time.sleep(1)
 print(".")
-# compute temperature
+
 # Read temperature
 temp = rpi_sig_gen.temperature
-print("Temperature: " + str(temp) + "°C")
+print("Chip Temperature: " + str(temp) + "°C")
 
-print("Frequency: " + str(rpi_sig_gen.channel[0].frequency) + " Hz")
-print("Scale: " + str(20 * np.log10(rpi_sig_gen.channel[0].raw / (2 ** 15))) + " dBFS")
+print("Output Frequency: " + str(rpi_sig_gen.frequency) + " Hz")
+print("Output power: " + str(20 * np.log10(rpi_sig_gen.raw / (2 ** 15))) + " dBFS")
 
-# turn off amplifier and disable transmit
+print("Disabling the amplifier and output...")
+# turn off amplifier and disable output
 rpi_sig_gen.amp_enable = False
-rpi_sig_gen.channel[0].tx_enable = False
+print("Amplifier enabled: ", rpi_sig_gen.amp_enable)
+rpi_sig_gen.tx_enable = False
+print("Output enabled: ", rpi_sig_gen.tx_enable)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -198,6 +198,14 @@ def attribute_single_value_pow2(classname, devicename, attr, max_pow, tol):
     assert bi.dev_interface(val, attr, tol) <= tol
 
 
+def attribute_single_value_boolean(classname, devicename, attr, value):
+    bi = BoardInterface(classname, devicename)
+    # Pick random number in operational range
+    setattr(bi, attr, value)
+    rval = getattr(bi, attr)
+    assert rval == value
+
+
 def dma_rx(classname, devicename, channel):
     bi = BoardInterface(classname, devicename)
     sdr = eval(bi.classname + "(uri='" + bi.uri + "')")
@@ -581,6 +589,12 @@ def test_attribute_single_value_str(request):
 def test_attribute_single_value_pow2(request):
     command_line_config(request)
     yield attribute_single_value_pow2
+
+
+@pytest.fixture()
+def test_attribute_single_value_boolean(request):
+    command_line_config(request)
+    yield attribute_single_value_boolean
 
 
 @pytest.fixture()

--- a/test/iio_scanner.py
+++ b/test/iio_scanner.py
@@ -87,26 +87,36 @@ def check_board_other(ctx):
         ctx, [device("ad9517"), device("ad9361-phy"), device("cf-ad9361-lpc", 4)]
     ):
         return "adrv9361"
+
     if check_config(ctx, [device("ad7291-bob"), device("cf-ad9361-lpc", 2)]):
         return "adrv9364"
+
     if check_config(
         ctx, [device("adm1177"), device("ad9361-phy"), device("cf-ad9361-lpc", 2)]
     ):
         return "pluto"
+
     if check_config(
         ctx, [device("ad7291"), device("ad9361-phy"), device("cf-ad9361-lpc", 4)]
     ):
         return "fmcomms2"
+
     if check_config(
         ctx, [device("ad7291"), device("ad9361-phy"), device("cf-ad9361-lpc", 2),],
     ):
         return "fmcomms4"
+
     if check_config(ctx, [device("ad9361-phy"), device("ad9361-phy-b")]):
         return "fmcomms5"
+
     if check_config(ctx, [device("ad9361-phy"), device("cf-ad9361-lpc", 2)]):
         return "ad9364"
+
     if check_config(ctx, [device("ad9361-phy"), device("cf-ad9361-lpc", 4)]):
         return "ad9361"
+
+    if check_config(ctx, [device("ad9166"), device("adf4372")]):
+        return "cn0511"
 
     if check_config(ctx, [device("axi-ad9144-hpc", 4), device("axi-ad9680-hpc", 2)]):
         return "daq2"
@@ -116,6 +126,7 @@ def check_board_other(ctx):
 
     if check_config(ctx, [device("adrv9009-phy"), device("adrv9009-phy-b")]):
         return "adrv9009-dual"
+
     if check_config(ctx, [device("adrv9009-phy")]):
         return "adrv9009"
 

--- a/test/test_cn0511_p.py
+++ b/test/test_cn0511_p.py
@@ -1,0 +1,40 @@
+import pytest
+
+hardware = "cn0511"
+classname = "adi.CN0511"
+
+
+#########################################
+@pytest.mark.parametrize("classname, hardware", [(classname, hardware)])
+@pytest.mark.parametrize(
+    "attr, start, stop, step, tol",
+    [
+        ("raw", 1, 2 ** 15 - 1, 1, 8),
+        ("sample_rate", 4915200000, 5898240000, 122880000, 8),
+    ],
+)
+def test_cn0511_attr(
+    test_attribute_single_value, classname, hardware, attr, start, stop, step, tol
+):
+    test_attribute_single_value(classname, hardware, attr, start, stop, step, tol)
+
+
+#########################################
+@pytest.mark.parametrize("classname, hardware", [(classname, hardware)])
+@pytest.mark.parametrize(
+    "attr, value",
+    [
+        ("amp_enable", True),
+        ("amp_enable", False),
+        ("temperature_enable", False),
+        ("temperature_enable", True),
+        ("FIR85_enable", True),
+        ("FIR85_enable", False),
+        ("tx_enable", False),
+        ("tx_enable", True),
+    ],
+)
+def test_cn0511_attr_boolean(
+    test_attribute_single_value_boolean, classname, hardware, attr, value
+):
+    test_attribute_single_value_boolean(classname, hardware, attr, value)


### PR DESCRIPTION
- Added library, example, and simple parametrized test for CN0511.
- Added partial support for AD9166 (NCO mode only).