### PR TITLE
Fix AD9361 test ranges and add AD9361 label for generic boards

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -225,7 +225,7 @@ def iio_attribute_single_value(
     # Pick random number in operational range
     numints = int((stop - start) / step)
     for _ in range(repeats):
-        ind = random.randint(0, numints + 1)
+        ind = random.randint(0, numints)
         val = start + step * ind
         # Check hardware
         assert (
@@ -241,7 +241,7 @@ def attribute_single_value(
     # Pick random number in operational range
     numints = int((stop - start) / step)
     for _ in range(repeats):
-        ind = random.randint(0, numints + 1)
+        ind = random.randint(0, numints)
         val = start + step * ind
         # Check hardware
         assert bi.dev_interface(val, attr, tol) <= tol

--- a/test/test_ad9361_p.py
+++ b/test/test_ad9361_p.py
@@ -1,6 +1,6 @@
 import pytest
 
-hardware = ["packrf", "adrv9361", "fmcomms2"]
+hardware = ["packrf", "adrv9361", "fmcomms2", "ad9361"]
 classname = "adi.ad9361"
 
 


### PR DESCRIPTION
Signed-off-by: Travis F. Collins <travis.collins@analog.com>

# Description

Fixed test ranges in randomized testing and add generic label for AD9361 tests for other devices.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

- [x] Tested with hardware test harness against two different ADRV9361 boards with different carriers

**Test Configuration**:
* Hardware: ADRV9361-(BOB and FMC)
* OS: Ubuntu 18.04

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
