### PR TITLE
Add automatic handling of SPI engine state

### DIFF
--- a/.github/scripts/install_libiio.sh
+++ b/.github/scripts/install_libiio.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 sudo apt-get -qq update
-sudo apt-get install -y git cmake graphviz libaio-dev libusb-1.0-0-dev libxml2-dev rpm tar bzip2 gzip flex bison git
-git clone -b 'v0.21' --single-branch --depth 1 https://github.com/analogdevicesinc/libiio.git
+sudo apt-get install -y git cmake graphviz libavahi-common-dev libavahi-client-dev libaio-dev libusb-1.0-0-dev libxml2-dev rpm tar bzip2 gzip flex bison git
+git clone -b 'master' --single-branch --depth 1 https://github.com/analogdevicesinc/libiio.git
 cd libiio
-cmake .
+cmake . -DHAVE_DNS_SD=OFF
 make
 sudo make install
 cd ..

--- a/adi/cn0540.py
+++ b/adi/cn0540.py
@@ -38,8 +38,21 @@ from adi.context_manager import context_manager
 from adi.rx_tx import rx
 
 
+def reset_buffer(func):
+    """Wrapper for set calls which require the SPI engine.
+    Without disabling the buffer the DMA would block forever
+    """
+
+    def wrapper(*args, **kwargs):
+        if args[0]._reset_on_spi_writes:
+            args[0].rx_destroy_buffer()
+        func(*args, **kwargs)
+
+    return wrapper
+
+
 class cn0540(rx, context_manager):
-    """ CN0540 CBM DAQ Board """
+    """CN0540 CBM DAQ Board"""
 
     _rx_data_type = np.int32
     _rx_data_si_type = np.float
@@ -52,6 +65,7 @@ class cn0540(rx, context_manager):
     _g = 0.3
     _fda_gain = 2.667
     _fda_vocm_mv = 2500
+    _reset_on_spi_writes = True
 
     def __init__(self, uri=""):
 
@@ -65,8 +79,9 @@ class cn0540(rx, context_manager):
 
         rx.__init__(self)
 
+    @reset_buffer
     def calibrate(self):
-        """ Tune LTC2606 to make AD7768-1 ADC codes zero mean """
+        """Tune LTC2606 to make AD7768-1 ADC codes zero mean"""
         adc_chan = self._rxadc
         dac_chan = self._ltc2606
         adc_scale = float(self._get_iio_attr("voltage0", "scale", False, adc_chan))
@@ -93,12 +108,13 @@ class cn0540(rx, context_manager):
         return self._get_iio_dev_attr("sampling_frequency")
 
     @sample_rate.setter
+    @reset_buffer
     def sample_rate(self, value):
         self._set_iio_dev_attr_str("sampling_frequency", value)
 
     @property
     def input_voltage(self):
-        """input_voltage: Input voltage in mV from ADC before shift voltage applied """
+        """input_voltage: Input voltage in mV from ADC before shift voltage applied"""
         adc_chan = self._rxadc
         adc_scale = float(self._get_iio_attr("voltage0", "scale", False, adc_chan))
         raw = self._get_iio_attr("voltage0", "raw", False, adc_chan)
@@ -106,13 +122,14 @@ class cn0540(rx, context_manager):
 
     @property
     def shift_voltage(self):
-        """shift_voltage: Shift voltage in mV from LTC2606 to bias sensor data """
+        """shift_voltage: Shift voltage in mV from LTC2606 to bias sensor data"""
         dac_chan = self._ltc2606
         dac_scale = float(self._get_iio_attr("voltage0", "scale", True, dac_chan))
         raw = self._get_iio_attr("voltage0", "raw", True, dac_chan)
         return raw * dac_scale * self._dac_buffer_gain
 
     @shift_voltage.setter
+    @reset_buffer
     def shift_voltage(self, value):
         dac_chan = self._ltc2606
         dac_scale = float(self._get_iio_attr("voltage0", "scale", True, dac_chan))
@@ -121,7 +138,7 @@ class cn0540(rx, context_manager):
 
     @property
     def sensor_voltage(self):
-        """sensor_voltage: Sensor voltage in mV read from ADC after biasing """
+        """sensor_voltage: Sensor voltage in mV read from ADC after biasing"""
         adc_chan = self._rxadc
         adc_scale = float(self._get_iio_attr("voltage0", "scale", False, adc_chan))
         raw = self._get_iio_attr("voltage0", "raw", False, adc_chan)
@@ -135,12 +152,12 @@ class cn0540(rx, context_manager):
 
     @property
     def sw_ff_status(self):
-        """sw_ff_status: Fault flag status """
+        """sw_ff_status: Fault flag status"""
         return self._get_iio_attr("voltage0", "raw", False, self._gpio)
 
     @property
     def monitor_powerup(self):
-        """monitor_powerup: Shutdown pin is tied to active-low inputs """
+        """monitor_powerup: Shutdown pin is tied to active-low inputs"""
         return self._get_iio_attr("voltage2", "raw", True, self._gpio)
 
     @monitor_powerup.setter
@@ -149,16 +166,17 @@ class cn0540(rx, context_manager):
 
     @property
     def fda_disable_status(self):
-        """fda_disable_status: Amplifier disable status """
+        """fda_disable_status: Amplifier disable status"""
         return self._get_iio_attr("voltage5", "raw", True, self._gpio)
 
     @fda_disable_status.setter
+    @reset_buffer
     def fda_disable_status(self, value):
         self._set_iio_attr_int("voltage5", "raw", True, value, self._gpio)
 
     @property
     def fda_mode(self):
-        """fda_mode: Amplifier mode. Options are low-power or full-power """
+        """fda_mode: Amplifier mode. Options are low-power or full-power"""
         return self._fda_mode_options[
             int(self._get_iio_attr("voltage6", "raw", True, self._gpio))
         ]
@@ -173,7 +191,7 @@ class cn0540(rx, context_manager):
 
     @property
     def red_led_enable(self):
-        """red_led_enable: Enable red LED on board """
+        """red_led_enable: Enable red LED on board"""
         return self._get_iio_attr("voltage1", "raw", True, self._gpio)
 
     @red_led_enable.setter


### PR DESCRIPTION
CN0540 which uses the SPI engine will block on rx() calls if a SPI
transation is made, like an update to the sample rate after a buffer has
been created. Decorators were added to the dependent properties to reset
the buffer automatically before the writes are made.

Signed-off-by: Travis F. Collins <travis.collins@analog.com>

# Description

This PR makes CN0540 easier to use.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How has this been tested?

Tested with CN0549 kit.

**Test Configuration**:
* Hardware: CN0540+DE10
* OS: Ubuntu 20.04

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
