### PR TITLE
adis16507: Remove burst_mode_enable

### DIFF
--- a/adi/adis16507.py
+++ b/adi/adis16507.py
@@ -86,17 +86,6 @@ class adis16507(rx, context_manager):
         self._set_iio_dev_attr_str("filter_low_pass_3db_frequency", value)
 
     @property
-    def burst_mode_enable(self):
-        """burst_mode_enable: Enables reading of the data with a SPI burst read"""
-        return self._get_iio_dev_attr("burst_mode_enable")
-
-    @burst_mode_enable.setter
-    def burst_mode_enable(self, value):
-        if isinstance(value, bool):
-            value = 1 if value else 0
-        self._set_iio_dev_attr_str("burst_mode_enable", value)
-
-    @property
     def current_timestamp_clock(self):
         """current_timestamp_clock: Source clock for timestamps"""
         return self._get_iio_dev_attr("current_timestamp_clock")

--- a/examples/adis16507_example.py
+++ b/examples/adis16507_example.py
@@ -42,7 +42,6 @@ imu.rx_output_type = "SI"
 imu.rx_enabled_channels = [0, 1, 2, 3, 4, 5]
 imu.sample_rate = 1024
 imu.rx_buffer_size = 100
-imu.burst_mode_enable = True
 
 for _ in range(100):
     data = imu.rx()


### PR DESCRIPTION
This attribute was removed from the driver. Burst mode is just used by
default.

Signed-off-by: Nuno Sá <nuno.sa@analog.com>