### PR TITLE
Update testing map to not allow ad9364 tests for ad9361

### DIFF
--- a/test/test_map.py
+++ b/test/test_map.py
@@ -69,6 +69,6 @@ def get_test_map():
         "zynq-adrv9364-z7020-bob",
         "zynq-adrv9364-z7020-bob-cmos",
         "zynq-zed-adv7511-ad9364-fmcomms4",
-    ] + test_map["ad9361"]
+    ]
 
     return test_map


### PR DESCRIPTION
Update the testing map to not allow ad9364 tests for ad9361. This will fixed skipped tests that appear for AD9361 based devices.