### PR TITLE
Adrv9009 multi profile

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     -   id: check-docstring-first
     -   id: flake8
 -   repo: https://github.com/psf/black
-    rev: stable
+    rev: 19.10b0
     hooks:
     - id: black
       language_version: python3.6

--- a/adi/adrv9009.py
+++ b/adi/adrv9009.py
@@ -64,7 +64,11 @@ class adrv9009(rx_tx, context_manager):
     def profile(self, value):
         with open(value, "r") as file:
             data = file.read()
-        self._set_iio_dev_attr_str("profile_config", data)
+        # Apply profiles in specific order if multiple phys found
+        phys = [p for p in self.__dict__.keys() if "_ctrl" in p]
+        phys = sorted(phys)
+        for phy in phys[1:] + [phys[0]]:
+            self._set_iio_dev_attr_str("profile_config", data, self.getattr(phy))
 
     @property
     def frequency_hopping_mode(self):


### PR DESCRIPTION
# Description

This fixes profiles loading when multiple adrv9009 chips are available in a context.

Fixes #113 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

- [ ] Tested against ADRV9009-ZU11EG+FMComms8

**Test Configuration**:
* Hardware:ADRV9009-ZU11EG+FMComms8
* OS: 2019_R1 release + custom kernel with updated JESD framework

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
