### PR TITLE
Added pyadi-iio support files for AD7606 devices

### DIFF
--- a/adi/ad7606.py
+++ b/adi/ad7606.py
@@ -1,0 +1,160 @@
+# Copyright (C) 2021 Analog Devices, Inc.
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#     - Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     - Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#     - Neither the name of Analog Devices, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#     - The use of this software may or may not infringe the patent rights
+#       of one or more patent holders.  This license does not release you
+#       from the requirement that you obtain separate licenses from these
+#       patent holders to use this software.
+#     - Use of the software either in source or binary form, must be run
+#       on or directly connected to an Analog Devices Inc. component.
+#
+# THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED.
+#
+# IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, INTELLECTUAL PROPERTY
+# RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+import numpy as np
+from adi.attribute import attribute
+from adi.context_manager import context_manager
+from adi.rx_tx import rx
+from decimal import Decimal
+
+
+class ad7606(rx, context_manager):
+    """ AD7606 ADC """
+
+    _complex_data = False
+    channel = []  # type: ignore
+    _device_name = ""
+
+    def __init__(self, uri="", device_name=""):
+
+        context_manager.__init__(self, uri, self._device_name)
+
+        compatible_parts = ["ad7605-4", "ad7606-4", "ad7606-6", "ad7606-8", "ad7606b", "ad7616"]
+
+        self._ctrl = None
+
+        if not device_name:
+            device_name = compatible_parts[0]
+        else:
+            if device_name not in compatible_parts:
+                raise Exception("Not a compatible device: " + device_name)
+
+        # Select the device matching device_name as working device
+        for device in self._ctx.devices:
+            if device.name == device_name:
+                self._ctrl = device
+                self._rxadc = device
+                break
+
+        for ch in self._ctrl._channels:
+            name = ch._id
+            self._rx_channel_names.append(name)
+            self.channel.append(self._channel(self._ctrl, name))
+
+        rx.__init__(self)
+
+    def rx(self):
+        sig = super().rx()
+
+        if (
+            self._rx_unbuffered_data
+            or self._complex_data
+            or self.rx_output_type == "raw"
+        ):
+            return sig
+        else:
+            mv_sig = []
+
+            for signal in sig:
+                mv_sig.append(signal / 1000)
+
+            return mv_sig
+
+    @property
+    def scale_available(self):
+        """Provides all available scale settings for the AD7606 channels"""
+        return self._get_iio_attr(self.channel[0].name, "scale_available", False)
+
+    @property
+    def range_available(self):
+        """Provides all available range settings for the AD7606 channels"""
+        return self._get_iio_attr(self.channel[0].name, "range_available", False)
+
+    @property
+    def oversampling_ratio(self):
+        """AD7606 oversampling_ratio"""
+        return self._get_iio_attr(self.name, "oversampling_ratio", False)
+
+    @oversampling_ratio.setter
+    def oversampling_ratio(self, value):
+        self._get_iio_attr(self.name, "oversampling_ratio", False, value)
+
+    @property
+    def oversampling_ratio_available(self):
+        """AD7606 channel oversampling_ratio_available"""
+        return self._get_iio_attr(self.name, "oversampling_ratio_available", False)
+
+    class _channel(attribute):
+        """AD7606 channel"""
+
+        def __init__(self, ctrl, channel_name):
+            self.name = channel_name
+            self._ctrl = ctrl
+
+        @property
+        def raw(self):
+            """AD7606 channel raw value"""
+            return self._get_iio_attr(self.name, "raw", False)
+
+        @property
+        def scale(self):
+            """AD7606 channel scale"""
+            return float(self._get_iio_attr_str(self.name, "scale", False))
+
+        @scale.setter
+        def scale(self, value):
+            self._set_iio_attr(self.name, "scale", False, str(Decimal(value).real))
+
+        @property
+        def range(self):
+            """AD7606 channel range"""
+            return self._get_iio_attr(self.name, "range", False)
+
+        @range.setter
+        def range(self, value):
+            self._set_iio_attr(self.name, "range", False, str(Decimal(value).real))
+
+    def to_volts(self, index, val):
+        """Converts raw value to SI"""
+        _scale = self.channel[index].scale
+
+        ret = None
+
+        if isinstance(val, np.int16):
+            ret = val * _scale
+
+        if isinstance(val, np.ndarray):
+            ret = [x * _scale for x in val]
+
+        return ret

