### PR TITLE
Multi type buffer

### DIFF
--- a/adi/rx_tx.py
+++ b/adi/rx_tx.py
@@ -194,7 +194,7 @@ class rx(attribute):
         sig = []
         for indx, chan_bytes in enumerate(channel_bytes):
             bar = bytearray()
-            for bytesI in range(offset, self.__rx_buffer_size, stride):
+            for bytesI in range(offset, len(data), stride):
                 bar.extend(data[bytesI : bytesI + chan_bytes])
 
             sig.append(np.frombuffer(bar, dtype=self._rx_data_type[indx]))

--- a/adi/rx_tx.py
+++ b/adi/rx_tx.py
@@ -188,7 +188,11 @@ class rx(attribute):
     def __multi_type_rx(self, data):
         """Process buffers with multiple data types"""
         # Process each channel at a time
-        channel_bytes = [np.dtype(k).itemsize for k in self._rx_data_type]
+        channel_bytes = []
+        curated_rx_type = []
+        for en_ch in self.rx_enabled_channels:
+            channel_bytes += [np.dtype(self._rx_data_type[en_ch]).itemsize]
+            curated_rx_type += [self._rx_data_type[en_ch]]
         offset = 0
         stride = sum(channel_bytes)
         sig = []
@@ -197,7 +201,7 @@ class rx(attribute):
             for bytesI in range(offset, len(data), stride):
                 bar.extend(data[bytesI : bytesI + chan_bytes])
 
-            sig.append(np.frombuffer(bar, dtype=self._rx_data_type[indx]))
+            sig.append(np.frombuffer(bar, dtype=curated_rx_type[indx]))
             offset += chan_bytes
         return sig
 


### PR DESCRIPTION
# Description

Some fixes to the functionality to read different data type channels from the same device.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Tested with adpd188 class with all channels and timestamp enabled, channels 0, 1 and timestamp enabled and channels 0, 5 and timestamp enabled. Also tested with only the data channels enabled without timestamp.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
