### PR TITLE
Fix missing argument in ADRV9009 test

### DIFF
--- a/test/test_adrv9009_p.py
+++ b/test/test_adrv9009_p.py
@@ -187,7 +187,9 @@ def test_adrv9009_dds_gain_check_vary_power(
     min_rssi,
     max_rssi,
 ):
-    test_gain_check(classname, channel, param_set, dds_scale, min_rssi, max_rssi)
+    test_gain_check(
+        iio_uri, classname, channel, param_set, dds_scale, min_rssi, max_rssi
+    )
 
 
 #########################################


### PR DESCRIPTION
Fix ADRV9009 test case with missing argument.

Signed-off-by: Travis F. Collins <travis.collins@analog.com>