### PR TITLE
Add support for bump2version

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,3 +9,4 @@ scipy
 pytest-cov
 coveralls
 pytest-libiio
+bump2version

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,12 @@
+[bumpversion]
+current_version = 0.0.7
+commit = True
+tag = True
+
+[bumpversion:file:adi/__init__.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"
+
 [isort]
 multi_line_output=3
 include_trailing_comma=True


### PR DESCRIPTION
Add bump2version tooling help create tagged releases.

Signed-off-by: Travis F. Collins <travis.collins@analog.com>
