### PR TITLE
Update GH action lint to print differences on errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,8 +47,10 @@ jobs:
 
       - name: Lint
         run: |
-          pre-commit run --all-files
+          pre-commit run --all-files 2> /dev/null
+          ec=$?
           git diff -U0 > log.txt && cat log.txt
+          exit $ec
 
   Doc:
     runs-on: ubuntu-latest


### PR DESCRIPTION
PR updates GH actions to print diffs of code during lint process to show required line changes. This was not happening before if the linter threw an error beforehand.

Signed-off-by: Travis F. Collins <travis.collins@analog.com>
