### PR TITLE
ad7746 example

### DIFF
--- a/examples/ad7746.py
+++ b/examples/ad7746.py
@@ -1,0 +1,91 @@
+# Copyright (C) 2021 Analog Devices, Inc.
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#     - Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     - Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#     - Neither the name of Analog Devices, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#     - The use of this software may or may not infringe the patent rights
+#       of one or more patent holders.  This license does not release you
+#       from the requirement that you obtain separate licenses from these
+#       patent holders to use this software.
+#     - Use of the software either in source or binary form, must be run
+#       on or directly connected to an Analog Devices Inc. component.
+#
+# THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED.
+#
+# IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, INTELLECTUAL PROPERTY
+# RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import adi
+
+VIN = "voltage0"
+VIN_VDD = "voltage1"
+TEMP_INT = "temp0"
+TEMP_EXT = "temp1"
+CIN1 = "capacitance0"
+CIN1_DIFF = "capacitance0-capacitance2"
+CIN2 = "capacitance1"
+CIN2_DIFF = "capacitance1-capacitance3"
+
+
+def cap_attributes(dev, ch):
+    print(ch)
+    val = dev.channel[ch].raw
+    print("\traw: {}".format(val))
+    val = dev.channel[ch].scale
+    print("\tscale: {}".format(val))
+    val = dev.channel[ch].sampling_frequency
+    print("\tsampling_frequency: {}".format(val))
+    val = dev.channel[ch].sampling_frequency_available
+    print("\tsampling_frequency_available: {}".format(val))
+    val = dev.channel[ch].calibbias
+    print("\tcalibbias: {}".format(val))
+    val = dev.channel[ch].calibscale
+    print("\tcalibscale: {}".format(val))
+
+
+# Set up AD7746
+dev = adi.ad7746(uri="serial:/dev/ttyACM0,115200,8n1", device_name="ad7746")
+# dev = adi.ad7746(uri="ip:192.168.1.10", device_name="ad7746")
+
+cap_attributes(dev, CIN1)
+cap_attributes(dev, CIN1_DIFF)
+cap_attributes(dev, CIN2)
+cap_attributes(dev, CIN2_DIFF)
+
+print("Changing sampling frequency to 50")
+dev.channel[CIN1].sampling_frequency = 50
+
+print("Changing calibbias to 12345")
+dev.channel[CIN1].calibbias = 12345
+
+print("Changing calibscale to 1.5")
+dev.channel[CIN1].calibscale = 1.5
+
+cap_attributes(dev, CIN1)
+cap_attributes(dev, CIN1_DIFF)
+cap_attributes(dev, CIN2)
+cap_attributes(dev, CIN2_DIFF)
+
+print("Calibbias calibration...")
+dev.channel[CIN1].calibbias_calibration()
+print("Calibscale calibration...")
+dev.channel[CIN1].calibscale_calibration()
+
+print("Temperature (internal): {}".format(dev.channel[TEMP_INT].input))
+print("Temperature (external): {}".format(dev.channel[TEMP_EXT].input))


### PR DESCRIPTION
# Description

Add a generic example file for ad7746.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ x] Test A

**Test Configuration**:
* Hardware: ADICUP3029 + CN0552 (connected via the PMOD connector)
* OS: no-OS
```
python examples/ad7746.py 
Found device ad7746
capacitance0
	raw: 31104
	scale: 4.88e-07
	sampling_frequency: 91
	sampling_frequency_available: [91, 84, 50, 26, 16, 13, 11, 9]
	calibbias: 32768
	calibscale: 1.425064
capacitance0-capacitance2
	raw: 10368
	scale: 4.88e-07
	sampling_frequency: 91
	sampling_frequency_available: [91, 84, 50, 26, 16, 13, 11, 9]
	calibbias: 32768
	calibscale: 1.425064
capacitance1
	raw: 38528
	scale: 4.88e-07
	sampling_frequency: 91
	sampling_frequency_available: [91, 84, 50, 26, 16, 13, 11, 9]
	calibbias: 32768
	calibscale: 1.425064
capacitance1-capacitance3
	raw: 30848
	scale: 4.88e-07
	sampling_frequency: 91
	sampling_frequency_available: [91, 84, 50, 26, 16, 13, 11, 9]
	calibbias: 32768
	calibscale: 1.425064
Changing sampling frequency to 50
Changing calibbias to 12345
Changing calibscale to 1.5
capacitance0
	raw: 1013391
	scale: 4.88e-07
	sampling_frequency: 50
	sampling_frequency_available: [91, 84, 50, 26, 16, 13, 11, 9]
	calibbias: 12345
	calibscale: 1.5
capacitance0-capacitance2
	raw: 991119
	scale: 4.88e-07
	sampling_frequency: 50
	sampling_frequency_available: [91, 84, 50, 26, 16, 13, 11, 9]
	calibbias: 12345
	calibscale: 1.5
capacitance1
	raw: 1021327
	scale: 4.88e-07
	sampling_frequency: 50
	sampling_frequency_available: [91, 84, 50, 26, 16, 13, 11, 9]
	calibbias: 12345
	calibscale: 1.5
capacitance1-capacitance3
	raw: 1013391
	scale: 4.88e-07
	sampling_frequency: 50
	sampling_frequency_available: [91, 84, 50, 26, 16, 13, 11, 9]
	calibbias: 12345
	calibscale: 1.5
Calibbias calibration...
Calibscale calibration...
Temperature (internal): 27312
Temperature (external): -250191
```

# Documentation

If this is a new feature or example please mention or link any documentation. All new hardware interface classes require documentation.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
