### PR TITLE
Big (hopefully final) ADAR1000 update

### DIFF
--- a/adi/__init__.py
+++ b/adi/__init__.py
@@ -81,6 +81,8 @@ from adi.ltc2983 import ltc2983
 
 from adi.one_bit_adc_dac import one_bit_adc_dac
 
+from adi.ltc2314_14 import ltc2314_14
+
 try:
     from adi.jesd import jesd
 except ImportError:

--- a/adi/adar1000.py
+++ b/adi/adar1000.py
@@ -91,11 +91,10 @@ class adar1000(attribute, context_manager):
     _device_name = ""
     _BIAS_CODE_TO_VOLTAGE_SCALE = -0.018824
 
-    class adar1000_channel:
+    class _adar1000_channel:
         """Class for each channel of the ADAR1000. This class is not meant
         to be instantiated directly. adar1000 objects will create their
         own handles of this class, one for each channel
-
         parameters:
             adar1000_parent: type=adar1000
                 Parent ADAR1000 instance
@@ -367,7 +366,6 @@ class adar1000(attribute, context_manager):
 
         def save_rx_beam(self, state, attenuator, gain, phase):
             """Save a beam to an Rx memory position
-
             parameters:
                 state: int
                     State number to save. Valid options are 0 to 120
@@ -386,7 +384,6 @@ class adar1000(attribute, context_manager):
 
         def save_tx_beam(self, state, attenuator, gain, phase):
             """Save a beam to a Tx memory position
-
             parameters:
                 state: int
                     State number to save. Valid options are 0 to 120
@@ -458,7 +455,7 @@ class adar1000(attribute, context_manager):
             element_number = element_numbers[i]
             row, column = element_rows_cols[element_number]
             self._channels.append(
-                self.adar1000_channel(self, i, element_number, row, column)
+                self._adar1000_channel(self, i, element_number, row, column)
             )
 
     def __repr__(self):
@@ -1083,7 +1080,6 @@ class adar1000(attribute, context_manager):
 
     def initialize(self, pa_off=-2.5, pa_on=-2.5, lna_off=-2, lna_on=-2):
         """Suggested initialization routine after powerup
-
         parameters:
             pa_off: float
                 Voltage to set the PA_BIAS_OFF values to during initialization
@@ -1176,7 +1172,6 @@ class adar1000(attribute, context_manager):
         rx_lna_bias_current,
     ):
         """Save a bias setting to an Rx memory position
-
         parameters:
             state: int
                 State number to save. Valid options are 1 to 7
@@ -1213,7 +1208,6 @@ class adar1000(attribute, context_manager):
         tx_pa_bias_current,
     ):
         """Save a bias setting to a Tx memory position
-
         parameters:
             state: int
                 State number to save. Valid options are 1 to 7
@@ -1260,7 +1254,6 @@ class adar1000(attribute, context_manager):
 
 class adar1000_array(context_manager):
     """ADAR1000 Beamformer Array
-
     parameters:
         uri: type=string
             URI of IIO context with ADAR1000 array
@@ -1599,7 +1592,6 @@ class adar1000_array(context_manager):
     def _calculate_phi(self, azimuth, elevation):
         """Calculate the Φ angles to steer the array in a particular direction. This method assumes that the entire
         array is one analog beam.
-
         parameters:
             azimuth: float
                 Desired beam angle in degrees for the horizontal direction.
@@ -1623,7 +1615,6 @@ class adar1000_array(context_manager):
         """ Initialize the ADAR1000s in the array """
         for device in self.devices.values():
             device.initialize()
-        return
 
     def latch_rx_settings(self):
         """ Latch in new Gain/Phase settings for the Rx """
@@ -1639,7 +1630,6 @@ class adar1000_array(context_manager):
 
     def steer_rx(self, azimuth, elevation):
         """Steer the Rx array in a particular direction. This method assumes that the entire array is one analog beam.
-
         parameters:
             azimuth: float
                 Desired beam angle in degrees for the horizontal direction.
@@ -1670,7 +1660,6 @@ class adar1000_array(context_manager):
 
     def steer_tx(self, azimuth, elevation):
         """Steer the Tx array in a particular direction. This method assumes that the entire array is one analog beam.
-
         parameters:
             azimuth: float
                 Desired beam angle in degrees for the horizontal direction.

--- a/adi/adar1000.py
+++ b/adi/adar1000.py
@@ -96,6 +96,76 @@ class adar1000(attribute, context_manager):
     """ Device attributes """
 
     @property
+    def bias_dac_enable(self):
+        """ Get/Set enable for bias DACs """
+        return bool(self._get_iio_dev_attr("bias_enable", self._ctrl))
+
+    @bias_dac_enable.setter
+    def bias_dac_enable(self, value):
+        """ Get/Set enable for bias DACs """
+        self._set_iio_dev_attr_str("bias_enable", int(value), self._ctrl)
+
+    @property
+    def bias_dac_mode(self):
+        """
+        Get/Set BIAS_CTRL bit (Register 0x30[6]) which controls whether the bias DACs stay at "ON" value,
+        or toggle with respect to T/R state.
+        """
+        value = bool(self._get_iio_dev_attr("bias_ctrl", self._ctrl))
+        if value:
+            return "toggle"
+        else:
+            return "on"
+
+    @bias_dac_mode.setter
+    def bias_dac_mode(self, value):
+        """
+        Get/Set BIAS_CTRL bit (Register 0x30[6]) which controls whether the bias DACs stay at "ON" value,
+        or toggle with respect to T/R state.
+        """
+        if value.lower() == "toggle":
+            self._set_iio_dev_attr_str("bias_ctrl", 1, self._ctrl)
+        elif value.lower() == "on":
+            self._set_iio_dev_attr_str("bias_ctrl", 0, self._ctrl)
+        else:
+            raise ValueError('bias_dac_mode should be "toggle" or "on"')
+
+    @property
+    def external_tr_pin(self):
+        """ Get/Set which external T/R switch driver is used ("positive" = TR_SW_POS, "negative" = TR_SW_NEG) """
+        value = bool(self._get_iio_dev_attr("sw_drv_tr_mode_sel", self._ctrl))
+        if value:
+            return "positive"
+        else:
+            return "negative"
+
+    @external_tr_pin.setter
+    def external_tr_pin(self, value):
+        """ Get/Set which external T/R switch driver is used ("positive" = TR_SW_POS, "negative" = TR_SW_NEG) """
+        if value.lower() == "positive":
+            self._set_iio_dev_attr_str("sw_drv_tr_mode_sel", 1, self._ctrl)
+        elif value.lower() == "negative":
+            self._set_iio_dev_attr_str("sw_drv_tr_mode_sel", 0, self._ctrl)
+        else:
+            raise ValueError('external_tr_pin should be "toggle" or "on"')
+
+    @property
+    def external_tr_polarity(self):
+        """
+        Get/Set polarity of the T/R switch driver compared to the T/R state of the ADAR1000.
+        True outputs 0V in Rx mode, False outputs either 3.3V or -5V, depending on which T/R switch driver is enabled.
+        """
+        return bool(self._get_iio_dev_attr("sw_drv_tr_state", self._ctrl))
+
+    @external_tr_polarity.setter
+    def external_tr_polarity(self, value):
+        """
+        Get/Set polarity of the T/R switch driver compared to the T/R state of the ADAR1000.
+        True outputs 0V in Rx mode, False outputs either 3.3V or -5V, depending on which T/R switch driver is enabled.
+        """
+        self._set_iio_dev_attr_str("sw_drv_tr_state", int(value), self._ctrl)
+
+    @property
     def lna_bias_off(self):
         """ Get/Set LNA_BIAS_OFF setting """
         return self._get_iio_dev_attr("lna_bias_off", self._ctrl)
@@ -116,6 +186,46 @@ class adar1000(attribute, context_manager):
         self._set_iio_dev_attr_str("lna_bias_on", value, self._ctrl)
 
     @property
+    def lna_bias_out_enable(self):
+        """ Get/Set enable for LNA bias DAC output. Disable to allow for always-on self-biased LNAs """
+        return bool(self._get_iio_dev_attr("lna_bias_out_enable", self._ctrl))
+
+    @lna_bias_out_enable.setter
+    def lna_bias_out_enable(self, value):
+        """ Get/Set enable for LNA bias DAC output. Disable to allow for always-on self-biased LNAs """
+        self._set_iio_dev_attr_str("lna_bias_out_enable", int(value), self._ctrl)
+
+    @property
+    def pol_state(self):
+        """ Get/Set polarity switch state. True outputs -5V, False outputs 0V """
+        return bool(self._get_iio_dev_attr("pol", self._ctrl))
+
+    @pol_state.setter
+    def pol_state(self, value):
+        """ Get/Set polarity switch state. True outputs -5V, False outputs 0V """
+        self._set_iio_dev_attr_str("pol", int(value), self._ctrl)
+
+    @property
+    def pol_switch_enable(self):
+        """ Get/Set polarity switch driver enable state """
+        return bool(self._get_iio_dev_attr("sw_drv_en_pol", self._ctrl))
+
+    @pol_switch_enable.setter
+    def pol_switch_enable(self, value):
+        """ Get/Set polarity switch driver enable state """
+        self._set_iio_dev_attr_str("sw_drv_en_pol", int(value), self._ctrl)
+
+    @property
+    def rx_enable(self):
+        """ Get/Set enable for entire Rx chain """
+        return bool(self._get_iio_dev_attr("rx_en", self._ctrl))
+
+    @rx_enable.setter
+    def rx_enable(self, value):
+        """ Get/Set enable for entire Rx chain """
+        self._set_iio_dev_attr_str("rx_en", int(value), self._ctrl)
+
+    @property
     def rx_lna_bias_current(self):
         """ Get/Set Rx LNA bias current setting """
         return self._get_iio_dev_attr("bias_current_rx_lna", self._ctrl)
@@ -134,6 +244,26 @@ class adar1000(attribute, context_manager):
     def rx_lna_enable(self, value):
         """ Get/Set Rx LNA enable status """
         self._set_iio_dev_attr_str("rx_lna_enable", int(value), self._ctrl)
+
+    @property
+    def rx_to_tx_delay_1(self):
+        """ Get/Set Rx to Tx Delay 1 """
+        return self._get_iio_dev_attr("rx_to_tx_delay_1", self._ctrl)
+
+    @rx_to_tx_delay_1.setter
+    def rx_to_tx_delay_1(self, value):
+        """ Get/Set Rx to Tx Delay 1 """
+        self._set_iio_dev_attr_str("rx_to_tx_delay_1", int(value), self._ctrl)
+
+    @property
+    def rx_to_tx_delay_2(self):
+        """ Get/Set Rx to Tx Delay 2 """
+        return self._get_iio_dev_attr("rx_to_tx_delay_2", self._ctrl)
+
+    @rx_to_tx_delay_2.setter
+    def rx_to_tx_delay_2(self, value):
+        """ Get/Set Rx to Tx Delay 2 """
+        self._set_iio_dev_attr_str("rx_to_tx_delay_2", int(value), self._ctrl)
 
     @property
     def rx_vga_enable(self):
@@ -176,6 +306,55 @@ class adar1000(attribute, context_manager):
         self._set_iio_dev_attr_str("sequencer_enable", int(value), self._ctrl)
 
     @property
+    def tr_source(self):
+        """ Get/Set TR source for the chip. Valid options are "external" or "spi" """
+        value = bool(self._get_iio_dev_attr("tr_source", self._ctrl))
+        if value:
+            return "external"
+        else:
+            return "spi"
+
+    @tr_source.setter
+    def tr_source(self, value):
+        """ Get/Set TR source for the chip. Valid options are "external" or "spi" """
+        if value.lower() == "external":
+            self._set_iio_dev_attr_str("tr_source", 1, self._ctrl)
+        elif value.lower() == "spi":
+            self._set_iio_dev_attr_str("tr_source", 0, self._ctrl)
+        else:
+            raise ValueError('tr_source should be "external" or "spi"')
+
+    @property
+    def tr_spi(self):
+        """ Get/Set T/R state using the SPI bit. True is Tx, False is Rx """
+        return bool(self._get_iio_dev_attr("tr_spi", self._ctrl))
+
+    @tr_spi.setter
+    def tr_spi(self, value):
+        """ Get/Set T/R state using the SPI bit. True is Tx, False is Rx """
+        self._set_iio_dev_attr_str("tr_spi", int(value), self._ctrl)
+
+    @property
+    def tr_switch_enable(self):
+        """ Get/Set T/R switch driver enable state """
+        return bool(self._get_iio_dev_attr("sw_drv_en_tr", self._ctrl))
+
+    @tr_switch_enable.setter
+    def tr_switch_enable(self, value):
+        """ Get/Set T/R switch driver enable state """
+        self._set_iio_dev_attr_str("sw_drv_en_tr", int(value), self._ctrl)
+
+    @property
+    def tx_enable(self):
+        """ Get/Set enable for entire Tx chain """
+        return bool(self._get_iio_dev_attr("tx_en", self._ctrl))
+
+    @tx_enable.setter
+    def tx_enable(self, value):
+        """ Get/Set enable for entire Tx chain """
+        self._set_iio_dev_attr_str("tx_en", int(value), self._ctrl)
+
+    @property
     def tx_pa_bias_current(self):
         """ Get/Set Tx PA bias current setting """
         return self._get_iio_dev_attr("bias_current_tx_drv", self._ctrl)
@@ -194,6 +373,26 @@ class adar1000(attribute, context_manager):
     def tx_pa_enable(self, value):
         """ Get/Set Tx PA enable status """
         self._set_iio_dev_attr_str("tx_drv_enable", int(value), self._ctrl)
+
+    @property
+    def tx_to_rx_delay_1(self):
+        """ Get/Set Tx to Rx Delay 1 """
+        return self._get_iio_dev_attr("tx_to_rx_delay_1", self._ctrl)
+
+    @tx_to_rx_delay_1.setter
+    def tx_to_rx_delay_1(self, value):
+        """ Get/Set Tx to Rx Delay 1 """
+        self._set_iio_dev_attr_str("tx_to_rx_delay_1", int(value), self._ctrl)
+
+    @property
+    def tx_to_rx_delay_2(self):
+        """ Get/Set Tx to Rx Delay 2 """
+        return self._get_iio_dev_attr("tx_to_rx_delay_2", self._ctrl)
+
+    @tx_to_rx_delay_2.setter
+    def tx_to_rx_delay_2(self, value):
+        """ Get/Set Tx to Rx Delay 2 """
+        self._set_iio_dev_attr_str("tx_to_rx_delay_2", int(value), self._ctrl)
 
     @property
     def tx_vga_enable(self):
@@ -270,22 +469,22 @@ class adar1000(attribute, context_manager):
     @property
     def ch1_detector_power(self):
         """ Get Channel 1 detector power reading """
-        return bool(self._get_iio_attr("voltage0", "raw", True, self._ctrl))
+        return self._get_iio_attr("voltage0", "raw", True, self._ctrl)
 
     @property
     def ch2_detector_power(self):
         """ Get Channel 2 detector power reading """
-        return bool(self._get_iio_attr("voltage1", "raw", True, self._ctrl))
+        return self._get_iio_attr("voltage1", "raw", True, self._ctrl)
 
     @property
     def ch3_detector_power(self):
         """ Get Channel 3 detector power reading """
-        return bool(self._get_iio_attr("voltage2", "raw", True, self._ctrl))
+        return self._get_iio_attr("voltage2", "raw", True, self._ctrl)
 
     @property
     def ch4_detector_power(self):
         """ Get Channel 4 detector power reading """
-        return bool(self._get_iio_attr("voltage3", "raw", True, self._ctrl))
+        return self._get_iio_attr("voltage3", "raw", True, self._ctrl)
 
     @property
     def ch1_pa_bias_off(self):
@@ -450,42 +649,42 @@ class adar1000(attribute, context_manager):
     @property
     def ch1_rx_powerdown(self):
         """ Get/Set Channel 1 Rx Powerdown """
-        return self._get_iio_attr("voltage0", "powerdown", False, self._ctrl)
+        return bool(self._get_iio_attr("voltage0", "powerdown", False, self._ctrl))
 
     @ch1_rx_powerdown.setter
     def ch1_rx_powerdown(self, value):
         """ Get/Set Channel 1 Rx Powerdown """
-        self._set_iio_attr("voltage0", "powerdown", False, value, self._ctrl)
+        self._set_iio_attr("voltage0", "powerdown", False, int(value), self._ctrl)
 
     @property
     def ch2_rx_powerdown(self):
         """ Get/Set Channel 2 Rx Powerdown """
-        return self._get_iio_attr("voltage1", "powerdown", False, self._ctrl)
+        return bool(self._get_iio_attr("voltage1", "powerdown", False, self._ctrl))
 
     @ch2_rx_powerdown.setter
     def ch2_rx_powerdown(self, value):
         """ Get/Set Channel 2 Rx Powerdown """
-        self._set_iio_attr("voltage1", "powerdown", False, value, self._ctrl)
+        self._set_iio_attr("voltage1", "powerdown", False, int(value), self._ctrl)
 
     @property
     def ch3_rx_powerdown(self):
         """ Get/Set Channel 3 Rx Powerdown """
-        return self._get_iio_attr("voltage2", "powerdown", False, self._ctrl)
+        return bool(self._get_iio_attr("voltage2", "powerdown", False, self._ctrl))
 
     @ch3_rx_powerdown.setter
     def ch3_rx_powerdown(self, value):
         """ Get/Set Channel 3 Rx Powerdown """
-        self._set_iio_attr("voltage2", "powerdown", False, value, self._ctrl)
+        self._set_iio_attr("voltage2", "powerdown", False, int(value), self._ctrl)
 
     @property
     def ch4_rx_powerdown(self):
         """ Get/Set Channel 4 Rx Powerdown """
-        return self._get_iio_attr("voltage3", "powerdown", False, self._ctrl)
+        return bool(self._get_iio_attr("voltage3", "powerdown", False, self._ctrl))
 
     @ch4_rx_powerdown.setter
     def ch4_rx_powerdown(self, value):
         """ Get/Set Channel 4 Rx Powerdown """
-        self._set_iio_attr("voltage3", "powerdown", False, value, self._ctrl)
+        self._set_iio_attr("voltage3", "powerdown", False, int(value), self._ctrl)
 
     @property
     def ch1_tx_gain(self):
@@ -570,42 +769,42 @@ class adar1000(attribute, context_manager):
     @property
     def ch1_tx_powerdown(self):
         """ Get/Set Channel 1 Tx Powerdown """
-        return self._get_iio_attr("voltage0", "powerdown", True, self._ctrl)
+        return bool(self._get_iio_attr("voltage0", "powerdown", True, self._ctrl))
 
     @ch1_tx_powerdown.setter
     def ch1_tx_powerdown(self, value):
         """ Get/Set Channel 1 Tx Powerdown """
-        self._set_iio_attr("voltage0", "powerdown", True, value, self._ctrl)
+        self._set_iio_attr("voltage0", "powerdown", True, int(value), self._ctrl)
 
     @property
     def ch2_tx_powerdown(self):
         """ Get/Set Channel 2 Tx Powerdown """
-        return self._get_iio_attr("voltage1", "powerdown", True, self._ctrl)
+        return bool(self._get_iio_attr("voltage1", "powerdown", True, self._ctrl))
 
     @ch2_tx_powerdown.setter
     def ch2_tx_powerdown(self, value):
         """ Get/Set Channel 2 Tx Powerdown """
-        self._set_iio_attr("voltage1", "powerdown", True, value, self._ctrl)
+        self._set_iio_attr("voltage1", "powerdown", True, int(value), self._ctrl)
 
     @property
     def ch3_tx_powerdown(self):
         """ Get/Set Channel 3 Tx Powerdown """
-        return self._get_iio_attr("voltage2", "powerdown", True, self._ctrl)
+        return bool(self._get_iio_attr("voltage2", "powerdown", True, self._ctrl))
 
     @ch3_tx_powerdown.setter
     def ch3_tx_powerdown(self, value):
         """ Get/Set Channel 3 Tx Powerdown """
-        self._set_iio_attr("voltage2", "powerdown", True, value, self._ctrl)
+        self._set_iio_attr("voltage2", "powerdown", True, int(value), self._ctrl)
 
     @property
     def ch4_tx_powerdown(self):
         """ Get/Set Channel 4 Tx Powerdown """
