### PR TITLE
Adxrs290 support

### DIFF
--- a/adi/adxrs290.py
+++ b/adi/adxrs290.py
@@ -1,0 +1,116 @@
+# Copyright (C) 2020 Analog Devices, Inc.
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#     - Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     - Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#     - Neither the name of Analog Devices, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#     - The use of this software may or may not infringe the patent rights
+#       of one or more patent holders.  This license does not release you
+#       from the requirement that you obtain separate licenses from these
+#       patent holders to use this software.
+#     - Use of the software either in source or binary form, must be run
+#       on or directly connected to an Analog Devices Inc. component.
+#
+# THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED.
+#
+# IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, INTELLECTUAL PROPERTY
+# RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import numpy as np
+from adi.attribute import attribute
+from adi.context_manager import context_manager
+from adi.rx_tx import rx
+
+
+class adxrs290(rx, context_manager, attribute):
+    """ ADI ADXRS290 Gyroscope """
+
+    _device_name = "ADXRS290"
+    _rx_data_type = np.int16
+    _rx_unbuffered_data = True
+    _rx_data_si_type = np.float
+
+    def __init__(self, uri=""):
+
+        context_manager.__init__(self, uri, self._device_name)
+        self._ctrl = self._ctx.find_device("adxrs290")
+        self.anglvel_x = self._channel(self._ctrl, "anglvel_x")
+        self.anglvel_y = self._channel(self._ctrl, "anglvel_y")
+        self.temp = self._channel(self._ctrl, "temp")
+        self._rxadc = self._ctx.find_device("adxrs290")
+        self._rx_channel_names = ["anglvel_x", "anglvel_y"]
+        rx.__init__(self)
+
+    @property
+    def hpf_3db_frequency_available(self):
+        """Provides all available high pass filter 3dB frequency settings for the ADXRS290 channels"""
+        return self._get_iio_attr_str(
+            "anglvel_x", "filter_high_pass_3db_frequency_available", False
+        )
+
+    @property
+    def hpf_3db_frequency(self):
+        """ADXRS290 high pass filter 3dB frequency"""
+        # Only need to consider one channel, all others follow
+        return float(
+            self._get_iio_attr_str("anglvel_x", "filter_high_pass_3db_frequency", False)
+        )
+
+    @hpf_3db_frequency.setter
+    def hpf_3db_frequency(self, value):
+        self._set_iio_attr(
+            "anglvel_x", "filter_high_pass_3db_frequency", False, str(float(value))
+        )
+
+    @property
+    def lpf_3db_frequency_available(self):
+        """Provides all available low pass filter 3dB frequency settings for the ADXRS290 channels"""
+        return self._get_iio_attr_str(
+            "anglvel_x", "filter_low_pass_3db_frequency_available", False
+        )
+
+    @property
+    def lpf_3db_frequency(self):
+        """ADXRS290 low pass filter 3dB frequency"""
+        # Only need to consider one channel, all others follow
+        return float(
+            self._get_iio_attr_str("anglvel_x", "filter_low_pass_3db_frequency", False)
+        )
+
+    @lpf_3db_frequency.setter
+    def lpf_3db_frequency(self, value):
+        self._set_iio_attr(
+            "anglvel_x", "filter_low_pass_3db_frequency", False, str(float(value))
+        )
+
+    class _channel(attribute):
+        """ADXRS290 channel"""
+
+        def __init__(self, ctrl, channel_name):
+            self.name = channel_name
+            self._ctrl = ctrl
+
+        @property
+        def raw(self):
+            """ADXRS290 channel raw value"""
+            return self._get_iio_attr(self.name, "raw", False)
+
+        @property
+        def scale(self):
+            """ADXRS290 channel scale(gain)"""
+            return float(self._get_iio_attr_str(self.name, "scale", False))

--- a/doc/source/devices/adi.adxrs290.rst
+++ b/doc/source/devices/adi.adxrs290.rst
@@ -1,0 +1,9 @@
+adxrs290
+==================
+
+.. automodule:: adi.adxrs290
+   :members:
+   :undoc-members:
+   :show-inheritance:
+.. autoclass:: adi.adxrs290::adxrs290._channel
+   :members:

