### PR TITLE
examples/adxrs290.py:: Changed the HPF's and LPF's 3dB frequencies

### DIFF
--- a/examples/adxrs290.py
+++ b/examples/adxrs290.py
@@ -55,9 +55,9 @@ print("Y Angular Velocity: " + str(mygyro.anglvel_y.raw))
 print("Chip Temperature: " + str(mygyro.temp.raw))
 
 # Setting and Reading the band pass filter
-mygyro.hpf_3db_frequency = 0.044000
+mygyro.hpf_3db_frequency = 0.000000
 print("High pass filter 3D frequency: " + str(mygyro.hpf_3db_frequency))
-mygyro.lpf_3db_frequency = 160.000000
+mygyro.lpf_3db_frequency = 480.000000
 print("Low pass filter 3D frequency: " + str(mygyro.lpf_3db_frequency))
 
 # Read using RX.


### PR DESCRIPTION
# Description

Changed the mygyro.hpf_3db_frequency to 0Hz and the mygyro.lpf_3db_frequency to 480Hz according to ADXRS290's datasheet.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

Signed-off-by: Hannah Rosete <Hannah.Rosete@analog.com>
