### PR TITLE
Fix AD9361 gain test

### DIFF
--- a/test/test_ad9361_p.py
+++ b/test/test_ad9361_p.py
@@ -9,7 +9,8 @@ classname = "adi.ad9361"
 @pytest.mark.parametrize(
     "attr, start, stop, step, tol, repeats",
     [
-        ("tx_hardwaregain", -89.75, 0.0, 0.25, 0, 100),
+        ("tx_hardwaregain_chan0", -89.75, 0.0, 0.25, 0, 100),
+        ("tx_hardwaregain_chan1", -89.75, 0.0, 0.25, 0, 100),
         ("rx_lo", 70000000, 6000000000, 1, 8, 100),
         ("tx_lo", 47000000, 6000000000, 1, 8, 100),
         ("sample_rate", 2084000, 61440000, 1, 4, 20),


### PR DESCRIPTION
Signed-off-by: Travis F. Collins <travis.collins@analog.com>

# Description

Fix broken attribute test for tx hardware gain of AD936x classes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

All AD9361 tests pass in hardware harness.

**Test Configuration**:
* Hardware: ADRV9361-Z7035
* OS: Ubuntu 18.04

# Documentation

No documentation changes needed.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