-        return self._get_iio_attr("voltage3", "powerdown", True, self._ctrl)
+        return bool(self._get_iio_attr("voltage3", "powerdown", True, self._ctrl))
 
     @ch4_tx_powerdown.setter
     def ch4_tx_powerdown(self, value):
         """ Get/Set Channel 4 Tx Powerdown """
-        self._set_iio_attr("voltage3", "powerdown", True, value, self._ctrl)
+        self._set_iio_attr("voltage3", "powerdown", True, int(value), self._ctrl)
 
     @property
     def rx_sequencer_start(self):
@@ -654,12 +853,14 @@ class adar1000(attribute, context_manager):
 
     """ Private Methods """
 
-    def _load_beam(self, rx_or_tx, state):
+    def _load_beam(self, rx_or_tx, channel, state):
         """Load a beam from a memory position
 
         parameters:
             rx_or_tx: string
                 String indicating whether to load an Rx or Tx beam state. Valid options are "rx" and "tx"
+            channel: int, string
+                Channel number to load (1-4) or "X" to load from CHX_{rx_or_tx}
             state: int
                 State number to load. Valid options are 0 to 120
         """
@@ -669,7 +870,14 @@ class adar1000(attribute, context_manager):
         else:
             output = True
 
-        self._set_iio_attr("voltage0", "beam_pos_load", output, state, self._ctrl)
+        if isinstance(channel, int):
+            self._set_iio_attr(
+                f"voltage{channel - 1}", "beam_pos_load", output, state, self._ctrl
+            )
+        else:
+            self._set_iio_dev_attr_str(
+                f"static_{rx_or_tx.lower()}_beam_pos", state, self._ctrl
+            )
 
     def _load_bias(self, rx_or_tx, state):
         """Load a bias from a memory position
@@ -728,23 +936,27 @@ class adar1000(attribute, context_manager):
         """ Generate CLK cycles before pulsing RX_LOAD or TX_LOAD """
         self._set_iio_dev_attr_str("gen_clk_cycles", "", self._ctrl)
 
-    def load_rx_beam(self, state):
+    def load_rx_beam(self, channel, state):
         """Load an Rx beam from a memory position
 
         parameters:
+            channel: int
+                Channel number to load
             state: int
                 State number to load. Valid options are 0 to 120
         """
-        self._load_beam("rx", state)
+        self._load_beam("rx", channel, state)
 
-    def load_tx_beam(self, state):
+    def load_tx_beam(self, channel, state):
         """Load a Tx beam from a memory position
 
         parameters:
+            channel: int
+                Channel number to load
             state: int
                 State number to load. Valid options are 0 to 120
         """
-        self._load_beam("tx", state)
+        self._load_beam("tx", channel, state)
 
     def load_rx_bias(self, state):
         """Load an Rx bias from a memory position

--- a/adi/adar1000.py
+++ b/adi/adar1000.py
@@ -1504,7 +1504,7 @@ class adar1000_array(context_manager):
                 "property in a subclass to allow for GPIO control of the ADAR1000's T/R input"
             )
 
-        return self.devices[0].tr_spi
+        return self.devices[1].tr_spi
 
     @tr.setter
     def tr(self, value):

--- a/adi/adar1000.py
+++ b/adi/adar1000.py
@@ -128,7 +128,7 @@ class adar1000(attribute, context_manager):
             return self._column
 
         @property
-        def detector_enable(self):
+        def _detector_enable(self):
             """ Get/Set the detector enable bit for the associated channel """
             return bool(
                 self.adar1000_parent._get_iio_attr(
@@ -136,8 +136,8 @@ class adar1000(attribute, context_manager):
                 )
             )
 