--- a/doc/source/devices/index.rst
+++ b/doc/source/devices/index.rst
@@ -29,6 +29,7 @@ Supported Devices
    adi.adxl345
    adi.cn0532
    adi.cn0540
+   adi.adxrs290
    adi.daq2
    adi.daq3
    adi.fmclidar1

--- a/examples/adxrs290.py
+++ b/examples/adxrs290.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Analog Devices, Inc.
+# Copyright (C) 2020 Analog Devices, Inc.
 #
 # All rights reserved.
 #
@@ -31,66 +31,40 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from adi.ad936x import ad9361, ad9363, ad9364, Pluto
+import time
 
-from adi.fmcomms5 import FMComms5
+import adi
 
-from adi.ad9371 import ad9371
+# Set up ADXRS290
+mygyro = adi.adxrs290(uri="ip:192.168.1.7")
 
-from adi.adrv9002 import adrv9002
+hpf = mygyro.hpf_3db_frequency_available
+print("High pass filter 3D frequencies available:")
+print(hpf)
 
-from adi.adrv9009 import adrv9009
+lpf = mygyro.lpf_3db_frequency_available
+print("Low pass filter 3D frequencies available:")
+print(lpf)
 
-from adi.adrv9009_zu11eg import adrv9009_zu11eg
+print("\nX Angular Velocity: " + str(mygyro.anglvel_x.raw))
+print("Y Angular Velocity: " + str(mygyro.anglvel_y.raw))
+print("Chip Temperature: " + str(mygyro.temp.raw))
 
-from adi.adrv9009_zu11eg_multi import adrv9009_zu11eg_multi
+# Setting and Reading the band pass filter
+mygyro.hpf_3db_frequency = 0.044000
+print("High pass filter 3D frequency: " + str(mygyro.hpf_3db_frequency))
+mygyro.lpf_3db_frequency = 160.000000
+print("Low pass filter 3D frequency: " + str(mygyro.lpf_3db_frequency))
 
-from adi.adrv9009_zu11eg_fmcomms8 import adrv9009_zu11eg_fmcomms8
+# Read using RX.
+mygyro.rx_output_type = "SI"
+mygyro.rx_buffer_size = 4
+mygyro.rx_enabled_channels = [0, 1]
+print("\nData using unbuffered rx(), SI (rad/s):")
+print(mygyro.rx())
 
-from adi.ad9081 import ad9081
+mygyro.rx_output_type = "raw"
+print("\nData using unbuffered rx(), raw:")
+print(mygyro.rx())
 
-from adi.ad9081_mc import ad9081_mc, QuadMxFE
-
-from adi.ad9094 import ad9094
-
-from adi.ad9680 import ad9680
-
-from adi.ad9144 import ad9144
-
-from adi.ad9152 import ad9152
-
-from adi.cn0532 import cn0532
-
-from adi.daq2 import DAQ2
-
-from adi.daq3 import DAQ3
-
-from adi.adis16460 import adis16460
-
-from adi.adis16507 import adis16507
-
-from adi.ad7124 import ad7124
-
-from adi.adxl345 import adxl345
-
-from adi.adxrs290 import adxrs290
-
-from adi.fmclidar1 import fmclidar1
-
-from adi.ad5686 import ad5686
-
-from adi.adar1000 import adar1000, adar1000_array
-
-from adi.ltc2983 import ltc2983
-
-from adi.one_bit_adc_dac import one_bit_adc_dac
-
-from adi.ltc2314_14 import ltc2314_14
-
-try:
-    from adi.jesd import jesd
-except ImportError:
-    pass
-
-__version__ = "0.0.8"
-name = "Analog Devices Hardware Interfaces"
+del mygyro

--- a/examples/adxrs290.py
+++ b/examples/adxrs290.py
@@ -31,20 +31,24 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import time
+from typing import List
 
 import adi
+import matplotlib.animation as animation
+import matplotlib.pyplot as plt
+import numpy as np
 
-# Set up ADXRS290
-mygyro = adi.adxrs290(uri="ip:192.168.1.7")
+# Set enable_plot to True if you want to plot in real-time
+enable_plot = True
 