--- a/doc/source/devices/adi.ad7606.rst
+++ b/doc/source/devices/adi.ad7606.rst
@@ -1,0 +1,7 @@
+ad7606
+=================
+
+.. automodule:: adi.ad7606
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/source/devices/index.rst
+++ b/doc/source/devices/index.rst
@@ -29,7 +29,6 @@ Supported Devices
    adi.adxl345
    adi.cn0532
    adi.cn0540
-   adi.adxrs290
    adi.daq2
    adi.daq3
    adi.fmclidar1
@@ -38,3 +37,4 @@ Supported Devices
    adi.ltc2314_14
    adi.ltc2983
    adi.one_bit_adc_dac
+   adi.ad7606

--- a/examples/ad7606.py
+++ b/examples/ad7606.py
@@ -31,66 +31,24 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from adi.ad936x import ad9361, ad9363, ad9364, Pluto
+import adi
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy import signal
 
-from adi.fmcomms5 import FMComms5
+# Set up AD7606
+ad7606 = adi.ad7606(uri="ip:analog")
+ad_channel = 0
 
-from adi.ad9371 import ad9371
+sc = ad7606.scale_available
 
-from adi.adrv9002 import adrv9002
+ad7606.channel[ad_channel].scale = sc[-1]  # get highest range
+ad7606.rx_output_type = "SI"
 
-from adi.adrv9009 import adrv9009
+ad7606.rx_enabled_channels = [ad_channel]
+ad7606.rx_buffer_size = 100
 
-from adi.adrv9009_zu11eg import adrv9009_zu11eg
+raw = ad7606.channel[0].raw
+data = ad7606.rx()
 
-from adi.adrv9009_zu11eg_multi import adrv9009_zu11eg_multi
-
-from adi.adrv9009_zu11eg_fmcomms8 import adrv9009_zu11eg_fmcomms8
-
-from adi.ad9081 import ad9081
-
-from adi.ad9081_mc import ad9081_mc, QuadMxFE
-
-from adi.ad9094 import ad9094
-
-from adi.ad9680 import ad9680
-
-from adi.ad9144 import ad9144
-
-from adi.ad9152 import ad9152
-
-from adi.cn0532 import cn0532
-
-from adi.daq2 import DAQ2
-
-from adi.daq3 import DAQ3
-
-from adi.adis16460 import adis16460
-
-from adi.adis16507 import adis16507
-
-from adi.ad7124 import ad7124
-
-from adi.adxl345 import adxl345
-
-from adi.fmclidar1 import fmclidar1
-
-from adi.ad5686 import ad5686
-
-from adi.adar1000 import adar1000, adar1000_array
-
-from adi.ltc2983 import ltc2983
-
-from adi.one_bit_adc_dac import one_bit_adc_dac
-
-from adi.ltc2314_14 import ltc2314_14
-
-from adi.ad7606 import *
-
-try:
-    from adi.jesd import jesd
-except ImportError:
-    pass
-
-__version__ = "0.0.8"
-name = "Analog Devices Hardware Interfaces"
+print(data)

--- a/supported_parts.md
+++ b/supported_parts.md
@@ -67,3 +67,4 @@
 - FMCLIDAR1
 - FMComms8
 - LTC2983
+- AD7606


### PR DESCRIPTION
Signed-off-by: mahphalke <Mahesh.Phalke@analog.com>

# Description
1) Defined ad7606 attribute and channel class through ad7606.py file from 'adi' directory.
2) The list of iio attributes is derived from linux drivers: https://wiki.analog.com/resources/tools-software/linux-drivers/iio-adc/ad7606.
3) Added other supported files (e.g. examples/ad7606.py, .rst, supported_parts.md)

Fixes # (issue)

## Type of change
- [ ] New feature (non-breaking change which adds functionality)

# How has this been tested?
Testing of ad7606.py file has been done through my local IIO based firmware application running on ARM processor.
https://wiki.analog.com/resources/tools-software/product-support-software/ad7606_mbed_iio_application

**Test Configuration**:
* Hardware: AD7606B Eval Board
* OS: Windows

# Documentation

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have signed off all commits and they contain "Signed-off by: <Mahesh.Phalke@analog.com>"
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
