### PR TITLE
Update arguments on ad9144 test

### DIFF
--- a/test/test_ad9144_p.py
+++ b/test/test_ad9144_p.py
@@ -8,4 +8,4 @@ classname = "adi.ad9144"
 @pytest.mark.parametrize("classname", [(classname)])
 @pytest.mark.parametrize("channel", [0, 1, [0, 1]])
 def test_ad9144_tx_data(test_dma_tx, iio_uri, classname, channel):
-    test_dma_tx(iio_uri, classname, hardware, channel)
+    test_dma_tx(iio_uri, classname, channel)


### PR DESCRIPTION
Signed-off-by: Trecia Agoylo <trecia.agoylo@analog.com>

# Description

Updated the arguments of the function on test_ad9144_p.py. There was a need for change because of incompatibility in the number of arguments after using pylibiio-test in managing the hardware.

#Fixes #155

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?
- [x] Setup fmcdaq2 on zc706 and ran pytest using the following command pytest test_ad9144_p.py -v --uri=<uri of the hardware> --adi-hw-map

**Test Configuration**:
* Hardware: fmcdaq2 on ZC706 
* OS: ADI Kuiper 2019R2 RC6

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
