### PR TITLE
Update CN0540 to use strings for fda_mode

### DIFF
--- a/adi/cn0540.py
+++ b/adi/cn0540.py
@@ -165,9 +165,11 @@ class cn0540(rx, context_manager):
 
     @fda_mode.setter
     def fda_mode(self, value):
-        if value not in ['full-power','low-power']:
-            raise Exception('fda_mode must be low-power or full-power')
-        self._set_iio_attr_int("voltage6", "raw", True, int(value=='full-power'), self._gpio)
+        if value not in ["full-power", "low-power"]:
+            raise Exception("fda_mode must be low-power or full-power")
+        self._set_iio_attr_int(
+            "voltage6", "raw", True, int(value == "full-power"), self._gpio
+        )
 
     @property
     def red_led_enable(self):

--- a/adi/cn0540.py
+++ b/adi/cn0540.py
@@ -165,7 +165,9 @@ class cn0540(rx, context_manager):
 
     @fda_mode.setter
     def fda_mode(self, value):
-        self._set_iio_attr_int("voltage6", "raw", True, value, self._gpio)
+        if value not in ['full-power','low-power']:
+            raise Exception('fda_mode must be low-power or full-power')
+        self._set_iio_attr_int("voltage6", "raw", True, int(value=='full-power'), self._gpio)
 
     @property
     def red_led_enable(self):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -7,8 +7,8 @@ from test.common import (
     pytest_addoption,
     pytest_collection_modifyitems,
     pytest_configure,
-    pytest_runtest_setup,
     pytest_generate_tests,
+    pytest_runtest_setup,
 )
 from test.dma_tests import *
 from test.generics import iio_attribute_single_value


### PR DESCRIPTION
Signed-off-by: Travis F. Collins <travis.collins@analog.com>

# Description

API update for CN0540 to use strings instead of booleans.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:
* Hardware: CN0549+DE10
* OS: Ubuntu 18.04 (Host). Kuiper (Embedded)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
