### PR TITLE
Do not set LOs of dev C and D when FMComms8 is not hooked up

### DIFF
--- a/adi/adrv9009_zu11eg_multi.py
+++ b/adi/adrv9009_zu11eg_multi.py
@@ -364,12 +364,13 @@ class adrv9009_zu11eg_multi(object):
             dev._set_iio_debug_attr_str(
                 "adi,trx-pll-lo-frequency_hz", freq, dev._ctrl_b
             )
-            dev._set_iio_debug_attr_str(
-                "adi,trx-pll-lo-frequency_hz", freq, dev._ctrl_c
-            )
-            dev._set_iio_debug_attr_str(
-                "adi,trx-pll-lo-frequency_hz", freq, dev._ctrl_d
-            )
+            if self.fmcomms8:
+                dev._set_iio_debug_attr_str(
+                    "adi,trx-pll-lo-frequency_hz", freq, dev._ctrl_c
+                )
+                dev._set_iio_debug_attr_str(
+                    "adi,trx-pll-lo-frequency_hz", freq, dev._ctrl_d
+                )
 
     def __refill_samples(self, dev, is_primary):
         if is_primary:


### PR DESCRIPTION
Signed-off-by: Travis F. Collins <travis.collins@analog.com>
