### PR TITLE
ADRV9002 split DMA fixes

### DIFF
--- a/adi/adrv9002.py
+++ b/adi/adrv9002.py
@@ -80,7 +80,7 @@ class adrv9002(rx_tx, context_manager):
 
         if len(rxdevs) > 1:
             self._rx_dma_mode = "split"
-            self._rxadc = self._ctx.find_device("axi-adrv9002-rx1-lpc")
+            self._rxadc = self._ctx.find_device("axi-adrv9002-rx-lpc")
             self._rxadc2 = self._ctx.find_device("axi-adrv9002-rx2-lpc")
             self._rx2 = obs(self._ctx, self._rxadc2, self._rx2_channel_names)
             setattr(adrv9002, "rx1", rx1)

--- a/adi/adrv9002.py
+++ b/adi/adrv9002.py
@@ -57,7 +57,7 @@ def tx1(self, data):
 
 def tx2(self, data):
     """tx2: Transmit data on channel 1 """
-    self._tx2.tx()
+    self._tx2.tx(data)
 
 
 class adrv9002(rx_tx, context_manager):
@@ -99,12 +99,13 @@ class adrv9002(rx_tx, context_manager):
 
         if len(txdevs) > 1:
             self._tx_dma_mode = "split"
-            self._txdac = self._ctx.find_device("axi-adrv9002-tx1-lpc")
+            self._txdac = self._ctx.find_device("axi-adrv9002-tx-lpc")
             self._txdac2 = self._ctx.find_device("axi-adrv9002-tx2-lpc")
             self._tx2 = tx_two(self._ctx, self._txdac2, self._tx2_channel_names)
             setattr(adrv9002, "tx1", tx1)
             setattr(adrv9002, "tx2", tx2)
             remap(self._tx2, "tx_", "tx2_", type(self))
+            remap(self._tx2, "dds_", "dds2_", type(self))
 
         else:
             self._tx_dma_mode = "combined"

--- a/adi/obs.py
+++ b/adi/obs.py
@@ -53,18 +53,14 @@ def remap(object_source, old, new, classname):
     method_list = [
         func
         for func in dir(object_source)
-        if (getattr(object_source, func))
-        and not func.startswith("__")
-        and not func.startswith("_")
+        if not func.startswith("__") and not func.startswith("_")
     ]
     for method in method_list:
         if old not in method:
             continue
         new_method = method.replace(old, new)
         setattr(
-            classname,
-            new_method,
-            _property_remap(method, object_source),
+            classname, new_method, _property_remap(method, object_source),
         )
 
 

--- a/adi/obs.py
+++ b/adi/obs.py
@@ -58,9 +58,13 @@ def remap(object_source, old, new, classname):
         and not func.startswith("_")
     ]
     for method in method_list:
+        if old not in method:
+            continue
         new_method = method.replace(old, new)
         setattr(
-            classname, new_method, _property_remap(method, object_source),
+            classname,
+            new_method,
+            _property_remap(method, object_source),
         )
 
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/analogdevicesinc/pyadi-iio",
-    packages=setuptools.find_packages(exclude=['test*']),
+    packages=setuptools.find_packages(exclude=["test*"]),
     python_requires=">=3.6",
     install_requires=["numpy", "pylibiio"],
     extras_require={"jesd": ["fs.sshfs"]},

--- a/test/test_adrv9002_p.py
+++ b/test/test_adrv9002_p.py
@@ -364,3 +364,31 @@ def test_adrv9002_rx_data(test_dma_rx, iio_uri, classname, channel):
 )
 def test_adrv9002_cw_loopback(test_cw_loopback, iio_uri, classname, channel, param_set):
     test_cw_loopback(iio_uri, classname, channel, param_set)
+
+
+#########################################
+@pytest.mark.iio_hardware(hardware)
+@pytest.mark.parametrize("classname", [(classname)])
+@pytest.mark.parametrize("channel", [0])
+@pytest.mark.parametrize(
+    "param_set",
+    [
+        dict(
+            tx0_lo=1000000000,
+            rx0_lo=1000000000,
+            tx1_lo=1000000000,
+            rx1_lo=1000000000,
+            rx_ensm_mode_chan0="rf_enabled",
+            rx_ensm_mode_chan1="rf_enabled",
+            tx_hardwaregain_chan0=-20,
+            tx_hardwaregain_chan1=-20,
+            tx_ensm_mode_chan0="rf_enabled",
+            tx_ensm_mode_chan1="rf_enabled",
+        )
+    ],
+)
+@pytest.mark.parametrize("use_tx2rx2", [False, True])
+def test_adrv9002_cw_loopback_split_dma(
+    test_cw_loopback, iio_uri, classname, channel, param_set, use_tx2rx2
+):
+    test_cw_loopback(iio_uri, classname, channel, param_set, use_tx2rx2, use_tx2rx2)


### PR DESCRIPTION
# Description

This PR address some issues with the split DMA case on ADRV9002. DDSs and TX pointers were getting duplicated causing all data to go to TX2.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

New test cases have been added to specifically handle split DMA

- [ ] test_adrv9002_cw_loopback_split_dma

**Test Configuration**:
* Hardware: ADRV9002+ZCU102
* OS: Ubuntu 18.04

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
