### PR TITLE
Jesd204 ad9371

### DIFF
--- a/adi/ad9371.py
+++ b/adi/ad9371.py
@@ -33,6 +33,7 @@
 
 from adi.context_manager import context_manager
 from adi.obs import obs
+from adi.jesd import jesd
 from adi.rx_tx import rx_tx
 
 
@@ -45,7 +46,7 @@ class ad9371(rx_tx, context_manager):
     _obs_channel_names = ["voltage0_i", "voltage0_q"]
     _device_name = ""
 
-    def __init__(self, uri=""):
+    def __init__(self, uri="", username="root", password="analog"):
 
         context_manager.__init__(self, uri, self._device_name)
 
@@ -53,6 +54,7 @@ class ad9371(rx_tx, context_manager):
         self._rxadc = self._ctx.find_device("axi-ad9371-rx-hpc")
         self._rxobs = self._ctx.find_device("axi-ad9371-rx-obs-hpc")
         self._txdac = self._ctx.find_device("axi-ad9371-tx-hpc")
+        self._jesd = jesd(uri, username=username, password=password)
 
         rx_tx.__init__(self)
 
@@ -224,3 +226,7 @@ class ad9371(rx_tx, context_manager):
     @obs_rf_port_select.setter
     def obs_rf_port_select(self, value):
         self._set_iio_attr("voltage2", "rf_port_select", False, value)
+
+    @property
+    def jesd204_statuses(self):
+        return self._jesd.get_all_statuses()

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,7 @@ setuptools.setup(
     url="https://github.com/analogdevicesinc/pyadi-iio",
     packages=setuptools.find_packages(exclude=["test*"]),
     python_requires=">=3.6",
-    install_requires=["numpy", "pylibiio"],
-    extras_require={"jesd": ["fs.sshfs"]},
+    install_requires=["numpy", "pylibiio", "paramiko"],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: BSD License",

--- a/test/common.py
+++ b/test/common.py
@@ -37,6 +37,26 @@ def pytest_collection_modifyitems(items):
                     break
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--username",
+        default="root",
+        help="SSH login username",
+    )
+    parser.addoption(
+        "--password",
+        default="analog",
+        help="SSH login password",
+    )
+
+
+def pytest_generate_tests(metafunc):
+    if "username" in metafunc.fixturenames:
+        metafunc.parametrize("username", [metafunc.config.getoption("username")])
+    if "password" in metafunc.fixturenames:
+        metafunc.parametrize("password", [metafunc.config.getoption("password")])
+
+
 #################################################
 def dev_interface(uri, classname, val, attr, tol):
     sdr = eval(classname + "(uri='" + uri + "')")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,7 +2,8 @@ import random
 import test.rf.spec as spec
 import time
 from test.attr_tests import *
-from test.common import dev_interface, pytest_collection_modifyitems, pytest_configure
+from test.common import dev_interface, pytest_collection_modifyitems, \
+        pytest_configure, pytest_generate_tests, pytest_addoption
 from test.dma_tests import *
 from test.generics import iio_attribute_single_value
 from test.globals import *

--- a/test/test_sshfs.py
+++ b/test/test_sshfs.py
@@ -1,0 +1,34 @@
+import adi
+import pytest
+
+hardware = ["ad9371" , "ad9144"]
+classname = "adi.sshfs.sshfs"
+
+
+def open_sshfs(classname, iio_uri, username, password):
+    _password = f'"{password}"' if password is not None else None
+    return eval(f'{classname}("{iio_uri}", "{username}", {_password})')
+
+
+@pytest.mark.iio_hardware(hardware)
+@pytest.mark.parametrize("classname", [(classname)])
+def test_sshfs_isfile(iio_uri, classname, username, password):
+    sshfs = open_sshfs(classname, iio_uri, username, password)
+    assert sshfs.isfile('/etc/os-release')
+    assert sshfs.isfile('/etc/') == False
+
+
+@pytest.mark.iio_hardware(hardware)
+@pytest.mark.parametrize("classname", [(classname)])
+@pytest.mark.iio_hardware(hardware)
+def test_sshfs_listdir(iio_uri, classname, username, password):
+    sshfs = open_sshfs(classname, iio_uri, username, password)
+    assert isinstance(sshfs.listdir('/etc/'), list)
+
+
+@pytest.mark.iio_hardware(hardware)
+@pytest.mark.parametrize("classname", [(classname)])
+@pytest.mark.iio_hardware(hardware)
+def test_sshfs_gettext(iio_uri, classname, username, password):
+    sshfs = open_sshfs(classname, iio_uri, username, password)
+    assert sshfs.gettext('/proc/version').startswith('Linux version')


### PR DESCRIPTION
# Description

It seems like on systems with dropbear as an sshserver, fs.sshfs fails to authenticate.
Using this minimal class instead lets users read files without issues.

It also allows for login with no password.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

This was tested using the jesd204 status files.
```python
>>> import adi
>>> sdr = adi.ad9371(uri=hostname)
>>> print(sdr.jesd204_statuses)
{'b3000000.axi-ad9371-jesd204-tx': {'enabled': 'enabled', 'Measured Link Clock': '122.882 MHz', 'Reported Link Clock': '122.880 MHz', 'Lane rate': '4915.200 MHz', 'Lane rate / 40': '122.880 MHz', 'LMFC rate': '7.680 MHz', 'SYNC~': 'deasserted', 'Link status': 'DATA', 'SYSREF captured': 'Yes', 'SYSREF alignment error': 'No'}, 'b3020000.axi-ad9371-jesd204-rx': {'enabled': 'enabled', 'Measured Link Clock': '122.882 MHz', 'Reported Link Clock': '122.880 MHz', 'Lane rate': '4915.200 MHz', 'Lane rate / 40': '122.880 MHz', 'LMFC rate': '3.840 MHz', 'Link status': 'CGS', 'SYSREF captured': 'Yes', 'SYSREF alignment error': 'No'}, 'b6000000.axi-ad9136-jesd204-tx': {'enabled': 'enabled', 'Measured Link Clock': '184.323 MHz', 'Reported Link Clock': '184.320 MHz', 'Lane rate': '7372.800 MHz', 'Lane rate / 40': '184.320 MHz', 'LMFC rate': '23.040 MHz', 'SYNC~': 'deasserted', 'Link status': 'DATA', 'SYSREF captured': 'disabled', 'SYSREF alignment error': 'disabled'}}
```

**Test Configuration**:
* Hardware: AD9371 on a custom board
* OS: Linux 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [X] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
