### PR TITLE
Multi type buffer

### DIFF
--- a/adi/rx_tx.py
+++ b/adi/rx_tx.py
@@ -194,7 +194,7 @@ class rx(attribute):
         sig = []
         for indx, chan_bytes in enumerate(channel_bytes):
             bar = bytearray()
-            for bytesI in range(offset, self.__rx_buffer_size, stride):
+            for bytesI in range(offset, len(data), stride):
                 bar.extend(data[bytesI : bytesI + chan_bytes])
 
             sig.append(np.frombuffer(bar, dtype=self._rx_data_type[indx]))

--- a/adi/rx_tx.py
+++ b/adi/rx_tx.py
@@ -188,7 +188,11 @@ class rx(attribute):
     def __multi_type_rx(self, data):
         """Process buffers with multiple data types"""
         # Process each channel at a time
-        channel_bytes = [np.dtype(k).itemsize for k in self._rx_data_type]
+        channel_bytes = []
+        curated_rx_type = []
+        for en_ch in self.rx_enabled_channels:
+            channel_bytes += [np.dtype(self._rx_data_type[en_ch]).itemsize]
+            curated_rx_type += [self._rx_data_type[en_ch]]
         offset = 0
         stride = sum(channel_bytes)
         sig = []
@@ -197,7 +201,7 @@ class rx(attribute):
             for bytesI in range(offset, len(data), stride):
                 bar.extend(data[bytesI : bytesI + chan_bytes])
 
-            sig.append(np.frombuffer(bar, dtype=self._rx_data_type[indx]))
+            sig.append(np.frombuffer(bar, dtype=curated_rx_type[indx]))
             offset += chan_bytes
         return sig
 


### PR DESCRIPTION
# Description

This PR adds support for buffers with mixed types such as the ADPD188BI or any device with a timestamp.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How has this been tested?

This was tested with the ADPD188BI evaluation board.

**Test Configuration**:
* Hardware: ADPD188BI
* OS: Ubuntu 18.04


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
