### PR TITLE
Add example for AD9361 ENSM navigation. Question came from EZ on how …

### DIFF
--- a/examples/ad9361_advanced_ensm.py
+++ b/examples/ad9361_advanced_ensm.py
@@ -1,0 +1,22 @@
+import adi
+
+# This example shows how to navigate between FDD and TDD modes using debug attributes for AD936X devices
+
+sdr = adi.ad9361(uri="ip:analog")
+
+# Initial stage
+print("Initial ensm_mode:", sdr._ctrl.attrs["ensm_mode"].value)
+
+# Get to TDD mode
+sdr._ctrl.debug_attrs["adi,frequency-division-duplex-mode-enable"].value = "0"
+sdr._ctrl.debug_attrs["initialize"].value = "1"
+print("ensm_mode_available:", sdr._ctrl.attrs["ensm_mode_available"].value)
+print("Current ensm:", sdr._ctrl.attrs["ensm_mode"].value)
+
+# Get to FDD mode
+sdr._ctrl.debug_attrs["adi,frequency-division-duplex-mode-enable"].value = "1"
+# Disable pin control so spi can move the states
+sdr._ctrl.debug_attrs["adi,ensm-enable-txnrx-control-enable"].value = "0"
+sdr._ctrl.debug_attrs["initialize"].value = "1"
+print("ensm_mode_available:", sdr._ctrl.attrs["ensm_mode_available"].value)
+print("Current ensm:", sdr._ctrl.attrs["ensm_mode"].value)


### PR DESCRIPTION

Signed-off-by: Travis F. Collins <travis.collins@analog.com>

# Description

PR adds example for AD9361 ENSM mode switching. Answers question on EZ: https://ez.analog.com/linux-software-drivers/f/q-a/534516/how-to-use-pyadi-iio-to-set-adrv9361-som-to-fdd-mode

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How has this been tested?

- [x] Manually verified with ADRV9361 SOM by developer and customer

**Test Configuration**:
* Hardware: ADRV9361-Z7035
* OS: Host: Ubuntu 18.04, Board: 2019 R1

# Documentation

Example is self documented.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