-        @detector_enable.setter
-        def detector_enable(self, value):
+        @_detector_enable.setter
+        def _detector_enable(self, value):
             """ Get/Set Channel 1 detector enable bit """
             self.adar1000_parent._set_iio_attr(
                 f"voltage{self.adar1000_channel}", "detector_en", True, int(value)
@@ -146,9 +146,16 @@ class adar1000(attribute, context_manager):
         @property
         def detector_power(self):
             """ Get the detector power reading for the associated channel """
-            return self.adar1000_parent._get_iio_attr(
+
+            self._detector_enable = True
+
+            readback = self.adar1000_parent._get_iio_attr(
                 f"voltage{self.adar1000_channel}", "raw", True
             )
+
+            self._detector_enable = False
+
+            return readback
 
         @property
         def pa_bias_off(self):

--- a/adi/adar1000.py
+++ b/adi/adar1000.py
@@ -39,40 +39,53 @@ from adi.context_manager import context_manager
 
 class adar1000(attribute, context_manager):
     """ADAR1000 Beamformer
-
     parameters:
         uri: type=string
-            URI of IIO context with ADAR1000(s)
+            Optional parameter for the URI of IIO context with ADAR1000(s). If
+            not given,
         context: type=iio.Context
-            IIO Context for the device. Only required if using adar1000_array.
+            Optional parameter for IIO Context handle for the device. Don't use if
+            instantiating the adar1000 class directly. The adar1000_array class
+            will handle this if creating an array instance.
         chip_id: type=string
-            String identifying desired chip select and hardware ID for the
-            ADAR1000. This string is the label coinciding with each chip
-            select and hardware address and are typically in the form csbX_chipX.
-            The csb line can be any number depending on how many are used in the
-            system. The chip number will typically be 1-4 because each CSB line
-            can control up to four ADAR1000s.
+            Required string identifying the desired chip select and hardware ID
+            for the ADAR1000. If creating a single adar1000 instance, you can
+            typically leave the default value of "csb1_chip1" as long as the
+            device tree label matches. If creating an adar1000_array instance,
+            the array class will handle the instantiation of individual adar1000
+            handles.
         device_number: type=int
-            Integer indicating the device number in the array
+            Required integer indicating the device number in the array. If creating
+            a single adar1000 instance, this value should be 1. If creating an
+            adar1000_array instance, the array class will handle the instantiation
+            of individual adar1000 handles.
         array_element_map: type=list[list[int]]
-            List with the map of where the ADAR1000 channels are in the array.
-            Each entry in the map represents a row of array channels referenced
-            by element number. For example, a map:
+            Required list of lists with the map of where the array elements are
+            located in the physical array. Each entry in the map represents a
+            row of elements referenced by element number. For example, a map:
                 | [[1, 5, 9, 13],
                 | [2, 6, 10, 14],
                 | [3, 7, 11, 15],
                 | [4, 8, 12, 16]]
-            represents an array of 16 elements (4 ADAR1000s) in a square array.
+            represents an array of 16 elements (4 ADAR1000s) in a 4x4 array.
+            If creating a single adar1000 instance, the elements should be 1-4 in
+            whatever configuration the physical array is (1x4, 2x2, 4x1, etc.). If
+            creating an adar1000_array instance, the array class will handle the
+            instantiation of indivdual adar1000 handles.
         channel_element_map: type=list[int]
-            List of integers relating the array element numbers to the channels
-            of the ADAR1000. Each number in the list is the element number in the
-            larger array, in order of the ADAR1000 channels. For example, a list
-            [10, 14, 13, 9] indicates that the ADAR1000's channels are the
-            following elements in the full array:
+            Required list of integers relating the array element numbers to the
+            channels of the ADAR1000 instance. Each number in the list is the
+            element number in the larger array, in order of the ADAR1000's channels.
+            For example, a list [10, 14, 13, 9] indicates that the ADAR1000's
+            channels are the following elements in the full array:
                 | Channel 1: Element # 10
                 | Channel 2: Element # 14
                 | Channel 3: Element # 13
                 | Channel 4: Element # 9
+            If creating a single adar1000 instance, the elements should be 1-4 in
+            order of the ADAR1000's channels related to the array elements. If
+            creating an adar1000_array instance, the array class will handle the
+            instantiation of indivdual adar1000 handles.
     """
 
     _device_name = ""
@@ -1268,9 +1281,9 @@ class adar1000_array(context_manager):
                 | [2, 4, 6, 8]]
             represents an array of 8 ADAR1000s 4 wide and 2 tall.
         element_map: type=list[list[int]]
-            List with the map of where the ADAR1000 channels are in the array.
-            Each entry in the map represents a row of array channels referenced
-            by element number. For example, a map:
+            List of lists with the map of where the array elements are in the
+            physical array. Each entry in the map represents a row of array
+            channels referenced by element number. For example, a map:
                 | [[1, 5, 9, 13],
                 | [2, 6, 10, 14],
                 | [3, 7, 11, 15],

--- a/adi/adar1000.py
+++ b/adi/adar1000.py
@@ -205,6 +205,22 @@ class adar1000(attribute, context_manager):
             )
 
         @property
+        def rx_beam_state(self):
+            """Get/Set the Channel Rx beam position used by RAM when
+            all channels point to individual states. Valid states are 0-120."""
+            return self.adar1000_parent._get_iio_attr(
+                f"voltage{self.adar1000_channel}", "beam_pos_load", False
+            )
+
+        @rx_beam_state.setter
+        def rx_beam_state(self, value):
+            """Get/Set the Channel Rx beam position used by RAM when
+            all channels point to individual states. Valid states are 0-120."""
+            self.adar1000_parent._set_iio_attr(
+                f"voltage{self.adar1000_channel}", "beam_pos_load", False, value
+            )
+
+        @property
         def rx_enable(self):
             """ Get/Set the Rx enable state for the associated channel """
             return bool(
@@ -267,6 +283,22 @@ class adar1000(attribute, context_manager):
             )
 
         @property
+        def tx_beam_state(self):
+            """Get/Set the Channel Tx beam position used by RAM when
+            all channels point to individual states. Valid states are 0-120."""
+            return self.adar1000_parent._get_iio_attr(
+                f"voltage{self.adar1000_channel}", "beam_pos_load", True
+            )
+
+        @tx_beam_state.setter
+        def tx_beam_state(self, value):
+            """Get/Set the Channel Tx beam position used by RAM when
+            all channels point to individual states. Valid states are 0-120."""
+            self.adar1000_parent._set_iio_attr(
+                f"voltage{self.adar1000_channel}", "beam_pos_load", True, value
+            )
+
+        @property
         def tx_enable(self):
             """ Get/Set the Tx enable state for the associated channel """
             return bool(
@@ -313,28 +345,6 @@ class adar1000(attribute, context_manager):
 
         """ Public Methods """
 
-        def load_rx_beam(self, state):
-            """Load an Rx beam from a memory position
-
-            parameters:
-                state: int
-                    State number to load. Valid options are 0 to 120
-            """
-            self.adar1000_parent._set_iio_attr(
-                f"voltage{self.adar1000_channel}", "beam_pos_load", False, state
-            )
-
-        def load_tx_beam(self, state):
-            """Load a Tx beam from a memory position
-
-            parameters:
-                state: int
-                    State number to load. Valid options are 0 to 120
-            """
-            self.adar1000_parent._set_iio_attr(
-                f"voltage{self.adar1000_channel}", "beam_pos_load", True, state
-            )
-
         def save_rx_beam(self, state, attenuator, gain, phase):
             """Save a beam to an Rx memory position
 
@@ -348,7 +358,7 @@ class adar1000(attribute, context_manager):
                 phase: float
                     Phase value for the beam position.
             """
-            save_string = f"{state}, {attenuator}, {gain}, {phase}"
+            save_string = f"{state}, {1 - int(attenuator)}, {gain}, {phase}"
 
             self.adar1000_parent._set_iio_attr(
                 f"voltage{self.adar1000_channel}", "beam_pos_save", False, save_string
@@ -367,7 +377,7 @@ class adar1000(attribute, context_manager):
                 phase: float
                     Phase value for the beam position.
             """
-            save_string = f"{state}, {attenuator}, {gain}, {phase}"
+            save_string = f"{state}, {1 - int(attenuator)}, {gain}, {phase}"
 
             self.adar1000_parent._set_iio_attr(
                 f"voltage{self.adar1000_channel}", "beam_pos_save", True, save_string
@@ -552,6 +562,30 @@ class adar1000(attribute, context_manager):
         self._set_iio_dev_attr_str("bias_enable", int(value), self._ctrl)
 
     @property
+    def common_rx_beam_state(self):
+        """Get/Set the Rx beam position used by RAM when all
+        channels point to a common state. Valid states are 0-120."""
+        return self._get_iio_dev_attr_str("static_rx_beam_pos_load", self._ctrl)
+
+    @common_rx_beam_state.setter
+    def common_rx_beam_state(self, value):
+        """Get/Set the Rx beam position used by RAM when all
+        channels point to a common state. Valid states are 0-120."""
+        self._set_iio_dev_attr_str("static_rx_beam_pos_load", value, self._ctrl)
+
+    @property
+    def common_tx_beam_state(self):
+        """Get/Set the Tx beam position used by RAM when all
+        channels point to a common state. Valid states are 0-120."""
+        return self._get_iio_dev_attr_str("static_tx_beam_pos_load", self._ctrl)
+
+    @common_tx_beam_state.setter
+    def common_tx_beam_state(self, value):
+        """Get/Set the Tx beam position used by RAM when all
+        channels point to a common state. Valid states are 0-120."""
+        self._set_iio_dev_attr_str("static_tx_beam_pos_load", value, self._ctrl)
+
+    @property
     def external_tr_pin(self):
         """ Get/Set which external T/R switch driver is used ("positive" = TR_SW_POS, "negative" = TR_SW_NEG) """
         value = bool(self._get_iio_dev_attr("sw_drv_tr_mode_sel", self._ctrl))
@@ -641,6 +675,16 @@ class adar1000(attribute, context_manager):
     def pol_switch_enable(self, value):
         """ Get/Set polarity switch driver enable state """
         self._set_iio_dev_attr_str("sw_drv_en_pol", int(value), self._ctrl)
+
+    @property
+    def rx_bias_state(self):
+        """ Get/Set the Rx bias memory position when loading from RAM. Valid states are 1-7. """
+        return self._get_iio_attr("voltage0", "bias_set_load", False, self._ctrl)
+
+    @rx_bias_state.setter
+    def rx_bias_state(self, value):
+        """ Get/Set the Rx bias memory position when loading from RAM. Valid states are 1-7. """
+        self._set_iio_attr("voltage0", "bias_set_load", False, value, self._ctrl)
 
     @property
     def rx_enable(self):
@@ -808,6 +852,16 @@ class adar1000(attribute, context_manager):
     def tr_switch_enable(self, value):
         """ Get/Set T/R switch driver enable state """
         self._set_iio_dev_attr_str("sw_drv_en_tr", int(value), self._ctrl)
+
+    @property
+    def tx_bias_state(self):
+        """ Get/Set the Tx bias memory position when loading from RAM. Valid states are 1-7. """
+        return self._get_iio_attr("voltage0", "bias_set_load", True, self._ctrl)
+
+    @tx_bias_state.setter
+    def tx_bias_state(self, value):
+        """ Get/Set the Tx bias memory position when loading from RAM. Valid states are 1-7. """
+        self._set_iio_attr("voltage0", "bias_set_load", True, value, self._ctrl)
 
     @property
     def tx_enable(self):
@@ -993,46 +1047,6 @@ class adar1000(attribute, context_manager):
     def latch_tx_settings(self):
         """ Latch in new Gain/Phase settings for the Tx """
         self._set_iio_dev_attr_str("tx_load_spi", 1, self._ctrl)
-
-    def load_common_rx_beam(self, state):
-        """Load a common Rx beam position from RAM
-
-        parameters:
-            state: int
-                State number to load. Valid options are 0 to 120
-        """
-
-        self._set_iio_dev_attr_str("static_rx_beam_pos", state, self._ctrl)
-
-    def load_common_tx_beam(self, state):
-        """Load a common Tx beam position from RAM
-
-        parameters:
-            state: int
-                State number to load. Valid options are 0 to 120
-        """
-
-        self._set_iio_dev_attr_str("static_tx_beam_pos", state, self._ctrl)
-
-    def load_rx_bias(self, state):
-        """Load an Rx bias from a memory position
-
-        parameters:
-            state: int
-                State number to load. Valid options are 1 to 7
-        """
-
-        self._set_iio_attr("voltage0", "bias_set_load", False, state, self._ctrl)
-
-    def load_tx_bias(self, state):
-        """Load a Tx bias from a memory position
-
-        parameters:
-            state: int
-                State number to load. Valid options are 1 to 7
-        """
-
-        self._set_iio_attr("voltage0", "bias_set_load", True, state, self._ctrl)
 
     def reset(self):
         """ Reset ADAR1000 to default settings """

--- a/adi/adar1000.py
+++ b/adi/adar1000.py
@@ -215,7 +215,7 @@ class adar1000(attribute, context_manager):
     @lna_bias_off.setter
     def lna_bias_off(self, value):
         """ Get/Set LNA_BIAS_OFF in voltage """
-        dac_code = value / self._BIAS_CODE_TO_VOLTAGE_SCALE
+        dac_code = value // self._BIAS_CODE_TO_VOLTAGE_SCALE
         self._set_iio_dev_attr_str("lna_bias_off", dac_code, self._ctrl)
 
     @property
@@ -227,7 +227,7 @@ class adar1000(attribute, context_manager):
     @lna_bias_on.setter
     def lna_bias_on(self, value):
         """ Get/Set LNA_BIAS_ON in voltage """
-        dac_code = value / self._BIAS_CODE_TO_VOLTAGE_SCALE
+        dac_code = value // self._BIAS_CODE_TO_VOLTAGE_SCALE
         self._set_iio_dev_attr_str("lna_bias_on", dac_code, self._ctrl)
 
     @property
@@ -553,7 +553,7 @@ class adar1000(attribute, context_manager):
     @ch1_pa_bias_off.setter
     def ch1_pa_bias_off(self, value):
         """ Get/Set Channel 1 PA_BIAS_OFF in voltage """
-        dac_code = value / self._BIAS_CODE_TO_VOLTAGE_SCALE
+        dac_code = value // self._BIAS_CODE_TO_VOLTAGE_SCALE
         self._set_iio_attr("voltage0", "pa_bias_off", True, dac_code, self._ctrl)
 
     @property
@@ -565,7 +565,7 @@ class adar1000(attribute, context_manager):
     @ch2_pa_bias_off.setter
     def ch2_pa_bias_off(self, value):
         """ Get/Set Channel 2 PA_BIAS_OFF in voltage """
-        dac_code = value / self._BIAS_CODE_TO_VOLTAGE_SCALE
+        dac_code = value // self._BIAS_CODE_TO_VOLTAGE_SCALE
         self._set_iio_attr("voltage1", "pa_bias_off", True, dac_code, self._ctrl)
 
     @property
@@ -577,7 +577,7 @@ class adar1000(attribute, context_manager):
     @ch3_pa_bias_off.setter
     def ch3_pa_bias_off(self, value):
         """ Get/Set Channel 3 PA_BIAS_OFF in voltage """
-        dac_code = value / self._BIAS_CODE_TO_VOLTAGE_SCALE
+        dac_code = value // self._BIAS_CODE_TO_VOLTAGE_SCALE
         self._set_iio_attr("voltage2", "pa_bias_off", True, dac_code, self._ctrl)
 
     @property
@@ -589,7 +589,7 @@ class adar1000(attribute, context_manager):
     @ch4_pa_bias_off.setter
     def ch4_pa_bias_off(self, value):
         """ Get/Set Channel 4 PA_BIAS_OFF in voltage """
-        dac_code = value / self._BIAS_CODE_TO_VOLTAGE_SCALE
+        dac_code = value // self._BIAS_CODE_TO_VOLTAGE_SCALE
         self._set_iio_attr("voltage3", "pa_bias_off", True, dac_code, self._ctrl)
 
     @property
@@ -601,7 +601,7 @@ class adar1000(attribute, context_manager):
     @ch1_pa_bias_on.setter
     def ch1_pa_bias_on(self, value):
         """ Get/Set Channel 1 PA_BIAS_ON in voltage """
-        dac_code = value / self._BIAS_CODE_TO_VOLTAGE_SCALE
+        dac_code = value // self._BIAS_CODE_TO_VOLTAGE_SCALE
         self._set_iio_attr("voltage0", "pa_bias_on", True, dac_code, self._ctrl)
 
     @property
@@ -613,7 +613,7 @@ class adar1000(attribute, context_manager):
     @ch2_pa_bias_on.setter
     def ch2_pa_bias_on(self, value):
         """ Get/Set Channel 2 PA_BIAS_ON in voltage """
-        dac_code = value / self._BIAS_CODE_TO_VOLTAGE_SCALE
+        dac_code = value // self._BIAS_CODE_TO_VOLTAGE_SCALE
         self._set_iio_attr("voltage1", "pa_bias_on", True, dac_code, self._ctrl)
 
     @property
@@ -625,7 +625,7 @@ class adar1000(attribute, context_manager):
     @ch3_pa_bias_on.setter
     def ch3_pa_bias_on(self, value):
         """ Get/Set Channel 3 PA_BIAS_ON in voltage """
-        dac_code = value / self._BIAS_CODE_TO_VOLTAGE_SCALE
+        dac_code = value // self._BIAS_CODE_TO_VOLTAGE_SCALE
         self._set_iio_attr("voltage2", "pa_bias_on", True, dac_code, self._ctrl)
 
     @property
@@ -637,7 +637,7 @@ class adar1000(attribute, context_manager):
     @ch4_pa_bias_on.setter
     def ch4_pa_bias_on(self, value):
         """ Get/Set Channel 4 PA_BIAS_ON in voltage """
-        dac_code = value / self._BIAS_CODE_TO_VOLTAGE_SCALE
+        dac_code = value // self._BIAS_CODE_TO_VOLTAGE_SCALE
         self._set_iio_attr("voltage3", "pa_bias_on", True, dac_code, self._ctrl)
 
     @property
@@ -1058,6 +1058,35 @@ class adar1000(attribute, context_manager):
 
         self._set_iio_attr("voltage0", "bias_set_load", output, state, self._ctrl)
 
+    def _save_beam(self, rx_or_tx, channel, state, attenuator, gain, phase):
+        """Save a beam to a memory position
+
+        parameters:
+            rx_or_tx: string
+                String indicating whether to load an Rx or Tx beam state. Valid options are "rx" and "tx"
+            channel: int
+                Channel number to save (1-4)
+            state: int
+                State number to save. Valid options are 0 to 120
+            attenuator: bool
+                Attenuator state for the beam position. True means the attenuator is in place.
+            gain: int
+                Gain value for the beam position. Valid settings are 0 to 127.
+            phase: float
+                Phase value for the beam position.
+        """
+
+        if rx_or_tx.lower() == "rx":
+            output = False
+        else:
+            output = True
+
+        save_string = f"{state}, {attenuator}, {gain}, {phase}"
+
+        self._set_iio_attr(
+            f"voltage{channel - 1}", "beam_pos_save", output, save_string, self._ctrl
+        )
+
     def _sequence_start(self, rx_or_tx, state):
         """Set the sequencer's start position
 
@@ -1149,6 +1178,130 @@ class adar1000(attribute, context_manager):
     def reset(self):
         """ Reset ADAR1000 to default settings """
         self._set_iio_dev_attr_str("reset", "1", self._ctrl)
+
+    def save_rx_beam(self, channel, state, attenuator, gain, phase):
+        """Save a beam to an Rx memory position
+
+        parameters:
+            channel: int
+                Channel number to save (1-4)
+            state: int
+                State number to save. Valid options are 0 to 120
+            attenuator: bool
+                Attenuator state for the beam position. True means the attenuator is in place.
+            gain: int
+                Gain value for the beam position. Valid settings are 0 to 127.
+            phase: float
+                Phase value for the beam position.
+        """
+        self._save_beam("rx", channel, state, attenuator, gain, phase)
+
+    def save_rx_bias(
+        self,
+        state,
+        lna_bias_off,
+        lna_bias_on,
+        rx_vga_vm_bias_current,
+        rx_lna_bias_current,
+    ):
+        """Save a bias setting to an Rx memory position
+
+        parameters:
+            state: int
+                State number to save. Valid options are 1 to 7
+            lna_bias_off: float
+                LNA_BIAS_OFF voltage
+            lna_bias_on: float
+                LNA_BIAS_ON voltage
+            rx_vga_vm_bias_current: int
+                Bias current setting for the Rx VGA and Vector Modulator
+            rx_lna_bias_current: int
+                Bias current setting for the Rx LNA
+        """
+
+        # Convert the LNA bias settings to dac codes:
+        lna_off_dac_code = lna_bias_off // self._BIAS_CODE_TO_VOLTAGE_SCALE
+        lna_on_dac_code = lna_bias_on // self._BIAS_CODE_TO_VOLTAGE_SCALE
+
+        save_string = f"{state}, {lna_off_dac_code}, {lna_on_dac_code}, {rx_vga_vm_bias_current}, {rx_lna_bias_current}"
+
+        self._set_iio_attr("voltage0", "bias_set_save", False, save_string, self._ctrl)
+
+    def save_tx_beam(self, channel, state, attenuator, gain, phase):
+        """Save a beam to a Tx memory position
+
+        parameters:
+            channel: int
+                Channel number to save (1-4)
+            state: int
+                State number to save. Valid options are 0 to 120
+            attenuator: bool
+                Attenuator state for the beam position. True means the attenuator is in place.
+            gain: int
+                Gain value for the beam position. Valid settings are 0 to 127.
+            phase: float
+                Phase value for the beam position.
+        """
+        self._save_beam("tx", channel, state, attenuator, gain, phase)
+
+    def save_tx_bias(
+        self,
+        state,
+        pa1_bias_off,
+        pa2_bias_off,
+        pa3_bias_off,
+        pa4_bias_off,
+        pa1_bias_on,
+        pa2_bias_on,
+        pa3_bias_on,
+        pa4_bias_on,
+        tx_vga_vm_bias_current,
+        tx_pa_bias_current,
+    ):
+        """Save a bias setting to a Tx memory position
+
+        parameters:
+            state: int
+                State number to save. Valid options are 1 to 7
+            pa1_bias_off: float
+                PA1_BIAS_OFF voltage
+            pa2_bias_off: float
+                PA2_BIAS_OFF voltage
+            pa3_bias_off: float
+                PA3_BIAS_OFF voltage
+            pa4_bias_off: float
+                PA4_BIAS_OFF voltage
+            pa1_bias_on: float
+                PA1_BIAS_ON voltage
+            pa2_bias_on: float
+                PA2_BIAS_ON voltage
+            pa3_bias_on: float
+                PA3_BIAS_ON voltage
+            pa4_bias_on: float
+                PA4_BIAS_ON voltage
+            tx_vga_vm_bias_current: int
+                Bias current setting for the Tx VGA and Vector Modulator
+            tx_lna_bias_current: int
+                Bias current setting for the Tx PA
+        """
+
+        # Convert the PA bias settings to dac codes:
+        pa1_off_dac_code = pa1_bias_off // self._BIAS_CODE_TO_VOLTAGE_SCALE
+        pa2_off_dac_code = pa2_bias_off // self._BIAS_CODE_TO_VOLTAGE_SCALE
+        pa3_off_dac_code = pa3_bias_off // self._BIAS_CODE_TO_VOLTAGE_SCALE
+        pa4_off_dac_code = pa4_bias_off // self._BIAS_CODE_TO_VOLTAGE_SCALE
+        pa1_on_dac_code = pa1_bias_on // self._BIAS_CODE_TO_VOLTAGE_SCALE
+        pa2_on_dac_code = pa2_bias_on // self._BIAS_CODE_TO_VOLTAGE_SCALE
+        pa3_on_dac_code = pa3_bias_on // self._BIAS_CODE_TO_VOLTAGE_SCALE
+        pa4_on_dac_code = pa4_bias_on // self._BIAS_CODE_TO_VOLTAGE_SCALE
+
+        save_string = (
+            f"{state}, {pa1_off_dac_code}, {pa2_off_dac_code}, {pa3_off_dac_code}, {pa4_off_dac_code}, "
+            f"{pa1_on_dac_code}, {pa2_on_dac_code}, {pa3_on_dac_code}, {pa4_on_dac_code}, {tx_vga_vm_bias_current}, "
+            f"{tx_pa_bias_current}"
+        )
+
+        self._set_iio_attr("voltage0", "bias_set_save", True, save_string, self._ctrl)
 
 
 class adar1000_array(context_manager):

--- a/adi/adar1000.py
+++ b/adi/adar1000.py
@@ -53,6 +53,7 @@ class adar1000(attribute, context_manager):
     """
 
     _device_name = ""
+    _BIAS_CODE_TO_VOLTAGE_SCALE = -0.018824
 
     def __init__(self, uri="", chip_id="csb1_chip1", context_handle=None):
 
@@ -96,6 +97,16 @@ class adar1000(attribute, context_manager):
     """ Device attributes """
 
     @property
+    def beam_mem_enable(self):
+        """ Get/Set enable bit for RAM control vs. SPI control of the beam state """
+        return bool(self._get_iio_dev_attr("beam_mem_enable", self._ctrl))
+
+    @beam_mem_enable.setter
+    def beam_mem_enable(self, value):
+        """ Get/Set enable bit for RAM control vs. SPI control of the beam state """
+        self._set_iio_dev_attr_str("beam_mem_enable", int(value), self._ctrl)
+
+    @property
     def bias_dac_enable(self):
         """ Get/Set enable for bias DACs """
         return bool(self._get_iio_dev_attr("bias_enable", self._ctrl))
@@ -129,6 +140,32 @@ class adar1000(attribute, context_manager):
             self._set_iio_dev_attr_str("bias_ctrl", 0, self._ctrl)
         else:
             raise ValueError('bias_dac_mode should be "toggle" or "on"')
+
+    @property
+    def bias_mem_enable(self):
+        """ Get/Set enable bit for RAM control vs. SPI control of the bias state """
+        return bool(self._get_iio_dev_attr("bias_mem_enable", self._ctrl))
+
+    @bias_mem_enable.setter
+    def bias_mem_enable(self, value):
+        """ Get/Set enable bit for RAM control vs. SPI control of the bias state """
+        self._set_iio_dev_attr_str("bias_mem_enable", int(value), self._ctrl)
+
+    @property
+    def common_mem_enable(self):
+        """
+        Get/Set the CHX_RAM_BYPASS bits to use either a common beam state for all channels set by registers 0x39
+        and 0x3A, or individual beam states set by registers 0x3D to 0x44.
+        """
+        return bool(self._get_iio_dev_attr("common_mem_enable", self._ctrl))
+
+    @common_mem_enable.setter
+    def common_mem_enable(self, value):
+        """
+        Get/Set the CHX_RAM_BYPASS bits to use either a common beam state for all channels set by registers 0x39
+        and 0x3A, or individual beam states set by registers 0x3D to 0x44.
+        """
+        self._set_iio_dev_attr_str("bias_enable", int(value), self._ctrl)
 
     @property
     def external_tr_pin(self):
@@ -167,23 +204,27 @@ class adar1000(attribute, context_manager):
 
     @property
     def lna_bias_off(self):
-        """ Get/Set LNA_BIAS_OFF setting """
-        return self._get_iio_dev_attr("lna_bias_off", self._ctrl)
+        """ Get/Set LNA_BIAS_OFF in voltage """
+        dac_code = self._get_iio_dev_attr("lna_bias_off", self._ctrl)
+        return dac_code * self._BIAS_CODE_TO_VOLTAGE_SCALE
 
     @lna_bias_off.setter
     def lna_bias_off(self, value):
-        """ Get/Set LNA_BIAS_OFF setting """
-        self._set_iio_dev_attr_str("lna_bias_off", value, self._ctrl)
+        """ Get/Set LNA_BIAS_OFF in voltage """
+        dac_code = value / self._BIAS_CODE_TO_VOLTAGE_SCALE
+        self._set_iio_dev_attr_str("lna_bias_off", dac_code, self._ctrl)
 
     @property
     def lna_bias_on(self):
-        """ Get/Set LNA_BIAS_ON setting """
-        return self._get_iio_dev_attr("lna_bias_on", self._ctrl)
+        """ Get/Set LNA_BIAS_ON in voltage """
+        dac_code = self._get_iio_dev_attr("lna_bias_on", self._ctrl)
+        return dac_code * self._BIAS_CODE_TO_VOLTAGE_SCALE
 
     @lna_bias_on.setter
     def lna_bias_on(self, value):
-        """ Get/Set LNA_BIAS_ON setting """
-        self._set_iio_dev_attr_str("lna_bias_on", value, self._ctrl)
+        """ Get/Set LNA_BIAS_ON in voltage """
+        dac_code = value / self._BIAS_CODE_TO_VOLTAGE_SCALE
+        self._set_iio_dev_attr_str("lna_bias_on", dac_code, self._ctrl)
 
     @property
     def lna_bias_out_enable(self):
@@ -488,83 +529,147 @@ class adar1000(attribute, context_manager):
 
     @property
     def ch1_pa_bias_off(self):
-        """ Get/Set Channel 1 PA_BIAS_OFF """
-        return self._get_iio_attr("voltage0", "pa_bias_off", True, self._ctrl)
+        """ Get/Set Channel 1 PA_BIAS_OFF in voltage """
+        dac_code = self._get_iio_attr("voltage0", "pa_bias_off", True, self._ctrl)
+        return dac_code * self._BIAS_CODE_TO_VOLTAGE_SCALE
 
     @ch1_pa_bias_off.setter
     def ch1_pa_bias_off(self, value):
-        """ Get/Set Channel 1 PA_BIAS_OFF """
-        self._set_iio_attr("voltage0", "pa_bias_off", True, value, self._ctrl)
+        """ Get/Set Channel 1 PA_BIAS_OFF in voltage """
+        dac_code = value / self._BIAS_CODE_TO_VOLTAGE_SCALE
+        self._set_iio_attr("voltage0", "pa_bias_off", True, dac_code, self._ctrl)
 
     @property
     def ch2_pa_bias_off(self):
-        """ Get/Set Channel 2 PA_BIAS_OFF """
-        return self._get_iio_attr("voltage1", "pa_bias_off", True, self._ctrl)
+        """ Get/Set Channel 2 PA_BIAS_OFF in voltage """
+        dac_code = self._get_iio_attr("voltage1", "pa_bias_off", True, self._ctrl)
+        return dac_code * self._BIAS_CODE_TO_VOLTAGE_SCALE
 
     @ch2_pa_bias_off.setter
     def ch2_pa_bias_off(self, value):
-        """ Get/Set Channel 2 PA_BIAS_OFF """
-        self._set_iio_attr("voltage1", "pa_bias_off", True, value, self._ctrl)
+        """ Get/Set Channel 2 PA_BIAS_OFF in voltage """
+        dac_code = value / self._BIAS_CODE_TO_VOLTAGE_SCALE
+        self._set_iio_attr("voltage1", "pa_bias_off", True, dac_code, self._ctrl)
 
     @property
     def ch3_pa_bias_off(self):
-        """ Get/Set Channel 3 PA_BIAS_OFF """
-        return self._get_iio_attr("voltage2", "pa_bias_off", True, self._ctrl)
+        """ Get/Set Channel 3 PA_BIAS_OFF in voltage """
+        dac_code = self._get_iio_attr("voltage2", "pa_bias_off", True, self._ctrl)
+        return dac_code * self._BIAS_CODE_TO_VOLTAGE_SCALE
 
     @ch3_pa_bias_off.setter
     def ch3_pa_bias_off(self, value):
-        """ Get/Set Channel 3 PA_BIAS_OFF """
-        self._set_iio_attr("voltage2", "pa_bias_off", True, value, self._ctrl)
+        """ Get/Set Channel 3 PA_BIAS_OFF in voltage """
+        dac_code = value / self._BIAS_CODE_TO_VOLTAGE_SCALE
+        self._set_iio_attr("voltage2", "pa_bias_off", True, dac_code, self._ctrl)
 
     @property
     def ch4_pa_bias_off(self):
-        """ Get/Set Channel 4 PA_BIAS_OFF """
-        return self._get_iio_attr("voltage3", "pa_bias_off", True, self._ctrl)
+        """ Get/Set Channel 4 PA_BIAS_OFF in voltage """
+        dac_code = self._get_iio_attr("voltage3", "pa_bias_off", True, self._ctrl)
+        return dac_code * self._BIAS_CODE_TO_VOLTAGE_SCALE
 
     @ch4_pa_bias_off.setter
     def ch4_pa_bias_off(self, value):
-        """ Get/Set Channel 4 PA_BIAS_OFF """
-        self._set_iio_attr("voltage3", "pa_bias_off", True, value, self._ctrl)
+        """ Get/Set Channel 4 PA_BIAS_OFF in voltage """
+        dac_code = value / self._BIAS_CODE_TO_VOLTAGE_SCALE
+        self._set_iio_attr("voltage3", "pa_bias_off", True, dac_code, self._ctrl)
 
     @property
     def ch1_pa_bias_on(self):
-        """ Get/Set Channel 1 PA_BIAS_ON """
-        return self._get_iio_attr("voltage0", "pa_bias_on", True, self._ctrl)
+        """ Get/Set Channel 1 PA_BIAS_ON in voltage """
+        dac_code = self._get_iio_attr("voltage0", "pa_bias_on", True, self._ctrl)
+        return dac_code * self._BIAS_CODE_TO_VOLTAGE_SCALE
 
     @ch1_pa_bias_on.setter
     def ch1_pa_bias_on(self, value):
-        """ Get/Set Channel 1 PA_BIAS_ON """
-        self._set_iio_attr("voltage0", "pa_bias_on", True, value, self._ctrl)
+        """ Get/Set Channel 1 PA_BIAS_ON in voltage """
+        dac_code = value / self._BIAS_CODE_TO_VOLTAGE_SCALE
+        self._set_iio_attr("voltage0", "pa_bias_on", True, dac_code, self._ctrl)
 
     @property
     def ch2_pa_bias_on(self):
-        """ Get/Set Channel 2 PA_BIAS_ON """
-        return self._get_iio_attr("voltage1", "pa_bias_on", True, self._ctrl)
+        """ Get/Set Channel 2 PA_BIAS_ON in voltage """
+        dac_code = self._get_iio_attr("voltage1", "pa_bias_on", True, self._ctrl)
+        return dac_code * self._BIAS_CODE_TO_VOLTAGE_SCALE
 
     @ch2_pa_bias_on.setter
     def ch2_pa_bias_on(self, value):
-        """ Get/Set Channel 2 PA_BIAS_ON """
-        self._set_iio_attr("voltage1", "pa_bias_on", True, value, self._ctrl)
+        """ Get/Set Channel 2 PA_BIAS_ON in voltage """
+        dac_code = value / self._BIAS_CODE_TO_VOLTAGE_SCALE
+        self._set_iio_attr("voltage1", "pa_bias_on", True, dac_code, self._ctrl)
 
     @property
     def ch3_pa_bias_on(self):
-        """ Get/Set Channel 3 PA_BIAS_ON """
-        return self._get_iio_attr("voltage2", "pa_bias_on", True, self._ctrl)
+        """ Get/Set Channel 3 PA_BIAS_ON in voltage """
+        dac_code = self._get_iio_attr("voltage2", "pa_bias_on", True, self._ctrl)
+        return dac_code * self._BIAS_CODE_TO_VOLTAGE_SCALE
 
     @ch3_pa_bias_on.setter
     def ch3_pa_bias_on(self, value):
-        """ Get/Set Channel 3 PA_BIAS_ON """
-        self._set_iio_attr("voltage2", "pa_bias_on", True, value, self._ctrl)
+        """ Get/Set Channel 3 PA_BIAS_ON in voltage """
+        dac_code = value / self._BIAS_CODE_TO_VOLTAGE_SCALE
+        self._set_iio_attr("voltage2", "pa_bias_on", True, dac_code, self._ctrl)
 
     @property
     def ch4_pa_bias_on(self):
-        """ Get/Set Channel 4 PA_BIAS_ON """
-        return self._get_iio_attr("voltage3", "pa_bias_on", True, self._ctrl)
+        """ Get/Set Channel 4 PA_BIAS_ON in voltage """
+        dac_code = self._get_iio_attr("voltage3", "pa_bias_on", True, self._ctrl)
+        return dac_code * self._BIAS_CODE_TO_VOLTAGE_SCALE
 
     @ch4_pa_bias_on.setter
     def ch4_pa_bias_on(self, value):
-        """ Get/Set Channel 4 PA_BIAS_ON """
-        self._set_iio_attr("voltage3", "pa_bias_on", True, value, self._ctrl)
+        """ Get/Set Channel 4 PA_BIAS_ON in voltage """
+        dac_code = value / self._BIAS_CODE_TO_VOLTAGE_SCALE
+        self._set_iio_attr("voltage3", "pa_bias_on", True, dac_code, self._ctrl)
+
+    @property
+    def ch1_rx_attenuator(self):
+        """ Get/Set Channel 1 Rx Attenuator state """
+        return bool(
+            1 - self._get_iio_attr("voltage0", "attenuation", False, self._ctrl)
+        )
+
+    @ch1_rx_attenuator.setter
+    def ch1_rx_attenuator(self, value):
+        """ Get/Set Channel 1 Rx Attenuator state """
+        self._set_iio_attr("voltage0", "attenuation", False, 1 - int(value), self._ctrl)
+
+    @property
+    def ch2_rx_attenuator(self):
+        """ Get/Set Channel 2 Rx Attenuator state """
+        return bool(
+            1 - self._get_iio_attr("voltage1", "attenuation", False, self._ctrl)
+        )
+
+    @ch2_rx_attenuator.setter
+    def ch2_rx_attenuator(self, value):
+        """ Get/Set Channel 2 Rx Attenuator state """
+        self._set_iio_attr("voltage1", "attenuation", False, 1 - int(value), self._ctrl)
+
+    @property
+    def ch3_rx_attenuator(self):
+        """ Get/Set Channel 3 Rx Attenuator state """
+        return bool(
+            1 - self._get_iio_attr("voltage2", "attenuation", False, self._ctrl)
+        )
+
+    @ch3_rx_attenuator.setter
+    def ch3_rx_attenuator(self, value):
+        """ Get/Set Channel 3 Rx Attenuator state """
+        self._set_iio_attr("voltage2", "attenuation", False, 1 - int(value), self._ctrl)
+
+    @property
+    def ch4_rx_attenuator(self):
+        """ Get/Set Channel 4 Rx Attenuator state """
+        return bool(
+            1 - self._get_iio_attr("voltage3", "attenuation", False, self._ctrl)
+        )
+
+    @ch4_rx_attenuator.setter
+    def ch4_rx_attenuator(self, value):
+        """ Get/Set Channel 4 Rx Attenuator state """
+        self._set_iio_attr("voltage3", "attenuation", False, 1 - int(value), self._ctrl)
 
     @property
     def ch1_rx_gain(self):
@@ -685,6 +790,46 @@ class adar1000(attribute, context_manager):
     def ch4_rx_powerdown(self, value):
         """ Get/Set Channel 4 Rx Powerdown """
         self._set_iio_attr("voltage3", "powerdown", False, int(value), self._ctrl)
+
+    @property
+    def ch1_tx_attenuator(self):
+        """ Get/Set Channel 1 Tx Attenuator state """
+        return bool(1 - self._get_iio_attr("voltage0", "attenuation", True, self._ctrl))
+
+    @ch1_tx_attenuator.setter
+    def ch1_tx_attenuator(self, value):
+        """ Get/Set Channel 1 Tx Attenuator state """
+        self._set_iio_attr("voltage0", "attenuation", True, 1 - int(value), self._ctrl)
+
+    @property
+    def ch2_tx_attenuator(self):
+        """ Get/Set Channel 2 Tx Attenuator state """
+        return bool(1 - self._get_iio_attr("voltage1", "attenuation", True, self._ctrl))
+
+    @ch2_tx_attenuator.setter
+    def ch2_tx_attenuator(self, value):
+        """ Get/Set Channel 2 Tx Attenuator state """
+        self._set_iio_attr("voltage1", "attenuation", True, 1 - int(value), self._ctrl)
+
+    @property
+    def ch3_tx_attenuator(self):
+        """ Get/Set Channel 3 Tx Attenuator state """
+        return bool(1 - self._get_iio_attr("voltage2", "attenuation", True, self._ctrl))
+
+    @ch3_tx_attenuator.setter
+    def ch3_tx_attenuator(self, value):
+        """ Get/Set Channel 3 Tx Attenuator state """
+        self._set_iio_attr("voltage2", "attenuation", True, 1 - int(value), self._ctrl)
+
+    @property
+    def ch4_tx_attenuator(self):
+        """ Get/Set Channel 4 Tx Attenuator state """
+        return bool(1 - self._get_iio_attr("voltage3", "attenuation", True, self._ctrl))
+
+    @ch4_tx_attenuator.setter
+    def ch4_tx_attenuator(self, value):
+        """ Get/Set Channel 4 Tx Attenuator state """
+        self._set_iio_attr("voltage3", "attenuation", True, 1 - int(value), self._ctrl)
 
     @property
     def ch1_tx_gain(self):
@@ -935,6 +1080,14 @@ class adar1000(attribute, context_manager):
     def generate_clocks(self):
         """ Generate CLK cycles before pulsing RX_LOAD or TX_LOAD """
         self._set_iio_dev_attr_str("gen_clk_cycles", "", self._ctrl)
+
+    def latch_rx_settings(self):
+        """ Latch in new Gain/Phase settings for the Rx """
+        self._set_iio_dev_attr_str("rx_load_spi", 1, self._ctrl)
+
+    def latch_tx_settings(self):
+        """ Latch in new Gain/Phase settings for the Tx """
+        self._set_iio_dev_attr_str("tx_load_spi", 1, self._ctrl)
 
     def load_rx_beam(self, channel, state):
         """Load an Rx beam from a memory position

--- a/adi/adar1000.py
+++ b/adi/adar1000.py
@@ -31,6 +31,8 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from math import pi, sin
+
 from adi.attribute import attribute
 from adi.context_manager import context_manager
 
@@ -41,6 +43,8 @@ class adar1000(attribute, context_manager):
     parameters:
         uri: type=string
             URI of IIO context with ADAR1000(s)
+        context: type=iio.Context
+            IIO Context for the device. Only required if using adar1000_array.
         chip_id: type=string
             String identifying desired chip select and hardware ID for the
             ADAR1000. This string is the label coinciding with each chip
@@ -48,25 +52,348 @@ class adar1000(attribute, context_manager):
             The csb line can be any number depending on how many are used in the
             system. The chip number will typically be 1-4 because each CSB line
             can control up to four ADAR1000s.
-        context_handle: type=iio.Context
-            IIO context handle. Not used unless creating an array of chips.
+        device_number: type=int
+            Integer indicating the device number in the array
+        array_element_map: type=list[list[int]]
+            List with the map of where the ADAR1000 channels are in the array.
+            Each entry in the map represents a row of array channels referenced
+            by element number. For example, a map:
+                | [[1, 5, 9, 13],
+                |   [2, 6, 10, 14],
+                |   [3, 7, 11, 15],
+                |   [4, 8, 12, 16]]
+            represents an array of 16 elements in a square array.
+        channel_element_map: type=list[int]
+            List of integers relating the array element numbers to the channels
+            of the ADAR1000. Each number in the list is the element number in the
+            larger array, in order of the ADAR1000 channels. For example, a list
+            [10, 14, 13, 9] indicates that the ADAR1000's channels are the
+            following elements in the full array:
+                | Channel 1: Element # 10
+                | Channel 2: Element # 14
+                | Channel 3: Element # 13
+                | Channel 4: Element # 9
     """
 
     _device_name = ""
     _BIAS_CODE_TO_VOLTAGE_SCALE = -0.018824
 
-    def __init__(self, uri="", chip_id="csb1_chip1", context_handle=None):
+    class adar1000_channel:
+        """Class for each channel of the ADAR1000. This class is not meant
+        to be instantiated directly. adar1000 objects will create their
+        own handles of this class, one for each channel
+
+        parameters:
+            adar1000_parent: type=adar1000
+                Parent ADAR1000 instance
+            adar_channel: type=int
+                Channel number of the parent corresponding to this channel
+            array_element: type=int
+                Element number of the array corresponding to this channel
+            row: int
+                Row number in the array
+            column: int
+                Column number in the array
+        """
+
+        def __init__(self, adar_parent, adar_channel, array_element, row, column):
+            self._adar1000_parent = adar_parent
+            self._adar1000_channel = adar_channel
+            self._array_element_number = array_element
+            self._row = row
+            self._column = column
+
+        def __repr__(self):
+            """ Representation of the ADAR1000 element class """
+            return f"ADAR1000 array element #{self.array_element_number}"
+
+        """ Channel Properties """
+
+        @property
+        def adar1000_channel(self):
+            return self._adar1000_channel
+
+        @property
+        def adar1000_parent(self):
+            return self._adar1000_parent
+
+        @property
+        def array_element_number(self):
+            """ Element number in the array """
+            return self._array_element_number
+
+        @property
+        def column(self):
+            """ Element column number in the array """
+            return self._column
+
+        @property
+        def detector_enable(self):
+            """ Get/Set the detector enable bit for the associated channel """
+            return bool(
+                self.adar1000_parent._get_iio_attr(
+                    f"voltage{self.adar1000_channel}", "detector_en", True
+                )
+            )
+
+        @detector_enable.setter
+        def detector_enable(self, value):
+            """ Get/Set Channel 1 detector enable bit """
+            self.adar1000_parent._set_iio_attr(
+                f"voltage{self.adar1000_channel}", "detector_en", True, int(value)
+            )
+
+        @property
+        def detector_power(self):
+            """ Get the detector power reading for the associated channel """
+            return self.adar1000_parent._get_iio_attr(
+                f"voltage{self.adar1000_channel}", "raw", True
+            )
+
+        @property
+        def pa_bias_off(self):
+            """ Get/Set PA_BIAS_OFF in voltage for the associated channel """
+            dac_code = self.adar1000_parent._get_iio_attr(
+                f"voltage{self.adar1000_channel}", "pa_bias_off", True
+            )
+            return dac_code * self.adar1000_parent._BIAS_CODE_TO_VOLTAGE_SCALE
+
+        @pa_bias_off.setter
+        def pa_bias_off(self, value):
+            """ Get/Set PA_BIAS_OFF in voltage for the associated channel """
+            dac_code = int(value / self.adar1000_parent._BIAS_CODE_TO_VOLTAGE_SCALE)
+            self.adar1000_parent._set_iio_attr(
+                f"voltage{self.adar1000_channel}", "pa_bias_off", True, dac_code
+            )
+
+        @property
+        def pa_bias_on(self):
+            """ Get/Set PA_BIAS_ON in voltage for the associated channel """
+            dac_code = self.adar1000_parent._get_iio_attr(
+                f"voltage{self.adar1000_channel}", "pa_bias_on", True
+            )
+            return dac_code * self.adar1000_parent._BIAS_CODE_TO_VOLTAGE_SCALE
+
+        @pa_bias_on.setter
+        def pa_bias_on(self, value):
+            """ Get/Set PA_BIAS_ON in voltage for the associated channel """
+            dac_code = int(value / self.adar1000_parent._BIAS_CODE_TO_VOLTAGE_SCALE)
+            self.adar1000_parent._set_iio_attr(
+                f"voltage{self.adar1000_channel}", "pa_bias_on", True, dac_code
+            )
+
+        @property
+        def row(self):
+            """ Element row number in the array """
+            return self._row
+
+        @property
+        def rx_attenuator(self):
+            """ Get/Set Rx Attenuator state for the associated channel """
+            return bool(
+                1
+                - self.adar1000_parent._get_iio_attr(
+                    f"voltage{self.adar1000_channel}", "attenuation", False
+                )
+            )
+
+        @rx_attenuator.setter
+        def rx_attenuator(self, value):
+            """ Get/Set Rx Attenuator state for the associated channel """
+            self.adar1000_parent._set_iio_attr(
+                f"voltage{self.adar1000_channel}", "attenuation", False, 1 - int(value)
+            )
+
+        @property
+        def rx_enable(self):
+            """ Get/Set the Rx enable state for the associated channel """
+            return bool(
+                1
+                - self.adar1000_parent._get_iio_attr(
+                    f"voltage{self.adar1000_channel}", "powerdown", False
+                )
+            )
+
+        @rx_enable.setter
+        def rx_enable(self, value):
+            """ Get/Set the Rx enable state for the associated channel """
+            self.adar1000_parent._set_iio_attr(
+                f"voltage{self.adar1000_channel}", "powerdown", False, 1 - int(value)
+            )
+
+        @property
+        def rx_gain(self):
+            """ Get/Set the Rx Gain for the associated channel """
+            return self.adar1000_parent._get_iio_attr(
+                f"voltage{self.adar1000_channel}", "hardwaregain", False
+            )
+
+        @rx_gain.setter
+        def rx_gain(self, value):
+            """ Get/Set the Rx Gain for the associated channel """
+            self.adar1000_parent._set_iio_attr(
+                f"voltage{self.adar1000_channel}", "hardwaregain", False, value
+            )
+
+        @property
+        def rx_phase(self):
+            """ Get/Set the Rx Phase for the associated channel """
+            return self.adar1000_parent._get_iio_attr(
+                f"voltage{self.adar1000_channel}", "phase", False
+            )
+
+        @rx_phase.setter
+        def rx_phase(self, value):
+            """ Get/Set the Rx Phase for the associated channel """
+            self.adar1000_parent._set_iio_attr(
+                f"voltage{self.adar1000_channel}", "phase", False, value
+            )
+
+        @property
+        def tx_attenuator(self):
+            """ Get/Set the Tx Attenuator state for the associated channel """
+            return bool(
+                1
+                - self.adar1000_parent._get_iio_attr(
+                    f"voltage{self.adar1000_channel}", "attenuation", True
+                )
+            )
+
+        @tx_attenuator.setter
+        def tx_attenuator(self, value):
+            """ Get/Set the Tx Attenuator state for the associated channel """
+            self.adar1000_parent._set_iio_attr(
+                f"voltage{self.adar1000_channel}", "attenuation", True, 1 - int(value)
+            )
+
+        @property
+        def tx_enable(self):
+            """ Get/Set the Tx enable state for the associated channel """
+            return bool(
+                1
+                - self.adar1000_parent._get_iio_attr(
+                    f"voltage{self.adar1000_channel}", "powerdown", True
+                )
+            )
+
+        @tx_enable.setter
+        def tx_enable(self, value):
+            """ Get/Set the Tx enable state for the associated channel """
+            self.adar1000_parent._set_iio_attr(
+                f"voltage{self.adar1000_channel}", "powerdown", True, 1 - int(value)
+            )
+
+        @property
+        def tx_gain(self):
+            """ Get/Set the Tx Gain for the associated channel """
+            return self.adar1000_parent._get_iio_attr(
+                f"voltage{self.adar1000_channel}", "hardwaregain", True
+            )
+
+        @tx_gain.setter
+        def tx_gain(self, value):
+            """ Get/Set the Tx Gain for the associated channel """
+            self.adar1000_parent._set_iio_attr(
+                f"voltage{self.adar1000_channel}", "hardwaregain", True, value
+            )
+
+        @property
+        def tx_phase(self):
+            """ Get/Set the Tx Phase for the associated channel """
+            return self.adar1000_parent._get_iio_attr(
+                f"voltage{self.adar1000_channel}", "phase", True
+            )
+
+        @tx_phase.setter
+        def tx_phase(self, value):
+            """ Get/Set the Tx Phase for the associated channel """
+            self.adar1000_parent._set_iio_attr(
+                f"voltage{self.adar1000_channel}", "phase", True, value
+            )
+
+        """ Public Methods """
+
+        def load_rx_beam(self, state):
+            """Load an Rx beam from a memory position
+
+            parameters:
+                state: int
+                    State number to load. Valid options are 0 to 120
+            """
+            self.adar1000_parent._set_iio_attr(
+                f"voltage{self.adar1000_channel}", "beam_pos_load", False, state
+            )
+
+        def load_tx_beam(self, state):
+            """Load a Tx beam from a memory position
+
+            parameters:
+                state: int
+                    State number to load. Valid options are 0 to 120
+            """
+            self.adar1000_parent._set_iio_attr(
+                f"voltage{self.adar1000_channel}", "beam_pos_load", True, state
+            )
+
+        def save_rx_beam(self, state, attenuator, gain, phase):
+            """Save a beam to an Rx memory position
+
+            parameters:
+                state: int
+                    State number to save. Valid options are 0 to 120
+                attenuator: bool
+                    Attenuator state for the beam position. True means the attenuator is in place.
+                gain: int
+                    Gain value for the beam position. Valid settings are 0 to 127.
+                phase: float
+                    Phase value for the beam position.
+            """
+            save_string = f"{state}, {attenuator}, {gain}, {phase}"
+
+            self.adar1000_parent._set_iio_attr(
+                f"voltage{self.adar1000_channel}", "beam_pos_save", False, save_string
+            )
+
+        def save_tx_beam(self, state, attenuator, gain, phase):
+            """Save a beam to a Tx memory position
+
+            parameters:
+                state: int
+                    State number to save. Valid options are 0 to 120
+                attenuator: bool
+                    Attenuator state for the beam position. True means the attenuator is in place.
+                gain: int
+                    Gain value for the beam position. Valid settings are 0 to 127.
+                phase: float
+                    Phase value for the beam position.
+            """
+            save_string = f"{state}, {attenuator}, {gain}, {phase}"
+
+            self.adar1000_parent._set_iio_attr(
+                f"voltage{self.adar1000_channel}", "beam_pos_save", True, save_string
+            )
+
+    def __init__(
+        self,
+        uri="",
+        context=None,
+        chip_id="csb1_chip1",
+        device_number=1,
+        array_element_map=None,
+        channel_element_map=None,
+    ):
 
         # Use the given context if possible, otherwise lookup the context
-        if context_handle is not None:
-            self._ctx = context_handle
-        else:
+        if context is None:
             context_manager.__init__(self, uri, self._device_name)
+        else:
+            self._ctx = context
 
         self._ctrl = None
         self._chip_id = chip_id
+        self._array_device_number = device_number
 
-        # Raise an error if the chip_id is a list. Suggest using the array class
+        # Raise an error if the chip_id is an iterable
         if isinstance(chip_id, (list, tuple, set)):
             raise Exception(
                 '"chip_id" can\'t be an iterable. '
@@ -86,15 +413,37 @@ class adar1000(attribute, context_manager):
         if not self._ctrl:
             raise Exception(f"Device not found for {chip_id}")
 
-    @property
-    def chip_id(self):
-        """
-        Chip ID including CSB and hardware address. Of the form "csbX_chipX" where csbX indicates the CSB
-        line for the IC and chipX indicating the hardware address of the chip, 1-4.
-        """
-        return self._chip_id
+        # Determine the row and column numbers for the elements using the maps given
+        element_numbers = channel_element_map
+        element_rows_cols = {}
+        for element_number in element_numbers:
+            for r, row in enumerate(array_element_map):
+                for c, map_value in enumerate(row):
+                    if map_value == element_number:
+                        element_rows_cols[element_number] = (r, c)
 
-    """ Device attributes """
+        # Create the channel instances
+        self._channels = []
+        for i in range(4):
+            element_number = element_numbers[i]
+            row, column = element_rows_cols[element_number]
+            self._channels.append(
+                self.adar1000_channel(self, i, element_number, row, column)
+            )
+
+    def __repr__(self):
+        """ Representation of the ADAR1000 class """
+        return (
+            f"ADAR1000 #{self.array_device_number} controlling array elements:\n"
+            f"\t{', '.join([str(channel.array_element_number) for channel in self.channels])}"
+        )
+
+    """ Device Properties """
+
+    @property
+    def array_device_number(self):
+        """ Device number in the array """
+        return self._array_device_number
 
     @property
     def beam_mem_enable(self):
@@ -152,6 +501,39 @@ class adar1000(attribute, context_manager):
     def bias_mem_enable(self, value):
         """ Get/Set enable bit for RAM control vs. SPI control of the bias state """
         self._set_iio_dev_attr_str("bias_mem_enable", int(value), self._ctrl)
+
+    @property
+    def channel1(self):
+        """ Handle for the ADAR1000's channel 1 object """
+        return self._channels[0]
+
+    @property
+    def channel2(self):
+        """ Handle for the ADAR1000's channel 2 object """
+        return self._channels[1]
+
+    @property
+    def channel3(self):
+        """ Handle for the ADAR1000's channel 3 object """
+        return self._channels[2]
+
+    @property
+    def channel4(self):
+        """ Handle for the ADAR1000's channel 4 object """
+        return self._channels[3]
+
+    @property
+    def channels(self):
+        """ List of the ADAR1000's channels, in order from 1 to 4 """
+        return self._channels
+
+    @property
+    def chip_id(self):
+        """
+        Chip ID including CSB and hardware address. Of the form "csbX_chipX" where csbX indicates the CSB
+        line for the IC and chipX indicating the hardware address of the chip, 1-4.
+        """
+        return self._chip_id
 
     @property
     def common_mem_enable(self):
@@ -215,7 +597,7 @@ class adar1000(attribute, context_manager):
     @lna_bias_off.setter
     def lna_bias_off(self, value):
         """ Get/Set LNA_BIAS_OFF in voltage """
-        dac_code = value // self._BIAS_CODE_TO_VOLTAGE_SCALE
+        dac_code = int(value / self._BIAS_CODE_TO_VOLTAGE_SCALE)
         self._set_iio_dev_attr_str("lna_bias_off", dac_code, self._ctrl)
 
     @property
@@ -227,7 +609,7 @@ class adar1000(attribute, context_manager):
     @lna_bias_on.setter
     def lna_bias_on(self, value):
         """ Get/Set LNA_BIAS_ON in voltage """
-        dac_code = value // self._BIAS_CODE_TO_VOLTAGE_SCALE
+        dac_code = int(value / self._BIAS_CODE_TO_VOLTAGE_SCALE)
         self._set_iio_dev_attr_str("lna_bias_on", dac_code, self._ctrl)
 
     @property
@@ -291,6 +673,26 @@ class adar1000(attribute, context_manager):
         self._set_iio_dev_attr_str("rx_lna_enable", int(value), self._ctrl)
 
     @property
+    def rx_sequencer_start(self):
+        """ Get/Set the Rx Sequencer's starting position """
+        return self._get_iio_attr("voltage0", "sequence_start", False)
+
+    @rx_sequencer_start.setter
+    def rx_sequencer_start(self, value):
+        """ Get/Set the Rx Sequencer's starting position """
+        self._set_iio_attr("voltage0", "sequence_start", False, value)
+
+    @property
+    def rx_sequencer_stop(self):
+        """ Get/Set the Rx Sequencer's ending position """
+        return self._get_iio_attr("voltage0", "sequence_end", False)
+
+    @rx_sequencer_stop.setter
+    def rx_sequencer_stop(self, value):
+        """ Get/Set the Rx Sequencer's ending position """
+        self._set_iio_attr("voltage0", "sequence_end", False, value)
+
+    @property
     def rx_to_tx_delay_1(self):
         """ Get/Set Rx to Tx Delay 1 """
         return self._get_iio_dev_attr("rx_to_tx_delay_1", self._ctrl)
@@ -349,6 +751,11 @@ class adar1000(attribute, context_manager):
     def sequencer_enable(self, value):
         """ Get/Set sequencer enable status """
         self._set_iio_dev_attr_str("sequencer_enable", int(value), self._ctrl)
+
+    @property
+    def temperature(self):
+        """ Get the temperature reading from the device """
+        return self._get_iio_attr("temp0", "raw", False)
 
     @property
     def tr_source(self):
@@ -433,6 +840,26 @@ class adar1000(attribute, context_manager):
         self._set_iio_dev_attr_str("tx_drv_enable", int(value), self._ctrl)
 
     @property
+    def tx_sequencer_start(self):
+        """ Get/Set the Tx Sequencer's starting position """
+        return self._get_iio_attr("voltage0", "sequence_start", True)
+
+    @tx_sequencer_start.setter
+    def tx_sequencer_start(self, value):
+        """ Get/Set the Tx Sequencer's starting position """
+        self._set_iio_attr("voltage0", "sequence_start", True, value)
+
+    @property
+    def tx_sequencer_stop(self):
+        """ Get/Set the Tx Sequencer's ending position """
+        return self._get_iio_attr("voltage0", "sequence_end", True)
+
+    @tx_sequencer_stop.setter
+    def tx_sequencer_stop(self, value):
+        """ Get/Set the Tx Sequencer's ending position """
+        self._set_iio_attr("voltage0", "sequence_end", True, value)
+
+    @property
     def tx_to_rx_delay_1(self):
         """ Get/Set Tx to Rx Delay 1 """
         return self._get_iio_dev_attr("tx_to_rx_delay_1", self._ctrl)
@@ -482,650 +909,82 @@ class adar1000(attribute, context_manager):
         """ Get/Set Tx Vector Modulator enable status """
         self._set_iio_dev_attr_str("tx_vm_enable", int(value), self._ctrl)
 
-    """ Channel attributes """
-
-    @property
-    def ch1_detector_enable(self):
-        """ Get/Set Channel 1 detector enable bit """
-        return bool(self._get_iio_attr("voltage0", "detector_en", True, self._ctrl))
-
-    @ch1_detector_enable.setter
-    def ch1_detector_enable(self, value):
-        """ Get/Set Channel 1 detector enable bit """
-        self._set_iio_attr("voltage0", "detector_en", True, int(value), self._ctrl)
-
-    @property
-    def ch2_detector_enable(self):
-        """ Get/Set Channel 2 detector enable bit """
-        return bool(self._get_iio_attr("voltage1", "detector_en", True, self._ctrl))
-
-    @ch2_detector_enable.setter
-    def ch2_detector_enable(self, value):
-        """ Get/Set Channel 2 detector enable bit """
-        self._set_iio_attr("voltage1", "detector_en", True, int(value), self._ctrl)
-
-    @property
-    def ch3_detector_enable(self):
-        """ Get/Set Channel 3 detector enable bit """
-        return bool(self._get_iio_attr("voltage2", "detector_en", True, self._ctrl))
-
-    @ch3_detector_enable.setter
-    def ch3_detector_enable(self, value):
-        """ Get/Set Channel 3 detector enable bit """
-        self._set_iio_attr("voltage2", "detector_en", True, int(value), self._ctrl)
-
-    @property
-    def ch4_detector_enable(self):
-        """ Get/Set Channel 4 detector enable bit """
-        return bool(self._get_iio_attr("voltage3", "detector_en", True, self._ctrl))
-
-    @ch4_detector_enable.setter
-    def ch4_detector_enable(self, value):
-        """ Get/Set Channel 4 detector enable bit """
-        self._set_iio_attr("voltage3", "detector_en", True, int(value), self._ctrl)
-
-    @property
-    def ch1_detector_power(self):
-        """ Get Channel 1 detector power reading """
-        return self._get_iio_attr("voltage0", "raw", True, self._ctrl)
-
-    @property
-    def ch2_detector_power(self):
-        """ Get Channel 2 detector power reading """
-        return self._get_iio_attr("voltage1", "raw", True, self._ctrl)
-
-    @property
-    def ch3_detector_power(self):
-        """ Get Channel 3 detector power reading """
-        return self._get_iio_attr("voltage2", "raw", True, self._ctrl)
-
-    @property
-    def ch4_detector_power(self):
-        """ Get Channel 4 detector power reading """
-        return self._get_iio_attr("voltage3", "raw", True, self._ctrl)
-
-    @property
-    def ch1_pa_bias_off(self):
-        """ Get/Set Channel 1 PA_BIAS_OFF in voltage """
-        dac_code = self._get_iio_attr("voltage0", "pa_bias_off", True, self._ctrl)
-        return dac_code * self._BIAS_CODE_TO_VOLTAGE_SCALE
-
-    @ch1_pa_bias_off.setter
-    def ch1_pa_bias_off(self, value):
-        """ Get/Set Channel 1 PA_BIAS_OFF in voltage """
-        dac_code = value // self._BIAS_CODE_TO_VOLTAGE_SCALE
-        self._set_iio_attr("voltage0", "pa_bias_off", True, dac_code, self._ctrl)
-
-    @property
-    def ch2_pa_bias_off(self):
-        """ Get/Set Channel 2 PA_BIAS_OFF in voltage """
-        dac_code = self._get_iio_attr("voltage1", "pa_bias_off", True, self._ctrl)
-        return dac_code * self._BIAS_CODE_TO_VOLTAGE_SCALE
-
-    @ch2_pa_bias_off.setter
-    def ch2_pa_bias_off(self, value):
-        """ Get/Set Channel 2 PA_BIAS_OFF in voltage """
-        dac_code = value // self._BIAS_CODE_TO_VOLTAGE_SCALE
-        self._set_iio_attr("voltage1", "pa_bias_off", True, dac_code, self._ctrl)
-
-    @property
-    def ch3_pa_bias_off(self):
-        """ Get/Set Channel 3 PA_BIAS_OFF in voltage """
-        dac_code = self._get_iio_attr("voltage2", "pa_bias_off", True, self._ctrl)
-        return dac_code * self._BIAS_CODE_TO_VOLTAGE_SCALE
-
-    @ch3_pa_bias_off.setter
-    def ch3_pa_bias_off(self, value):
-        """ Get/Set Channel 3 PA_BIAS_OFF in voltage """
-        dac_code = value // self._BIAS_CODE_TO_VOLTAGE_SCALE
-        self._set_iio_attr("voltage2", "pa_bias_off", True, dac_code, self._ctrl)
-
-    @property
-    def ch4_pa_bias_off(self):
-        """ Get/Set Channel 4 PA_BIAS_OFF in voltage """
-        dac_code = self._get_iio_attr("voltage3", "pa_bias_off", True, self._ctrl)
-        return dac_code * self._BIAS_CODE_TO_VOLTAGE_SCALE
-
-    @ch4_pa_bias_off.setter
-    def ch4_pa_bias_off(self, value):
-        """ Get/Set Channel 4 PA_BIAS_OFF in voltage """
-        dac_code = value // self._BIAS_CODE_TO_VOLTAGE_SCALE
-        self._set_iio_attr("voltage3", "pa_bias_off", True, dac_code, self._ctrl)
-
-    @property
-    def ch1_pa_bias_on(self):
-        """ Get/Set Channel 1 PA_BIAS_ON in voltage """
-        dac_code = self._get_iio_attr("voltage0", "pa_bias_on", True, self._ctrl)
-        return dac_code * self._BIAS_CODE_TO_VOLTAGE_SCALE
-
-    @ch1_pa_bias_on.setter
-    def ch1_pa_bias_on(self, value):
-        """ Get/Set Channel 1 PA_BIAS_ON in voltage """
-        dac_code = value // self._BIAS_CODE_TO_VOLTAGE_SCALE
-        self._set_iio_attr("voltage0", "pa_bias_on", True, dac_code, self._ctrl)
-
-    @property
-    def ch2_pa_bias_on(self):
-        """ Get/Set Channel 2 PA_BIAS_ON in voltage """
-        dac_code = self._get_iio_attr("voltage1", "pa_bias_on", True, self._ctrl)
-        return dac_code * self._BIAS_CODE_TO_VOLTAGE_SCALE
-
-    @ch2_pa_bias_on.setter
-    def ch2_pa_bias_on(self, value):
-        """ Get/Set Channel 2 PA_BIAS_ON in voltage """
-        dac_code = value // self._BIAS_CODE_TO_VOLTAGE_SCALE
-        self._set_iio_attr("voltage1", "pa_bias_on", True, dac_code, self._ctrl)
-
-    @property
-    def ch3_pa_bias_on(self):
-        """ Get/Set Channel 3 PA_BIAS_ON in voltage """
-        dac_code = self._get_iio_attr("voltage2", "pa_bias_on", True, self._ctrl)
-        return dac_code * self._BIAS_CODE_TO_VOLTAGE_SCALE
-
-    @ch3_pa_bias_on.setter
-    def ch3_pa_bias_on(self, value):
-        """ Get/Set Channel 3 PA_BIAS_ON in voltage """
-        dac_code = value // self._BIAS_CODE_TO_VOLTAGE_SCALE
-        self._set_iio_attr("voltage2", "pa_bias_on", True, dac_code, self._ctrl)
-
-    @property
-    def ch4_pa_bias_on(self):
-        """ Get/Set Channel 4 PA_BIAS_ON in voltage """
-        dac_code = self._get_iio_attr("voltage3", "pa_bias_on", True, self._ctrl)
-        return dac_code * self._BIAS_CODE_TO_VOLTAGE_SCALE
-
-    @ch4_pa_bias_on.setter
-    def ch4_pa_bias_on(self, value):
-        """ Get/Set Channel 4 PA_BIAS_ON in voltage """
-        dac_code = value // self._BIAS_CODE_TO_VOLTAGE_SCALE
-        self._set_iio_attr("voltage3", "pa_bias_on", True, dac_code, self._ctrl)
-
-    @property
-    def ch1_rx_attenuator(self):
-        """ Get/Set Channel 1 Rx Attenuator state """
-        return bool(
-            1 - self._get_iio_attr("voltage0", "attenuation", False, self._ctrl)
-        )
-
-    @ch1_rx_attenuator.setter
-    def ch1_rx_attenuator(self, value):
-        """ Get/Set Channel 1 Rx Attenuator state """
-        self._set_iio_attr("voltage0", "attenuation", False, 1 - int(value), self._ctrl)
-
-    @property
-    def ch2_rx_attenuator(self):
-        """ Get/Set Channel 2 Rx Attenuator state """
-        return bool(
-            1 - self._get_iio_attr("voltage1", "attenuation", False, self._ctrl)
-        )
-
-    @ch2_rx_attenuator.setter
-    def ch2_rx_attenuator(self, value):
-        """ Get/Set Channel 2 Rx Attenuator state """
-        self._set_iio_attr("voltage1", "attenuation", False, 1 - int(value), self._ctrl)
-
-    @property
-    def ch3_rx_attenuator(self):
-        """ Get/Set Channel 3 Rx Attenuator state """
-        return bool(
-            1 - self._get_iio_attr("voltage2", "attenuation", False, self._ctrl)
-        )
-
-    @ch3_rx_attenuator.setter
-    def ch3_rx_attenuator(self, value):
-        """ Get/Set Channel 3 Rx Attenuator state """
-        self._set_iio_attr("voltage2", "attenuation", False, 1 - int(value), self._ctrl)
-
-    @property
-    def ch4_rx_attenuator(self):
-        """ Get/Set Channel 4 Rx Attenuator state """
-        return bool(
-            1 - self._get_iio_attr("voltage3", "attenuation", False, self._ctrl)
-        )
-
-    @ch4_rx_attenuator.setter
-    def ch4_rx_attenuator(self, value):
-        """ Get/Set Channel 4 Rx Attenuator state """
-        self._set_iio_attr("voltage3", "attenuation", False, 1 - int(value), self._ctrl)
-
-    @property
-    def ch1_rx_gain(self):
-        """ Get/Set Channel 1 Rx Gain """
-        return self._get_iio_attr("voltage0", "hardwaregain", False, self._ctrl)
-
-    @ch1_rx_gain.setter
-    def ch1_rx_gain(self, value):
-        """ Get/Set Channel 1 Rx Gain """
-        self._set_iio_attr("voltage0", "hardwaregain", False, value, self._ctrl)
-
-    @property
-    def ch2_rx_gain(self):
-        """ Get/Set Channel 2 Rx Gain """
-        return self._get_iio_attr("voltage1", "hardwaregain", False, self._ctrl)
-
-    @ch2_rx_gain.setter
-    def ch2_rx_gain(self, value):
-        """ Get/Set Channel 2 Rx Gain """
-        self._set_iio_attr("voltage1", "hardwaregain", False, value, self._ctrl)
-
-    @property
-    def ch3_rx_gain(self):
-        """ Get/Set Channel 3 Rx Gain """
-        return self._get_iio_attr("voltage2", "hardwaregain", False, self._ctrl)
-
-    @ch3_rx_gain.setter
-    def ch3_rx_gain(self, value):
-        """ Get/Set Channel 3 Rx Gain """
-        self._set_iio_attr("voltage2", "hardwaregain", False, value, self._ctrl)
-
-    @property
-    def ch4_rx_gain(self):
-        """ Get/Set Channel 4 Rx Gain """
-        return self._get_iio_attr("voltage3", "hardwaregain", False, self._ctrl)
-
-    @ch4_rx_gain.setter
-    def ch4_rx_gain(self, value):
-        """ Get/Set Channel 4 Rx Gain """
-        self._set_iio_attr("voltage3", "hardwaregain", False, value, self._ctrl)
-
-    @property
-    def ch1_rx_phase(self):
-        """ Get/Set Channel 1 Rx Phase """
-        return self._get_iio_attr("voltage0", "phase", False, self._ctrl)
-
-    @ch1_rx_phase.setter
-    def ch1_rx_phase(self, value):
-        """ Get/Set Channel 1 Rx Phase """
-        self._set_iio_attr("voltage0", "phase", False, value, self._ctrl)
-
-    @property
-    def ch2_rx_phase(self):
-        """ Get/Set Channel 2 Rx Phase """
-        return self._get_iio_attr("voltage1", "phase", False, self._ctrl)
-
-    @ch2_rx_phase.setter
-    def ch2_rx_phase(self, value):
-        """ Get/Set Channel 2 Rx Phase """
-        self._set_iio_attr("voltage1", "phase", False, value, self._ctrl)
-
-    @property
-    def ch3_rx_phase(self):
-        """ Get/Set Channel 3 Rx Phase """
-        return self._get_iio_attr("voltage2", "phase", False, self._ctrl)
-
-    @ch3_rx_phase.setter
-    def ch3_rx_phase(self, value):
-        """ Get/Set Channel 3 Rx Phase """
-        self._set_iio_attr("voltage2", "phase", False, value, self._ctrl)
-
-    @property
-    def ch4_rx_phase(self):
-        """ Get/Set Channel 4 Rx Phase """
-        return self._get_iio_attr("voltage3", "phase", False, self._ctrl)
-
-    @ch4_rx_phase.setter
-    def ch4_rx_phase(self, value):
-        """ Get/Set Channel 4 Rx Phase """
-        self._set_iio_attr("voltage3", "phase", False, value, self._ctrl)
-
-    @property
-    def ch1_rx_powerdown(self):
-        """ Get/Set Channel 1 Rx Powerdown """
-        return bool(self._get_iio_attr("voltage0", "powerdown", False, self._ctrl))
-
-    @ch1_rx_powerdown.setter
-    def ch1_rx_powerdown(self, value):
-        """ Get/Set Channel 1 Rx Powerdown """
-        self._set_iio_attr("voltage0", "powerdown", False, int(value), self._ctrl)
-
-    @property
-    def ch2_rx_powerdown(self):
-        """ Get/Set Channel 2 Rx Powerdown """
-        return bool(self._get_iio_attr("voltage1", "powerdown", False, self._ctrl))
-
-    @ch2_rx_powerdown.setter
-    def ch2_rx_powerdown(self, value):
-        """ Get/Set Channel 2 Rx Powerdown """
-        self._set_iio_attr("voltage1", "powerdown", False, int(value), self._ctrl)
-
-    @property
-    def ch3_rx_powerdown(self):
-        """ Get/Set Channel 3 Rx Powerdown """
-        return bool(self._get_iio_attr("voltage2", "powerdown", False, self._ctrl))
-
-    @ch3_rx_powerdown.setter
-    def ch3_rx_powerdown(self, value):
-        """ Get/Set Channel 3 Rx Powerdown """
-        self._set_iio_attr("voltage2", "powerdown", False, int(value), self._ctrl)
-
-    @property
-    def ch4_rx_powerdown(self):
-        """ Get/Set Channel 4 Rx Powerdown """
-        return bool(self._get_iio_attr("voltage3", "powerdown", False, self._ctrl))
-
-    @ch4_rx_powerdown.setter
-    def ch4_rx_powerdown(self, value):
-        """ Get/Set Channel 4 Rx Powerdown """
-        self._set_iio_attr("voltage3", "powerdown", False, int(value), self._ctrl)
-
-    @property
-    def ch1_tx_attenuator(self):
-        """ Get/Set Channel 1 Tx Attenuator state """
-        return bool(1 - self._get_iio_attr("voltage0", "attenuation", True, self._ctrl))
-
-    @ch1_tx_attenuator.setter
-    def ch1_tx_attenuator(self, value):
-        """ Get/Set Channel 1 Tx Attenuator state """
-        self._set_iio_attr("voltage0", "attenuation", True, 1 - int(value), self._ctrl)
-
-    @property
-    def ch2_tx_attenuator(self):
-        """ Get/Set Channel 2 Tx Attenuator state """
-        return bool(1 - self._get_iio_attr("voltage1", "attenuation", True, self._ctrl))
-
-    @ch2_tx_attenuator.setter
-    def ch2_tx_attenuator(self, value):
-        """ Get/Set Channel 2 Tx Attenuator state """
-        self._set_iio_attr("voltage1", "attenuation", True, 1 - int(value), self._ctrl)
-
-    @property
-    def ch3_tx_attenuator(self):
-        """ Get/Set Channel 3 Tx Attenuator state """
-        return bool(1 - self._get_iio_attr("voltage2", "attenuation", True, self._ctrl))
-
-    @ch3_tx_attenuator.setter
-    def ch3_tx_attenuator(self, value):
-        """ Get/Set Channel 3 Tx Attenuator state """
-        self._set_iio_attr("voltage2", "attenuation", True, 1 - int(value), self._ctrl)
-
-    @property
-    def ch4_tx_attenuator(self):
-        """ Get/Set Channel 4 Tx Attenuator state """
-        return bool(1 - self._get_iio_attr("voltage3", "attenuation", True, self._ctrl))
-
-    @ch4_tx_attenuator.setter
-    def ch4_tx_attenuator(self, value):
-        """ Get/Set Channel 4 Tx Attenuator state """
-        self._set_iio_attr("voltage3", "attenuation", True, 1 - int(value), self._ctrl)
-
-    @property
-    def ch1_tx_gain(self):
-        """ Get/Set Channel 1 Tx Gain """
-        return self._get_iio_attr("voltage0", "hardwaregain", True, self._ctrl)
-
-    @ch1_tx_gain.setter
-    def ch1_tx_gain(self, value):
-        """ Get/Set Channel 1 Tx Gain """
-        self._set_iio_attr("voltage0", "hardwaregain", True, value, self._ctrl)
-
-    @property
-    def ch2_tx_gain(self):
-        """ Get/Set Channel 2 Tx Gain """
-        return self._get_iio_attr("voltage1", "hardwaregain", True, self._ctrl)
-
-    @ch2_tx_gain.setter
-    def ch2_tx_gain(self, value):
-        """ Get/Set Channel 2 Tx Gain """
-        self._set_iio_attr("voltage1", "hardwaregain", True, value, self._ctrl)
-
-    @property
-    def ch3_tx_gain(self):
-        """ Get/Set Channel 3 Tx Gain """
-        return self._get_iio_attr("voltage2", "hardwaregain", True, self._ctrl)
-
-    @ch3_tx_gain.setter
-    def ch3_tx_gain(self, value):
-        """ Get/Set Channel 3 Tx Gain """
-        self._set_iio_attr("voltage2", "hardwaregain", True, value, self._ctrl)
-
-    @property
-    def ch4_tx_gain(self):
-        """ Get/Set Channel 4 Tx Gain """
-        return self._get_iio_attr("voltage3", "hardwaregain", True, self._ctrl)
-
-    @ch4_tx_gain.setter
-    def ch4_tx_gain(self, value):
-        """ Get/Set Channel 4 Tx Gain """
-        self._set_iio_attr("voltage3", "hardwaregain", True, value, self._ctrl)
-
-    @property
-    def ch1_tx_phase(self):
-        """ Get/Set Channel 1 Tx Phase """
-        return self._get_iio_attr("voltage0", "phase", True, self._ctrl)
-
-    @ch1_tx_phase.setter
-    def ch1_tx_phase(self, value):
-        """ Get/Set Channel 1 Tx Phase """
-        self._set_iio_attr("voltage0", "phase", True, value, self._ctrl)
-
-    @property
-    def ch2_tx_phase(self):
-        """ Get/Set Channel 2 Tx Phase """
-        return self._get_iio_attr("voltage1", "phase", True, self._ctrl)
-
-    @ch2_tx_phase.setter
-    def ch2_tx_phase(self, value):
-        """ Get/Set Channel 2 Tx Phase """
-        self._set_iio_attr("voltage1", "phase", True, value, self._ctrl)
-
-    @property
-    def ch3_tx_phase(self):
-        """ Get/Set Channel 3 Tx Phase """
-        return self._get_iio_attr("voltage2", "phase", True, self._ctrl)
-
-    @ch3_tx_phase.setter
-    def ch3_tx_phase(self, value):
-        """ Get/Set Channel 3 Tx Phase """
-        self._set_iio_attr("voltage2", "phase", True, value, self._ctrl)
-
-    @property
-    def ch4_tx_phase(self):
-        """ Get/Set Channel 4 Tx Phase """
-        return self._get_iio_attr("voltage3", "phase", True, self._ctrl)
-
-    @ch4_tx_phase.setter
-    def ch4_tx_phase(self, value):
-        """ Get/Set Channel 4 Tx Phase """
-        self._set_iio_attr("voltage3", "phase", True, value, self._ctrl)
-
-    @property
-    def ch1_tx_powerdown(self):
-        """ Get/Set Channel 1 Tx Powerdown """
-        return bool(self._get_iio_attr("voltage0", "powerdown", True, self._ctrl))
-
-    @ch1_tx_powerdown.setter
-    def ch1_tx_powerdown(self, value):
-        """ Get/Set Channel 1 Tx Powerdown """
-        self._set_iio_attr("voltage0", "powerdown", True, int(value), self._ctrl)
-
-    @property
-    def ch2_tx_powerdown(self):
-        """ Get/Set Channel 2 Tx Powerdown """
-        return bool(self._get_iio_attr("voltage1", "powerdown", True, self._ctrl))
-
-    @ch2_tx_powerdown.setter
-    def ch2_tx_powerdown(self, value):
-        """ Get/Set Channel 2 Tx Powerdown """
-        self._set_iio_attr("voltage1", "powerdown", True, int(value), self._ctrl)
-
-    @property
-    def ch3_tx_powerdown(self):
-        """ Get/Set Channel 3 Tx Powerdown """
-        return bool(self._get_iio_attr("voltage2", "powerdown", True, self._ctrl))
-
-    @ch3_tx_powerdown.setter
-    def ch3_tx_powerdown(self, value):
-        """ Get/Set Channel 3 Tx Powerdown """
-        self._set_iio_attr("voltage2", "powerdown", True, int(value), self._ctrl)
-
-    @property
-    def ch4_tx_powerdown(self):
-        """ Get/Set Channel 4 Tx Powerdown """
-        return bool(self._get_iio_attr("voltage3", "powerdown", True, self._ctrl))
-
-    @ch4_tx_powerdown.setter
-    def ch4_tx_powerdown(self, value):
-        """ Get/Set Channel 4 Tx Powerdown """
-        self._set_iio_attr("voltage3", "powerdown", True, int(value), self._ctrl)
-
-    @property
-    def rx_sequencer_start(self):
-        """ Get/Set the Rx Sequencer's starting position """
-        return self._get_iio_attr("voltage0", "sequence_start", False, self._ctrl)
-
-    @rx_sequencer_start.setter
-    def rx_sequencer_start(self, value):
-        """ Get/Set the Rx Sequencer's starting position """
-        self._sequence_start("rx", value)
-
-    @property
-    def rx_sequencer_stop(self):
-        """ Get/Set the Rx Sequencer's ending position """
-        return self._get_iio_attr("voltage0", "sequence_end", False, self._ctrl)
-
-    @rx_sequencer_stop.setter
-    def rx_sequencer_stop(self, value):
-        """ Get/Set the Rx Sequencer's ending position """
-        self._sequence_stop("rx", value)
-
-    @property
-    def temperature(self):
-        """ Get the temperature reading from the device """
-        return self._get_iio_attr("temp0", "raw", False, self._ctrl)
-
-    @property
-    def tx_sequencer_start(self):
-        """ Get/Set the Tx Sequencer's starting position """
-        return self._get_iio_attr("voltage0", "sequence_start", True, self._ctrl)
-
-    @tx_sequencer_start.setter
-    def tx_sequencer_start(self, value):
-        """ Get/Set the Tx Sequencer's starting position """
-        self._sequence_start("tx", value)
-
-    @property
-    def tx_sequencer_stop(self):
-        """ Get/Set the Tx Sequencer's ending position """
-        return self._get_iio_attr("voltage0", "sequence_end", True, self._ctrl)
-
-    @tx_sequencer_stop.setter
-    def tx_sequencer_stop(self, value):
-        """ Get/Set the Tx Sequencer's ending position """
-        self._sequence_stop("tx", value)
-
-    """ Private Methods """
-
-    def _load_beam(self, rx_or_tx, channel, state):
-        """Load a beam from a memory position
-
-        parameters:
-            rx_or_tx: string
-                String indicating whether to load an Rx or Tx beam state. Valid options are "rx" and "tx"
-            channel: int, string
-                Channel number to load (1-4) or "X" to load from CHX_{rx_or_tx}
-            state: int
-                State number to load. Valid options are 0 to 120
-        """
-
-        if rx_or_tx.lower() == "rx":
-            output = False
-        else:
-            output = True
-
-        if isinstance(channel, int):
-            self._set_iio_attr(
-                f"voltage{channel - 1}", "beam_pos_load", output, state, self._ctrl
-            )
-        else:
-            self._set_iio_dev_attr_str(
-                f"static_{rx_or_tx.lower()}_beam_pos", state, self._ctrl
-            )
-
-    def _load_bias(self, rx_or_tx, state):
-        """Load a bias from a memory position
-
-        parameters:
-            rx_or_tx: string
-                String indicating whether to load an Rx or Tx bias state. Valid options are "rx" and "tx"
-            state: int
-                State number to load. Valid options are 1 to 7
-        """
-
-        if rx_or_tx.lower() == "rx":
-            output = False
-        else:
-            output = True
-
-        self._set_iio_attr("voltage0", "bias_set_load", output, state, self._ctrl)
-
-    def _save_beam(self, rx_or_tx, channel, state, attenuator, gain, phase):
-        """Save a beam to a memory position
-
-        parameters:
-            rx_or_tx: string
-                String indicating whether to load an Rx or Tx beam state. Valid options are "rx" and "tx"
-            channel: int
-                Channel number to save (1-4)
-            state: int
-                State number to save. Valid options are 0 to 120
-            attenuator: bool
-                Attenuator state for the beam position. True means the attenuator is in place.
-            gain: int
-                Gain value for the beam position. Valid settings are 0 to 127.
-            phase: float
-                Phase value for the beam position.
-        """
-
-        if rx_or_tx.lower() == "rx":
-            output = False
-        else:
-            output = True
-
-        save_string = f"{state}, {attenuator}, {gain}, {phase}"
-
-        self._set_iio_attr(
-            f"voltage{channel - 1}", "beam_pos_save", output, save_string, self._ctrl
-        )
-
-    def _sequence_start(self, rx_or_tx, state):
-        """Set the sequencer's start position
-
-        parameters:
-            rx_or_tx: string
-                String indicating whether to load an Rx or Tx bias state. Valid options are "rx" and "tx"
-            state: int
-                State number to set. Valid options are 0 to 120
-        """
-
-        if rx_or_tx.lower() == "rx":
-            output = False
-        else:
-            output = True
-
-        self._set_iio_attr("voltage0", "sequence_start", output, state, self._ctrl)
-
-    def _sequence_stop(self, rx_or_tx, state):
-        """Set the sequencer's stop position
-
-        parameters:
-            rx_or_tx: string
-                String indicating whether to load an Rx or Tx bias state. Valid options are "rx" and "tx"
-            state: int
-                State number to set. Valid options are 0 to 120
-        """
-
-        if rx_or_tx.lower() == "rx":
-            output = False
-        else:
-            output = True
-
-        self._set_iio_attr("voltage0", "sequence_end", output, state, self._ctrl)
-
     """ Public Methods """
 
     def generate_clocks(self):
         """ Generate CLK cycles before pulsing RX_LOAD or TX_LOAD """
         self._set_iio_dev_attr_str("gen_clk_cycles", "", self._ctrl)
+
+    def initialize(self, pa_off=-2.5, lna_off=-2):
+        """Suggested initialization routine after powerup
+
+        parameters:
+            pa_off: float
+                Voltage to set the PA_BIAS_ON and PA_BIAS_OFF values to during initialization
+            lna_off: float
+                Voltage to set the LNA_BIAS_ON and LNA_BIAS_OFF values to during initialization
+        """
+        # Put the part in a known state
+        self.reset()
+
+        # Set the bias currents to nominal
+        self.rx_lna_bias_current = 0x08
+        self.rx_vga_vm_bias_current = 0x55
+        self.tx_vga_vm_bias_current = 0x2D
+        self.tx_pa_bias_current = 0x06
+
+        # Disable RAM control
+        self.beam_mem_enable = False
+        self.bias_mem_enable = False
+        self.common_mem_enable = False
+
+        # Enable all internal amplifiers
+        self.rx_vga_enable = True
+        self.rx_vm_enable = True
+        self.rx_lna_enable = True
+        self.tx_vga_enable = True
+        self.tx_vm_enable = True
+        self.tx_pa_enable = True
+
+        # Disable Tx/Rx paths
+        self.rx_enable = False
+        self.tx_enable = False
+
+        # Enable the PA/LNA bias DACs
+        self.lna_bias_out_enable = True
+        self.bias_dac_enable = True
+        self.bias_dac_mode = "toggle"
+
+        # Configure the external switch control
+        self.external_tr_polarity = True
+        self.tr_switch_enable = True
+
+        # Set the default LNA bias
+        self.lna_bias_off = lna_off
+        self.lna_bias_on = lna_off
+
+        # Settings for each channel
+        for channel in self.channels:
+            # Default channel enable
+            channel.rx_enable = True
+            channel.tx_enable = True
+
+            # Default PA bias
+            channel.pa_bias_off = pa_off
+            channel.pa_bias_on = pa_off
+
+            # Default attenuator, gain, and phase
+            channel.rx_attenuator = False
+            channel.rx_gain = 127
+            channel.rx_phase = 0
+            channel.tx_attenuator = False
+            channel.tx_gain = 127
+            channel.tx_phase = 0
+
+        # Latch in the new settings
+        self.latch_rx_settings()
+        self.latch_tx_settings()
+        return
 
     def latch_rx_settings(self):
         """ Latch in new Gain/Phase settings for the Rx """
@@ -1135,27 +994,25 @@ class adar1000(attribute, context_manager):
         """ Latch in new Gain/Phase settings for the Tx """
         self._set_iio_dev_attr_str("tx_load_spi", 1, self._ctrl)
 
-    def load_rx_beam(self, channel, state):
-        """Load an Rx beam from a memory position
+    def load_common_rx_beam(self, state):
+        """Load a common Rx beam position from RAM
 
         parameters:
-            channel: int
-                Channel number to load
             state: int
                 State number to load. Valid options are 0 to 120
         """
-        self._load_beam("rx", channel, state)
 
-    def load_tx_beam(self, channel, state):
-        """Load a Tx beam from a memory position
+        self._set_iio_dev_attr_str("static_rx_beam_pos", state, self._ctrl)
+
+    def load_common_tx_beam(self, state):
+        """Load a common Tx beam position from RAM
 
         parameters:
-            channel: int
-                Channel number to load
             state: int
                 State number to load. Valid options are 0 to 120
         """
-        self._load_beam("tx", channel, state)
+
+        self._set_iio_dev_attr_str("static_tx_beam_pos", state, self._ctrl)
 
     def load_rx_bias(self, state):
         """Load an Rx bias from a memory position
@@ -1164,7 +1021,8 @@ class adar1000(attribute, context_manager):
             state: int
                 State number to load. Valid options are 1 to 7
         """
-        self._load_bias("rx", state)
+
+        self._set_iio_attr("voltage0", "bias_set_load", False, state, self._ctrl)
 
     def load_tx_bias(self, state):
         """Load a Tx bias from a memory position
@@ -1173,28 +1031,12 @@ class adar1000(attribute, context_manager):
             state: int
                 State number to load. Valid options are 1 to 7
         """
-        self._load_bias("tx", state)
+
+        self._set_iio_attr("voltage0", "bias_set_load", True, state, self._ctrl)
 
     def reset(self):
         """ Reset ADAR1000 to default settings """
-        self._set_iio_dev_attr_str("reset", "1", self._ctrl)
-
-    def save_rx_beam(self, channel, state, attenuator, gain, phase):
-        """Save a beam to an Rx memory position
-
-        parameters:
-            channel: int
-                Channel number to save (1-4)
-            state: int
-                State number to save. Valid options are 0 to 120
-            attenuator: bool
-                Attenuator state for the beam position. True means the attenuator is in place.
-            gain: int
-                Gain value for the beam position. Valid settings are 0 to 127.
-            phase: float
-                Phase value for the beam position.
-        """
-        self._save_beam("rx", channel, state, attenuator, gain, phase)
+        self._set_iio_dev_attr("reset", 1, self._ctrl)
 
     def save_rx_bias(
         self,
@@ -1220,29 +1062,12 @@ class adar1000(attribute, context_manager):
         """
 
         # Convert the LNA bias settings to dac codes:
-        lna_off_dac_code = lna_bias_off // self._BIAS_CODE_TO_VOLTAGE_SCALE
-        lna_on_dac_code = lna_bias_on // self._BIAS_CODE_TO_VOLTAGE_SCALE
+        lna_off_dac_code = int(lna_bias_off / self._BIAS_CODE_TO_VOLTAGE_SCALE)
+        lna_on_dac_code = int(lna_bias_on / self._BIAS_CODE_TO_VOLTAGE_SCALE)
 
         save_string = f"{state}, {lna_off_dac_code}, {lna_on_dac_code}, {rx_vga_vm_bias_current}, {rx_lna_bias_current}"
 
         self._set_iio_attr("voltage0", "bias_set_save", False, save_string, self._ctrl)
-
-    def save_tx_beam(self, channel, state, attenuator, gain, phase):
-        """Save a beam to a Tx memory position
-
-        parameters:
-            channel: int
-                Channel number to save (1-4)
-            state: int
-                State number to save. Valid options are 0 to 120
-            attenuator: bool
-                Attenuator state for the beam position. True means the attenuator is in place.
-            gain: int
-                Gain value for the beam position. Valid settings are 0 to 127.
-            phase: float
-                Phase value for the beam position.
-        """
-        self._save_beam("tx", channel, state, attenuator, gain, phase)
 
     def save_tx_bias(
         self,
@@ -1286,14 +1111,14 @@ class adar1000(attribute, context_manager):
         """
 
         # Convert the PA bias settings to dac codes:
-        pa1_off_dac_code = pa1_bias_off // self._BIAS_CODE_TO_VOLTAGE_SCALE
-        pa2_off_dac_code = pa2_bias_off // self._BIAS_CODE_TO_VOLTAGE_SCALE
-        pa3_off_dac_code = pa3_bias_off // self._BIAS_CODE_TO_VOLTAGE_SCALE
-        pa4_off_dac_code = pa4_bias_off // self._BIAS_CODE_TO_VOLTAGE_SCALE
-        pa1_on_dac_code = pa1_bias_on // self._BIAS_CODE_TO_VOLTAGE_SCALE
-        pa2_on_dac_code = pa2_bias_on // self._BIAS_CODE_TO_VOLTAGE_SCALE
-        pa3_on_dac_code = pa3_bias_on // self._BIAS_CODE_TO_VOLTAGE_SCALE
-        pa4_on_dac_code = pa4_bias_on // self._BIAS_CODE_TO_VOLTAGE_SCALE
+        pa1_off_dac_code = int(pa1_bias_off / self._BIAS_CODE_TO_VOLTAGE_SCALE)
+        pa2_off_dac_code = int(pa2_bias_off / self._BIAS_CODE_TO_VOLTAGE_SCALE)
+        pa3_off_dac_code = int(pa3_bias_off / self._BIAS_CODE_TO_VOLTAGE_SCALE)
+        pa4_off_dac_code = int(pa4_bias_off / self._BIAS_CODE_TO_VOLTAGE_SCALE)
+        pa1_on_dac_code = int(pa1_bias_on / self._BIAS_CODE_TO_VOLTAGE_SCALE)
+        pa2_on_dac_code = int(pa2_bias_on / self._BIAS_CODE_TO_VOLTAGE_SCALE)
+        pa3_on_dac_code = int(pa3_bias_on / self._BIAS_CODE_TO_VOLTAGE_SCALE)
+        pa4_on_dac_code = int(pa4_bias_on / self._BIAS_CODE_TO_VOLTAGE_SCALE)
 
         save_string = (
             f"{state}, {pa1_off_dac_code}, {pa2_off_dac_code}, {pa3_off_dac_code}, {pa4_off_dac_code}, "
@@ -1316,97 +1141,234 @@ class adar1000_array(context_manager):
             each chip select and hardware address and are typically in the
             form csbX_chipX. The csb line can be any number depending on how
             many are used in the system. The chip number will typically be
-            1-4 because each CSB line can control up to four ADAR1000s. Use
-            a list when multiple chips are to be controlled.
+            1-4 because each CSB line can control up to four ADAR1000s. Note
+            that the order of the devices listed will correspond to the
+            device numbers in the array map directly.
+        device_map: type=list[list[int]]
+            List with the map of where the ADAR1000s are in the array. Each
+            entry in the map represents a row of ADAR1000s referenced by
+            device number. For example, a map:
+                [[1, 3, 5, 7],
+                [2, 4, 6, 8]]
+            represents an array of 8 ADAR1000s 4 wide and 2 tall.
+        element_map: type=list[list[int]]
+            List with the map of where the ADAR1000 channels are in the array.
+            Each entry in the map represents a row of array channels referenced
+            by element number. For example, a map:
+                [[1, 5, 9, 13],
+                [2, 6, 10, 14],
+                [3, 7, 11, 15],
+                [4, 8, 12, 16]]
+            represents an array of 16 elements in a square array.
+        device_element_map: type=dict[int, list[int]]
+            Dictionary with the map of ADAR1000 to array element references. Each
+            key in the map is a device number. The corresponding list of integers
+            represents the array element numbers connected to that ADAR1000, in
+            order of the ADAR1000's channels. For example, an entry of
+            {3: [10, 14, 13, 9]} connects ADAR1000 #3 to array elements 10, 14, 13,
+            and 9. Element #10 is on the ADAR1000's channel 1 while element #13 is
+            on the ADAR1000's channel 3.
     """
 
     _device_name = ""
 
     def __init__(
-        self, uri="", chip_ids=("csb1_chip1", "csb1_chip2", "csb1_chip3", "csb1_chip4")
+        self,
+        uri="",
+        chip_ids=None,
+        device_map=None,
+        element_map=None,
+        device_element_map=None,
     ):
+        # Check that the number of chips matches for all the inputs
+        chip_ids_len = len(chip_ids)
+        adar1000_map_len = len([num for row in device_map for num in row])
+        element_map_len = len([num for row in element_map for num in row]) / 4
+        device_element_map_len = len(device_element_map)
+        if not (
+            chip_ids_len
+            == adar1000_map_len
+            == element_map_len
+            == device_element_map_len
+        ):
+            raise ValueError("The number of chips must match for all the inputs")
+
+        # Get the context
         context_manager.__init__(self, uri, self._device_name)
 
-        self._ctrls = []
+        # Initialize the devices dictionary
+        self._devices = {}
 
-        for chip_id in chip_ids:
-            # Get an ADAR1000 handle for each chip ID using the context already found
-            self._ctrls.append(adar1000(uri, chip_id, self._ctx))
+        # Get an ADAR1000 handle for each chip ID using the context already found
+        for i, chip_id in enumerate(chip_ids):
+            device_number = i + 1
+            self._devices[chip_id] = adar1000(
+                uri,
+                self._ctx,
+                chip_id,
+                device_number,
+                element_map,
+                device_element_map[device_number],
+            )
 
-        if len(self._ctrls) != len(chip_ids):
-            raise Exception(f"Couldn't find all devices in {', '.join(chip_ids)}")
+        if len(self.devices) != len(chip_ids):
+            raise Exception(
+                f"Couldn't find all devices in the array {', '.join(chip_ids)}"
+            )
+
+        # Initialize some class fields
+        self._chip_ids = chip_ids
+        self._device_map = device_map
+        self._element_map = element_map
+        self._element_spacing = 0.015
+        self._frequency = 10e9
+        self._mode = "disabled"
+        self._rx_azimuth = 0
+        self._rx_azimuth_phi = 0
+        self._rx_elevation = 0
+        self._rx_elevation_phi = 0
+        self._tx_azimuth = 0
+        self._tx_azimuth_phi = 0
+        self._tx_elevation = 0
+        self._tx_elevation_phi = 0
 
     def __repr__(self):
         """ Representation of the ADAR1000 array class """
-        return f"ADAR1000 array containing {len(self.devices)} ADAR1000 instances:\n\t{', '.join(self.devices)}"
+        return f"ADAR1000 array containing {len(self.devices)} ADAR1000 instances:\n\t{', '.join(self._chip_ids)}"
+
+    """ Array Properties """
+
+    @property
+    def all_rx_attenuators(self):
+        """Get/Set all Rx Attenuator settings in the array.
+        The format is a list of lists where each row in the
+        array is a list entry in the larger list."""
+        attenuator_map = []
+        for r, row in enumerate(self.element_map):
+            attenuator_map.append([])
+            for element in row:
+                attenuator_map[r].append(self.elements[element].rx_attenuator)
+
+        return attenuator_map
+
+    @all_rx_attenuators.setter
+    def all_rx_attenuators(self, value):
+        """Get/Set all Rx Attenuator settings in the array.
+        The format is a list of lists where each row in the
+        array is a list entry in the larger list."""
+        for r, row in enumerate(self.element_map):
+            for e, element in enumerate(row):
+                self.elements[element].rx_attenuator = value[r][e]
 
     @property
     def all_rx_gains(self):
-        """ Get/Set all Rx Gain settings in the array. """
-        return {
-            f"{chip.chip_id}_ch{ch}": getattr(chip, f"ch{ch}_rx_gain")
-            for chip in self.devices.values()
-            for ch in range(1, 5)
-        }
+        """Get/Set all Rx Gain settings in the array.
+        The format is a list of lists where each row in the
+        array is a list entry in the larger list."""
+        gain_map = []
+        for r, row in enumerate(self.element_map):
+            gain_map.append([])
+            for element in row:
+                gain_map[r].append(self.elements[element].rx_gain)
+
+        return gain_map
 
     @all_rx_gains.setter
     def all_rx_gains(self, value):
-        """ Get/Set all Rx Gain settings in the array. """
-        for id_string, gain in value.items():
-            chip_id = "_".join(id_string.split("_")[:2])
-            channel = id_string.split("_")[-1]
-            setattr(self.devices[chip_id], f"{channel}_rx_gain", gain)
+        """Get/Set all Rx Gain settings in the array.
+        The format is a list of lists where each row in the
+        array is a list entry in the larger list."""
+        for r, row in enumerate(self.element_map):
+            for e, element in enumerate(row):
+                self.elements[element].rx_gain = value[r][e]
 
     @property
     def all_rx_phases(self):
-        """ Get/Set all Rx Phase settings in the array. """
-        return {
-            f"{chip.chip_id}_ch{ch}": getattr(chip, f"ch{ch}_rx_phase")
-            for chip in self.devices.values()
-            for ch in range(1, 5)
-        }
+        """Get/Set all Rx Phase settings in the array.
+        The format is a list of lists where each row in the
+        array is a list entry in the larger list."""
+        phase_map = []
+        for r, row in enumerate(self.element_map):
+            phase_map.append([])
+            for element in row:
+                phase_map[r].append(self.elements[element].rx_phase)
+
+        return phase_map
 
     @all_rx_phases.setter
     def all_rx_phases(self, value):
-        """ Get/Set all Rx Phase settings in the array. """
-        for id_string, gain in value.items():
-            chip_id = "_".join(id_string.split("_")[:2])
-            channel = id_string.split("_")[-1]
-            setattr(self.devices[chip_id], f"{channel}_rx_phase", gain)
+        """Get/Set all Rx Phase settings in the array.
+        The format is a list of lists where each row in the
+        array is a list entry in the larger list."""
+        for r, row in enumerate(self.element_map):
+            for e, element in enumerate(row):
+                self.elements[element].rx_phase = value[r][e]
+
+    @property
+    def all_tx_attenuators(self):
+        """Get/Set all Tx Attenuator settings in the array.
+        The format is a list of lists where each row in the
+        array is a list entry in the larger list."""
+        attenuator_map = []
+        for r, row in enumerate(self.element_map):
+            attenuator_map.append([])
+            for element in row:
+                attenuator_map[r].append(self.elements[element].tx_attenuator)
+
+        return attenuator_map
+
+    @all_tx_attenuators.setter
+    def all_tx_attenuators(self, value):
+        """Get/Set all Tx Attenuator settings in the array.
+        The format is a list of lists where each row in the
+        array is a list entry in the larger list."""
+        for r, row in enumerate(self.element_map):
+            for e, element in enumerate(row):
+                self.elements[element].tx_attenuator = value[r][e]
 
     @property
     def all_tx_gains(self):
-        """ Get/Set all Tx Gain settings in the array. """
-        return {
-            f"{chip.chip_id}_ch{ch}": getattr(chip, f"ch{ch}_tx_gain")
-            for chip in self.devices.values()
-            for ch in range(1, 5)
-        }
+        """Get/Set all Tx Gain settings in the array.
+        The format is a list of lists where each row in the
+        array is a list entry in the larger list."""
+        gain_map = []
+        for r, row in enumerate(self.element_map):
+            gain_map.append([])
+            for element in row:
+                gain_map[r].append(self.elements[element].tx_gain)
+
+        return gain_map
 
     @all_tx_gains.setter
     def all_tx_gains(self, value):
-        """ Get/Set all Tx Gain settings in the array. """
-        for id_string, gain in value.items():
-            chip_id = "_".join(id_string.split("_")[:2])
-            channel = id_string.split("_")[-1]
-            setattr(self.devices[chip_id], f"{channel}_tx_gain", gain)
+        """Get/Set all Tx Gain settings in the array.
+        The format is a list of lists where each row in the
+        array is a list entry in the larger list."""
+        for r, row in enumerate(self.element_map):
+            for e, element in enumerate(row):
+                self.elements[element].tx_gain = value[r][e]
 
     @property
     def all_tx_phases(self):
-        """ Get/Set all Tx Phase settings in the array. """
-        return {
-            f"{chip.chip_id}_ch{ch}": getattr(chip, f"ch{ch}_tx_phase")
-            for chip in self.devices.values()
-            for ch in range(1, 5)
-        }
+        """Get/Set all Tx Phase settings in the array.
+        The format is a list of lists where each row in the
+        array is a list entry in the larger list."""
+        phase_map = []
+        for r, row in enumerate(self.element_map):
+            phase_map.append([])
+            for element in row:
+                phase_map[r].append(self.elements[element].tx_phase)
+
+        return phase_map
 
     @all_tx_phases.setter
     def all_tx_phases(self, value):
-        """ Get/Set all Tx Phase settings in the array. """
-        for id_string, gain in value.items():
-            chip_id = "_".join(id_string.split("_")[:2])
-            channel = id_string.split("_")[-1]
-            setattr(self.devices[chip_id], f"{channel}_tx_phase", gain)
+        """Get/Set all Tx Phase settings in the array.
+        The format is a list of lists where each row in the
+        array is a list entry in the larger list."""
+        for r, row in enumerate(self.element_map):
+            for e, element in enumerate(row):
+                self.elements[element].tx_phase = value[r][e]
 
     @property
     def devices(self):
@@ -1414,4 +1376,270 @@ class adar1000_array(context_manager):
         Dictionary representing all of the connected ADAR1000s.
         The dictionary key is the chip_id for each device.
         """
-        return {chip.chip_id: chip for chip in self._ctrls}
+        return {device.array_device_number: device for device in self._devices.values()}
+
+    @property
+    def device_map(self):
+        """ Get the map of ADAR1000s in the array """
+        return self._device_map
+
+    @property
+    def elements(self):
+        """
+        Dictionary representing all of the connected ADAR1000 elements sorted by element number.
+        The dictionary key is the element number for each device.
+        """
+        dictionary = {
+            el.array_element_number: el
+            for dev in self.devices.values()
+            for el in dev.channels
+        }
+        return {k: v for k, v in sorted(dictionary.items(), key=lambda x: x[0])}
+
+    @property
+    def element_map(self):
+        """ Get the map of elements in the array """
+        return self._element_map
+
+    @property
+    def element_spacing(self):
+        """ Get/Set the element spacing for the array in meters """
+        return self._element_spacing
+
+    @element_spacing.setter
+    def element_spacing(self, value):
+        """ Get/Set the element spacing for the array in meters """
+        self._element_spacing = value
+
+    @property
+    def frequency(self):
+        """ Get/Set the board frequency in Hz """
+        return self._frequency
+
+    @frequency.setter
+    def frequency(self, value):
+        """ Get/Set the board frequency in Hz """
+        self._frequency = value
+
+    @property
+    def mode(self):
+        """ Get/Set the mode of operation for the array. Valid options are "rx", "tx", and "disabled" """
+        return self._mode
+
+    @mode.setter
+    def mode(self, value):
+        """ Get/Set the mode of operation for the array. Valid options are "rx", "tx", and "disabled" """
+        mode = value.strip().lower()
+        if mode not in ("rx", "tx", "disabled",):
+            raise ValueError(
+                'Mode of operation must be either "rx", "tx", or "disabled"'
+            )
+
+        self._mode = mode
+
+        if mode == "disabled":
+            for device in self.devices.values():
+                device.rx_enable = False
+                device.tx_enable = False
+        elif mode == "rx":
+            for device in self.devices.values():
+                device.rx_enable = True
+                device.tx_enable = False
+        else:
+            for device in self.devices.values():
+                device.rx_enable = False
+                device.tx_enable = True
+
+        if mode != "disabled":
+            self.tr = mode
+
+    @property
+    def rx_azimuth(self):
+        """ Get the Rx azimuth angle for the array in degrees """
+        return self._rx_azimuth
+
+    @property
+    def rx_azimuth_phi(self):
+        """ Get the Rx azimuth phi angle for the array in degrees """
+        return self._rx_azimuth_phi
+
+    @property
+    def rx_elevation(self):
+        """ Get the Rx elevation angle for the array in degrees """
+        return self._rx_elevation
+
+    @property
+    def rx_elevation_phi(self):
+        """ Get the Rx elevation phi angle for the array in degrees """
+        return self._rx_elevation_phi
+
+    @property
+    def temperatures(self):
+        """ Get the temperature readings of the ADAR1000s in a dictionary """
+        return {chip_id: device.temperature for chip_id, device in self.devices.items()}
+
+    @property
+    def tr(self):
+        """Get/Set the T/R input to the array. Valid options are "tx" or "rx". This property must be overwritten to
+        use the external T/R input, as the GPIO control is not included.
+        """
+
+        if self.tr_source == "external":
+            raise NotImplementedError(
+                "External T/R control is not implemented in this driver. Overwrite this "
+                "property in a subclass to allow for GPIO control of the ADAR1000's T/R input"
+            )
+
+        return self.devices[0].tr_spi
+
+    @tr.setter
+    def tr(self, value):
+        """Get/Set the T/R input to the array. Valid options are "tx" or "rx". This property must be overwritten to
+        use the external T/R input, as the GPIO control is not included.
+        """
+
+        if self.tr_source == "external":
+            raise NotImplementedError(
+                "External T/R control is not implemented in this driver. Overwrite this "
+                "property in a subclass to allow for GPIO control of the ADAR1000's T/R input"
+            )
+
+        for device in self.devices.values():
+            device.tr_spi = value
+        return
+
+    @property
+    def tr_source(self):
+        """ Get/Set the T/R source for the array. Valid options are "external" or "spi". """
+        return self.devices[1].tr_source
+
+    @tr_source.setter
+    def tr_source(self, value):
+        """ Get/Set the T/R source for the array. Valid options are "external" or "spi". """
+        for device in self.devices.values():
+            device.tr_source = value
+
+    @property
+    def tx_azimuth(self):
+        """ Get the Tx azimuth angle for the array in degrees """
+        return self._tx_azimuth
+
+    @property
+    def tx_azimuth_phi(self):
+        """ Get the Tx azimuth phi angle for the array in degrees """
+        return self._tx_azimuth_phi
+
+    @property
+    def tx_elevation(self):
+        """ Get the Tx elevation angle for the array in degrees """
+        return self._tx_elevation
+
+    @property
+    def tx_elevation_phi(self):
+        """ Get the Tx elevation phi angle for the array in degrees """
+        return self._tx_elevation_phi
+
+    """ Private Methods """
+
+    def _calculate_phi(self, azimuth, elevation):
+        """Calculate the Φ angles to steer the array in a particular direction. This method assumes that the entire
+        array is one analog beam.
+
+        parameters:
+            azimuth: float
+                Desired beam angle in degrees for the horizontal direction.
+            elevation: float
+                Desired beam angle in degrees for the vertical direction.
+        """
+
+        # Convert the input angles to radians
+        az_rads = azimuth * pi / 180
+        el_rads = elevation * pi / 180
+
+        # Calculate the phase increment (Φ) for each element in the array in both directions (in degrees)
+        az_phi = 2 * self.frequency * self.element_spacing * sin(az_rads) * 180 / 3e8
+        el_phi = 2 * self.frequency * self.element_spacing * sin(el_rads) * 180 / 3e8
+
+        return az_phi, el_phi
+
+    """ Public Methods """
+
+    def initialize_devices(self):
+        """ Initialize the ADAR1000s in the array """
+        for device in self.devices.values():
+            device.initialize()
+        return
+
+    def latch_rx_settings(self):
+        """ Latch in new Gain/Phase settings for the Rx """
+        for device in self.devices.values():
+            device.latch_rx_settings()
+        return
+
+    def latch_tx_settings(self):
+        """ Latch in new Gain/Phase settings for the Tx """
+        for device in self.devices.values():
+            device.latch_tx_settings()
+        return
+
+    def steer_rx(self, azimuth, elevation):
+        """Steer the Rx array in a particular direction. This method assumes that the entire array is one analog beam.
+
+        parameters:
+            azimuth: float
+                Desired beam angle in degrees for the horizontal direction.
+            elevation: float
+                Desired beam angle in degrees for the vertical direction.
+        """
+
+        # Calculate the Φ angles for each element in both directions (in degrees)
+        azimuth_phi, elevation_phi = self._calculate_phi(azimuth, elevation)
+
+        # Update the class variables
+        self._rx_azimuth = azimuth
+        self._rx_elevation = elevation
+        self._rx_azimuth_phi = azimuth_phi
+        self._rx_elevation_phi = elevation_phi
+
+        # Steer the elements in the array
+        for element in self.elements.values():
+            # Calculate the row and column phases
+            column_phase = element.column * azimuth_phi
+            row_phase = element.row * elevation_phi
+
+            element.rx_phase = column_phase + row_phase
+
+        # Latch in the new phases
+        self.latch_rx_settings()
+        return
+
+    def steer_tx(self, azimuth, elevation):
+        """Steer the Tx array in a particular direction. This method assumes that the entire array is one analog beam.
+
+        parameters:
+            azimuth: float
+                Desired beam angle in degrees for the horizontal direction.
+            elevation: float
+                Desired beam angle in degrees for the vertical direction.
+        """
+
+        # Calculate the Φ angles for each element in both directions (in degrees)
+        azimuth_phi, elevation_phi = self._calculate_phi(azimuth, elevation)
+
+        # Update the class variables
+        self._tx_azimuth = azimuth
+        self._tx_elevation = elevation
+        self._tx_azimuth_phi = azimuth_phi
+        self._tx_elevation_phi = elevation_phi
+
+        # Steer the elements in the array
+        for element in self.elements.values():
+            # Calculate the row and column phases
+            column_phase = element.column * azimuth_phi
+            row_phase = element.row * elevation_phi
+
+            element.tx_phase = column_phase + row_phase
+
+        # Latch in the new phases
+        self.latch_tx_settings()
+        return

--- a/adi/adar1000.py
+++ b/adi/adar1000.py
@@ -135,11 +135,13 @@ class adar1000(attribute, context_manager):
         or toggle with respect to T/R state.
         """
         if value.lower() == "toggle":
-            self._set_iio_dev_attr_str("bias_ctrl", 1, self._ctrl)
+            set_value = 1
         elif value.lower() == "on":
-            self._set_iio_dev_attr_str("bias_ctrl", 0, self._ctrl)
+            set_value = 0
         else:
             raise ValueError('bias_dac_mode should be "toggle" or "on"')
+
+        self._set_iio_dev_attr_str("bias_ctrl", set_value, self._ctrl)
 
     @property
     def bias_mem_enable(self):
@@ -172,19 +174,21 @@ class adar1000(attribute, context_manager):
         """ Get/Set which external T/R switch driver is used ("positive" = TR_SW_POS, "negative" = TR_SW_NEG) """
         value = bool(self._get_iio_dev_attr("sw_drv_tr_mode_sel", self._ctrl))
         if value:
-            return "positive"
-        else:
             return "negative"
+        else:
+            return "positive"
 
     @external_tr_pin.setter
     def external_tr_pin(self, value):
         """ Get/Set which external T/R switch driver is used ("positive" = TR_SW_POS, "negative" = TR_SW_NEG) """
-        if value.lower() == "positive":
-            self._set_iio_dev_attr_str("sw_drv_tr_mode_sel", 1, self._ctrl)
-        elif value.lower() == "negative":
-            self._set_iio_dev_attr_str("sw_drv_tr_mode_sel", 0, self._ctrl)
+        if value.lower() == "negative":
+            set_value = 1
+        elif value.lower() == "positive":
+            set_value = 0
         else:
-            raise ValueError('external_tr_pin should be "toggle" or "on"')
+            raise ValueError('external_tr_pin should be "positive" or "negative"')
+
+        self._set_iio_dev_attr_str("sw_drv_tr_mode_sel", set_value, self._ctrl)
 
     @property
     def external_tr_polarity(self):
@@ -359,21 +363,34 @@ class adar1000(attribute, context_manager):
     def tr_source(self, value):
         """ Get/Set TR source for the chip. Valid options are "external" or "spi" """
         if value.lower() == "external":
-            self._set_iio_dev_attr_str("tr_source", 1, self._ctrl)
+            set_value = 1
         elif value.lower() == "spi":
-            self._set_iio_dev_attr_str("tr_source", 0, self._ctrl)
+            set_value = 0
         else:
             raise ValueError('tr_source should be "external" or "spi"')
 
+        self._set_iio_dev_attr_str("tr_source", set_value, self._ctrl)
+
     @property
     def tr_spi(self):
-        """ Get/Set T/R state using the SPI bit. True is Tx, False is Rx """
-        return bool(self._get_iio_dev_attr("tr_spi", self._ctrl))
+        """ Get/Set T/R state using the SPI bit. Valid options are "tx" or "rx" """
+        value = bool(self._get_iio_dev_attr("tr_spi", self._ctrl))
+        if value:
+            return "tx"
+        else:
+            return "rx"
 
     @tr_spi.setter
     def tr_spi(self, value):
-        """ Get/Set T/R state using the SPI bit. True is Tx, False is Rx """
-        self._set_iio_dev_attr_str("tr_spi", int(value), self._ctrl)
+        """ Get/Set T/R state using the SPI bit. Valid options are "tx" or "rx" """
+        if value.lower() == "tx":
+            set_value = 1
+        elif value.lower() == "rx":
+            set_value = 0
+        else:
+            raise ValueError('tr_spi should be "tx" or "rx"')
+
+        self._set_iio_dev_attr_str("tr_spi", set_value, self._ctrl)
 
     @property
     def tr_switch_enable(self):

--- a/adi/ltc2314_14.py
+++ b/adi/ltc2314_14.py
@@ -31,8 +31,8 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from adi.rx_tx import rx
 from adi.context_manager import context_manager
+from adi.rx_tx import rx
 
 
 class ltc2314_14(rx, context_manager):
@@ -49,16 +49,16 @@ class ltc2314_14(rx, context_manager):
         context_manager.__init__(self, uri, self._device_name)
 
         # Find the main and trigger devices
-        self._ctrl = self._ctx.find_device('ltc2314-14')
-        self._trig = self._ctx.find_device('ltc2314_trigger')
+        self._ctrl = self._ctx.find_device("ltc2314-14")
+        self._trig = self._ctx.find_device("ltc2314_trigger")
 
         # Raise an exception if the device isn't found
         if not self._ctrl:
-            raise Exception(f"LTC2314-14 device not found")
+            raise Exception("LTC2314-14 device not found")
 
         # Raise an exception if the trigger isn't found
         if not self._trig:
-            raise Exception(f"LTC2314-14 trigger not found")
+            raise Exception("LTC2314-14 trigger not found")
 
         # Add the trigger to the main device
         self._ctrl.trigger = self._trig
@@ -76,7 +76,7 @@ class ltc2314_14(rx, context_manager):
     def lsb_mv(self):
         """ Get/Set the LSB in millivolts """
         return self._get_iio_dev_attr("in_voltage_scale", self._ctrl)
-    
+
     @lsb_mv.setter
     def lsb_mv(self, value):
         """ Get/Set the LSB in millivolts """
@@ -93,6 +93,6 @@ class ltc2314_14(rx, context_manager):
         self._set_iio_dev_attr_str("sampling_frequency", value, self._trig)
 
 
-if __name__ == '__main__':
-    adc = ltc2314_14('ip:192.168.1.18')
+if __name__ == "__main__":
+    adc = ltc2314_14("ip:192.168.1.18")
     print(adc.rx())

--- a/adi/ltc2314_14.py
+++ b/adi/ltc2314_14.py
@@ -50,49 +50,18 @@ class ltc2314_14(rx, context_manager):
 
         # Find the main and trigger devices
         self._ctrl = self._ctx.find_device("ltc2314-14")
-        self._trig = self._ctx.find_device("ltc2314_trigger")
 
         # Raise an exception if the device isn't found
         if not self._ctrl:
             raise Exception("LTC2314-14 device not found")
 
-        # Raise an exception if the trigger isn't found
-        if not self._trig:
-            raise Exception("LTC2314-14 trigger not found")
-
-        # Add the trigger to the main device
-        self._ctrl.trigger = self._trig
-
-        # Initialize the rx device
-        rx.__init__(self)
-
-        # Set the buffer length
-        self.rx_buffer_size = 2
-
-        # Set the sampling frequency for the trigger
-        self.sampling_frequency = 10000
-
     @property
     def lsb_mv(self):
-        """ Get/Set the LSB in millivolts """
-        return self._get_iio_dev_attr("in_voltage_scale", self._ctrl)
-
-    @lsb_mv.setter
-    def lsb_mv(self, value):
-        """ Get/Set the LSB in millivolts """
-        self._set_iio_dev_attr_str("in_voltage_scale", value, self._ctrl)
+        """ Get the LSB in millivolts """
+        return self._get_iio_attr("voltage0", "scale", False, self._ctrl)
 
     @property
-    def sampling_frequency(self):
-        """ Get/Set the sampling frequency for the trigger """
-        return self._get_iio_dev_attr("sampling_frequency", self._trig)
-
-    @sampling_frequency.setter
-    def sampling_frequency(self, value):
-        """ Get/Set the sampling frequency for the trigger """
-        self._set_iio_dev_attr_str("sampling_frequency", value, self._trig)
-
-
-if __name__ == "__main__":
-    adc = ltc2314_14("ip:192.168.1.18")
-    print(adc.rx())
+    def voltage(self):
+        """ Get the voltage reading from the ADC """
+        code = self._get_iio_attr("voltage0", "raw", False, self._ctrl)
+        return code * self.lsb_mv / 1000

--- a/adi/ltc2314_14.py
+++ b/adi/ltc2314_14.py
@@ -31,11 +31,11 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from adi.attribute import attribute
 from adi.context_manager import context_manager
-from adi.rx_tx import rx
 
 
-class ltc2314_14(rx, context_manager):
+class ltc2314_14(attribute, context_manager):
     """LTC2314-14 14-Bit, 4.5Msps Serial Sampling ADC
 
     parameters:

--- a/adi/ltc2314_14.py
+++ b/adi/ltc2314_14.py
@@ -1,0 +1,98 @@
+# Copyright (C) 2020 Analog Devices, Inc.
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#     - Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     - Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#     - Neither the name of Analog Devices, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#     - The use of this software may or may not infringe the patent rights
+#       of one or more patent holders.  This license does not release you
+#       from the requirement that you obtain separate licenses from these
+#       patent holders to use this software.
+#     - Use of the software either in source or binary form, must be run
+#       on or directly connected to an Analog Devices Inc. component.
+#
+# THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED.
+#
+# IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, INTELLECTUAL PROPERTY
+# RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from adi.rx_tx import rx
+from adi.context_manager import context_manager
+
+
+class ltc2314_14(rx, context_manager):
+    """LTC2314-14 14-Bit, 4.5Msps Serial Sampling ADC
+
+    parameters:
+        uri: type=string
+            URI of IIO context with LTC2314-14
+    """
+
+    _device_name = ""
+
+    def __init__(self, uri=""):
+        context_manager.__init__(self, uri, self._device_name)
+
+        # Find the main and trigger devices
+        self._ctrl = self._ctx.find_device('ltc2314-14')
+        self._trig = self._ctx.find_device('ltc2314_trigger')
+
+        # Raise an exception if the device isn't found
+        if not self._ctrl:
+            raise Exception(f"LTC2314-14 device not found")
+
+        # Raise an exception if the trigger isn't found
+        if not self._trig:
+            raise Exception(f"LTC2314-14 trigger not found")
+
+        # Add the trigger to the main device
+        self._ctrl.trigger = self._trig
+
+        # Initialize the rx device
+        rx.__init__(self)
+
+        # Set the buffer length
+        self.rx_buffer_size = 2
+
+        # Set the sampling frequency for the trigger
+        self.sampling_frequency = 10000
+
+    @property
+    def lsb_mv(self):
+        """ Get/Set the LSB in millivolts """
+        return self._get_iio_dev_attr("in_voltage_scale", self._ctrl)
+    
+    @lsb_mv.setter
+    def lsb_mv(self, value):
+        """ Get/Set the LSB in millivolts """
+        self._set_iio_dev_attr_str("in_voltage_scale", value, self._ctrl)
+
+    @property
+    def sampling_frequency(self):
+        """ Get/Set the sampling frequency for the trigger """
+        return self._get_iio_dev_attr("sampling_frequency", self._trig)
+
+    @sampling_frequency.setter
+    def sampling_frequency(self, value):
+        """ Get/Set the sampling frequency for the trigger """
+        self._set_iio_dev_attr_str("sampling_frequency", value, self._trig)
+
+
+if __name__ == '__main__':
+    adc = ltc2314_14('ip:192.168.1.18')
+    print(adc.rx())

--- a/adi/one_bit_adc_dac.py
+++ b/adi/one_bit_adc_dac.py
@@ -56,7 +56,10 @@ class _dyn_property:
 
 
 class one_bit_adc_dac(attribute, context_manager):
-    """ One bit ADC/DAC (GPIO)
+    """One bit ADC/DAC (GPIO). This driver will create a handle for the
+    GPIO device as well as properties for each GPIO pin it accesses.
+    Each GPIO pin name will be lowercase and of the format:
+        "gpio_{pin name}"
 
     parameters:
         uri: type=string

--- a/doc/source/devices/adi.ltc2314_14.rst
+++ b/doc/source/devices/adi.ltc2314_14.rst
@@ -1,0 +1,7 @@
+ltc2314-14
+===================
+
+.. automodule:: adi.ltc2314_14
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/source/devices/adi.one_bit_adc_dac.rst
+++ b/doc/source/devices/adi.one_bit_adc_dac.rst
@@ -1,0 +1,7 @@
+one_bit_adc_dac
+===================
+
+.. automodule:: adi.one_bit_adc_dac
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/source/devices/index.rst
+++ b/doc/source/devices/index.rst
@@ -33,4 +33,6 @@ Supported Devices
    adi.fmclidar1
    adi.fmcomms5
    adi.jesd
+   adi.ltc2314_14
    adi.ltc2983
+   adi.one_bit_adc_dac

--- a/examples/adar1000_array_example.py
+++ b/examples/adar1000_array_example.py
@@ -1,0 +1,138 @@
+# Copyright (C) 2020 Analog Devices, Inc.
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#     - Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     - Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#     - Neither the name of Analog Devices, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#     - The use of this software may or may not infringe the patent rights
+#       of one or more patent holders.  This license does not release you
+#       from the requirement that you obtain separate licenses from these
+#       patent holders to use this software.
+#     - Use of the software either in source or binary form, must be run
+#       on or directly connected to an Analog Devices Inc. component.
+#
+# THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED.
+#
+# IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, INTELLECTUAL PROPERTY
+# RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+""" Example of how to use the adar1000_array class """
+
+import adi
+
+# Create handle for an array of 4 ADAR1000s with the channels configured in a 4x4 array.
+#
+# Instantiation arguments:
+#     chip_ids: Must match the ADAR1000 labels in the device tree
+#
+#     device_map: Maps the ADAR1000s to their location in the array. See below:
+#         (ADAR1000 #1)    (ADAR1000 #2)
+#         (ADAR1000 #3)    (ADAR1000 #4)
+#
+#     element_map: Maps the element numbers in the array. See below:
+#         (El. #1)    (El. #2)    (El. #3)    (El. #4)
+#         (El. #5)    (El. #6)    (El. #7)    (El. #8)
+#         (El. #9)    (El. #10)   (El. #11)   (El. #12)
+#         (El. #13)   (El. #14)   (El. #15)   (El. #16)
+#
+#     device_element_map: Maps the ADAR1000s to specific elements in the array, in channel order. See below:
+#         ADAR1000 #1:
+#             Ch. #1 -> El. #5
+#             Ch. #2 -> El. #6
+#             Ch. #3 -> El. #2
+#             Ch. #4 -> El. #1
+#         ADAR1000 #2:
+#             Ch. #1 -> El. #7
+#             Ch. #2 -> El. #8
+#             Ch. #3 -> El. #4
+#             Ch. #4 -> El. #3
+#         ADAR1000 #3:
+#             Ch. #1 -> El. #13
+#             Ch. #2 -> El. #14
+#             Ch. #3 -> El. #10
+#             Ch. #4 -> El. #9
+#         ADAR1000 #4:
+#             Ch. #1 -> El. #15
+#             Ch. #2 -> El. #16
+#             Ch. #3 -> El. #12
+#             Ch. #4 -> El. #11
+array = adi.adar1000_array(
+    chip_ids=["csb1_chip1", "csb1_chip2", "csb1_chip3", "csb1_chip4"],
+    device_map=[[1, 2], [3, 4]],
+    element_map=[[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]],
+    device_element_map={
+        1: [5, 6, 2, 1],
+        2: [7, 8, 4, 3],
+        3: [13, 14, 10, 9],
+        4: [15, 16, 12, 11],
+    },
+)
+
+# Set the array frequency to 12GHz and the element spacing to 12.5mm so that the array can be accurately steered
+array.frequency = 12e9
+array.element_spacing = 0.0125
+
+ARRAY_MODE = "rx"
+if ARRAY_MODE == "rx":
+    # Configure the array for Rx
+    for device in array.devices.values():
+        device.mode = "rx"
+
+        SELF_BIASED_LNAs = True
+        if SELF_BIASED_LNAs:
+            # Allow the external LNAs to self-bias
+            device.lna_bias_out_enable = False
+        else:
+            # Set the external LNA bias
+            device.lna_bias_on = -0.7
+
+        # Enable the Rx path for each channel
+        for channel in device.channels:
+            channel.rx_enable = True
+
+# Configure the array for Tx mode
+else:
+    for device in array.devices.values():
+        device.mode = "tx"
+
+        # Enable the Tx path for each channel and set the external PA bias
+        for channel in device.channels:
+            channel.pa_bias_on = -1.1
+            channel.tx_enable = True
+
+# Steer the Rx array to 10° azimuth and 45° elevation
+if ARRAY_MODE == "rx":
+    array.steer_rx(azimuth=10, elevation=45)
+
+    # Set the element gains to 0x67
+    for element in array.elements.values():
+        element.rx_gain = 0x67
+
+    # Latch in the new gains
+    array.latch_rx_settings()
+
+# Steer the Tx array to 10° azimuth and 45° elevation
+else:
+    array.steer_tx(azimuth=10, elevation=45)
+
+    # Set the element gains to 0x67
+    for element in array.elements.values():
+        element.tx_gain = 0x67
+
+    # Latch in the new gains
+    array.latch_tx_settings()

--- a/examples/adar1000_single_example.py
+++ b/examples/adar1000_single_example.py
@@ -1,0 +1,96 @@
+# Copyright (C) 2020 Analog Devices, Inc.
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#     - Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     - Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#     - Neither the name of Analog Devices, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#     - The use of this software may or may not infringe the patent rights
+#       of one or more patent holders.  This license does not release you
+#       from the requirement that you obtain separate licenses from these
+#       patent holders to use this software.
+#     - Use of the software either in source or binary form, must be run
+#       on or directly connected to an Analog Devices Inc. component.
+#
+# THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED.
+#
+# IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, INTELLECTUAL PROPERTY
+# RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+""" Example of how to use the adar1000 class """
+
+import adi
+
+# Create device handle for a single ADAR1000 with the channels configured in a 1x4 array.
+# Instantiation arguments:
+#     chip_id: Must match the ADAR1000 label in the device tree. Defaults to "csb1_chip1"
+#
+#     array_element_map: Maps the array elements to a 1x4 array. See below:
+#         (El. #1)    (El. #2)    (El. #3)    (El. #4)
+#
+#     channel_element_map: Maps the ADAR1000's channels to the array elements. See below:
+#         Ch. #1 -> El. #2
+#         Ch. #2 -> El. #1
+#         Ch. #3 -> El. #4
+#         Ch. #4 -> El. #3
+device = adi.adar1000(
+    chip_id="csb1_chip1",
+    array_element_map=[[1, 2, 3, 4]],
+    channel_element_map=[2, 1, 4, 3],
+)
+
+DEVICE_MODE = "rx"
+if DEVICE_MODE == "rx":
+    # Configure the device for Rx mode
+    device.mode = "rx"
+
+    SELF_BIASED_LNAs = True
+    if SELF_BIASED_LNAs:
+        # Allow the external LNAs to self-bias
+        device.lna_bias_out_enable = False
+    else:
+        # Set the external LNA bias
+        device.lna_bias_on = -0.7
+
+    # Enable the Rx path for each channel
+    for channel in device.channels:
+        channel.rx_enable = True
+
+# Configure the device for Tx mode
+else:
+    device.mode = "tx"
+
+    # Enable the Tx path for each channel and set the external PA bias
+    for channel in device.channels:
+        channel.tx_enable = True
+        channel.pa_bias_on = -1.1
+
+# Set the array phases to 10°, 20°, 30°, and 40° and the gains to 0x67.
+for channel in device.channels:
+    # Set the gain and phase depending on the device mode
+    if device.mode == "rx":
+        channel.rx_phase = channel.array_element_number * 10
+        channel.rx_gain = 0x67
+    else:
+        channel.tx_phase = channel.array_element_number * 10
+        channel.tx_gain = 0x67
+
+# Latch in the new gains & phases
+if device.mode == "rx":
+    device.latch_rx_settings()
+else:
+    device.latch_tx_settings()


### PR DESCRIPTION
- Add missing ADAR1000 attributes
- Add more properties & methods for control of an array as a single entity (attenuators, gains, phases, steering, etc.)
- Nest adar1000_channel class under adar1000 to allow for simpler access to the elements in the array (can be accessed via element number in the array class, or from the parent ADAR1000 object)
- Add support for LTC2314-14
- Add LTC2314-14 and one_bit_adc_dac to the documentation