-hpf = mygyro.hpf_3db_frequency_available
-print("High pass filter 3D frequencies available:")
-print(hpf)
+# Set up ADXRS290. Use correct URI.
 
-lpf = mygyro.lpf_3db_frequency_available
-print("Low pass filter 3D frequencies available:")
-print(lpf)
+# Use this with Raspberry Pi from a computer on the same network
+# and make sure to use the correct IP of the  RPI.
+# mygyro = adi.adxrs290(uri="ip:192.168.50.10")
+
+# Use this with ADICUP3029 and make sure to use the correct com port.
+mygyro = adi.adxrs290(uri="serial:COM26")
 
 print("\nX Angular Velocity: " + str(mygyro.anglvel_x.raw))
 print("Y Angular Velocity: " + str(mygyro.anglvel_y.raw))
@@ -58,7 +62,7 @@ print("Low pass filter 3D frequency: " + str(mygyro.lpf_3db_frequency))
 
 # Read using RX.
 mygyro.rx_output_type = "SI"
-mygyro.rx_buffer_size = 4
+mygyro.rx_buffer_size = 10
 mygyro.rx_enabled_channels = [0, 1]
 print("\nData using unbuffered rx(), SI (rad/s):")
 print(mygyro.rx())
@@ -66,5 +70,49 @@ print(mygyro.rx())
 mygyro.rx_output_type = "raw"
 print("\nData using unbuffered rx(), raw:")
 print(mygyro.rx())
+
+if enable_plot:
+
+    # Create figure for plotting
+    fig = plt.figure()
+    ax = fig.add_subplot(1, 1, 1)
+    xs: List[float] = []
+    ys: List[float] = []
+
+    # Set output type to SI
+    mygyro.rx_output_type = "SI"
+
+    def animate(i, xs, ys):
+        """Function called to animate in real time using SI"""
+
+        # Getting unbuffered rx() data, SI
+        # Continuously adding streams of x and y to lists
+        xs.extend(mygyro.rx()[0])  # X Angular Velocity
+        ys.extend(mygyro.rx()[1])  # Y Angular Velocity
+
+        # Limit x and y lists to 200 items
+        xs = xs[-200:]
+        ys = ys[-200:]
+
+        # Draw x and y lists
+        ax.clear()
+        ax.set_ylim([-5, 5])
+        ax.plot(xs, label="X Angular Velocity", linewidth=2.0)
+        ax.plot(ys, label="Y Angular Velocity", linewidth=2.0)
+
+        # Format plot
+        plt.title("ADXRS290 Angular Velocity Plot", fontweight="bold")
+        plt.ylabel("Angular Velocity (rad/s)")
+        plt.subplots_adjust(bottom=0.30)
+        plt.tick_params(
+            axis="x", which="both", bottom=True, top=False, labelbottom=False
+        )
+        plt.legend(
+            bbox_to_anchor=[0.5, -0.1], ncol=2, loc="upper center", frameon=False
+        )
+
+    # Set up plot to call animate() function periodically
+    ani = animation.FuncAnimation(fig, animate, fargs=(xs, ys), interval=10)
+    plt.show()
 
 del mygyro

--- a/examples/requirements_adiplot.txt
+++ b/examples/requirements_adiplot.txt
@@ -1,3 +1,4 @@
 pyqtgraph
 scipy
 PyQt5
+matplotlib


### PR DESCRIPTION
# Description

This is the ADXRS290 support for the Pyadi-iio. This support includes an example which can be use with the serial backend assuming that the serial uri is correctly set. The serial backend support for the adxrs290 has been tested to work with libiio starting with 0.21 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How has this been tested?

The feature has been verified by running the examples on both adxrs290 attached to the ADICUP3029 and Raspberry pi.

- [ X] Change the URI in the example to use the uri of the actual device. Then run the example. The example should show a realtime plot. The X and Y should respond to the motion of the ADXRS290.

**Test Configuration**:
* Hardware: ADICUP3029 +EVAL-ADXRS290-PMDZ and Raspberry PI 3B + EVAL-ADXRS290-PMDZ
* OS: Windows 10

# Documentation

The documentation for the ADXRS290 has been updated and included in the ToC.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
