### PR TITLE
Production tests for fmcomms 2 and 3

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,3 +12,4 @@ pytest-libiio
 bump2version
 pytest-html
 plotly-express
+pyvisa

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -14,6 +14,7 @@ from test.dma_tests import *
 from test.generics import iio_attribute_single_value
 from test.globals import *
 from test.html import pytest_html_report_title, pytest_runtest_makereport
+from test.scpi import dcxo_calibrate
 
 import adi
 import numpy as np
@@ -127,6 +128,11 @@ def test_hardwaregain(request):
 @pytest.fixture()
 def test_harmonics(request):
     yield harmonic_vals
+
+
+@pytest.fixture()
+def test_dcxo_calibration(request):
+    yield dcxo_calibrate
 
 
 @pytest.fixture()

--- a/test/scpi.py
+++ b/test/scpi.py
@@ -1,0 +1,146 @@
+import time
+
+import iio
+
+import adi
+import numpy as np
+import paramiko
+import pytest
+import pyvisa
+from pyvisa import constants
+
+supported_instruments = ["HAMEG Instruments,HM8123,5.12"]
+
+
+def find_instrument():
+    rm = pyvisa.ResourceManager()
+    all_resources = rm.list_resources()
+    if len(all_resources) == 0:
+        return None
+    for i in range(0, len(all_resources)):
+        my_instrument = rm.open_resource(
+            all_resources[i],
+            baud_rate=9600,
+            data_bits=8,
+            parity=constants.Parity.none,
+            stop_bits=constants.StopBits.one,
+            write_termination="\r",
+            read_termination="\r",
+        )
+
+        try:
+            idn = my_instrument.query("*IDN?")
+            if idn in supported_instruments:
+                break
+            else:
+                print("This instrument is currently not supported!")
+        except Exception as e:
+            my_instrument = None
+            continue
+    return my_instrument
+
+
+def select_channel(instr):
+    idn = instr.query("*IDN?")
+    if idn == "HAMEG Instruments,HM8123,5.12":
+        ch = ["FRA", "FRB", "FRC"]
+        for i in range(0, len(ch)):
+            instr.write(ch[i])
+            time.sleep(3)
+            xmt = instr.query("XMT?")
+            time.sleep(1)
+            if xmt != "Not Available":
+                return xmt
+
+
+def get_freq(instr):
+    # set gate time to 600 for better precision
+    instr.write("SMT600")
+    xmt = select_channel(instr)
+    frq_str = xmt.split(" ", 2)
+    scale = 1
+    if frq_str[1] == "GHz":
+        scale = pow(10, 9)
+    elif frq_str[1] == "MHz":
+        scale = pow(10, 6)
+    elif frq_str[1] == "KHz":
+        scale = pow(10, 3)
+    return float(frq_str[0]) * scale
+
+
+def get_clk_rate(classname, iio_uri):
+    sdr = eval(classname + "(uri='" + iio_uri + "')")
+    sdr._ctrl.debug_attrs["adi,clk-output-mode-select"].value = "1"
+    sdr._ctrl.debug_attrs["initialize"].value = "1"
+
+    full_uri = iio_uri.split(":", 2)
+    if full_uri[0] != "ip":
+        print("Tuning currently supported only for ip URIs")
+    ip = full_uri[1]
+
+    ssh_client = paramiko.SSHClient()
+    ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    ssh_client.connect(ip, username="root", password="analog")
+    ssh_stdin, ssh_stdout, ssh_stderr = ssh_client.exec_command(
+        "cat /sys/kernel/debug/clk/ad9361_ext_refclk/clk_rate"
+    )
+
+    if ssh_stderr.channel.recv_exit_status() != 0:
+        raise paramiko.SSHException("Command did not execute properly")
+
+    clk_rate = ssh_stdout.readline()
+    ssh_client.close()
+    return float(clk_rate)
+
+
+def dcxo_calibrate(classname, iio_uri):
+    prev_diff = 0
+    diff = 0
+    coarse = 0
+    fine = 4095
+    finetune = False
+    step = 1
+    direction = -2
+    instr = find_instrument()
+    if instr is None:
+        pytest.skip("No supported instrument found")
+        return
+    target_frq = get_clk_rate(classname, iio_uri)
+    sdr = eval(classname + "(uri='" + iio_uri + "')")
+
+    sdr._set_iio_dev_attr("dcxo_tune_coarse", coarse, sdr._ctrl)
+    sdr._set_iio_dev_attr("dcxo_tune_fine", fine, sdr._ctrl)
+
+    while 1:
+        current_frq = get_freq(instr)
+
+        prev_diff = diff
+        diff = target_frq - current_frq
+        if round(diff) == 0:
+            print("Close to target value:", current_frq)
+            break
+        if direction == -2:
+            direction = np.sign(diff)
+        if finetune:
+            step = int(round(-1 * diff / 2))
+            if step == 0:
+                step = -1 * direction
+            fine += step
+            fine = int(fine)
+        else:
+            if step != 0:
+                if prev_diff != 0 and prev_diff != diff:
+                    step = int(round(-1 * ((step * diff) / abs(diff - prev_diff)) / 2))
+                coarse += step
+            else:
+                finetune = True
+
+        sdr._set_iio_dev_attr("dcxo_tune_coarse", coarse, sdr._ctrl)
+        sdr._set_iio_dev_attr("dcxo_tune_fine", fine, sdr._ctrl)
+
+        if coarse < 0 or coarse > 63 or fine < 0 or fine > 8191:
+            pytest.fail("Outside tuning bounds")
+            break
+
+    # End clean
+    del sdr

--- a/test/test_fmcomms2-3_p.py
+++ b/test/test_fmcomms2-3_p.py
@@ -1,0 +1,216 @@
+import iio
+
+import adi
+import numpy as np
+import pytest
+
+hardware = ["packrf", "adrv9361", "fmcomms3", "ad9361"]
+classname = "adi.ad9361"
+
+##################################
+@pytest.mark.iio_hardware(hardware)
+@pytest.mark.parametrize(
+    "voltage_raw, low, high",
+    [
+        ("in_temp0", 80, 160),
+        ("in_voltage0", 3045, 3629),
+        ("in_voltage1", 3045, 3629),
+        ("in_voltage2", 3045, 3629),
+        ("in_voltage3", 1231, 1393),
+        ("in_voltage4", 1661, 2749),
+        ("in_voltage5", 1231, 1393),
+    ],
+)
+def test_ad7291(context_desc, voltage_raw, low, high):
+    ctx = None
+    for ctx_desc in context_desc:
+        if ctx_desc["hw"] in hardware:
+            ctx = iio.Context(ctx_desc["uri"])
+    if not ctx:
+        pytest.skip("No valid hardware found")
+
+    ad7291 = ctx.find_device("ad7291")
+
+    for channel in ad7291.channels:
+        c_name = "out" if channel.output else "in"
+        c_name += "_" + str(channel.id)
+        if c_name == voltage_raw:
+            for attr in channel.attrs:
+                if attr == "raw":
+                    try:
+                        print(channel.attrs[attr].value)
+                        assert low <= int(channel.attrs[attr].value) <= high
+                    except OSError:
+                        continue
+
+
+@pytest.mark.iio_hardware(hardware)
+@pytest.mark.parametrize("classname", [(classname)])
+@pytest.mark.parametrize(
+    "attr, start, stop, step, tol, repeats",
+    [
+        ("tx_hardwaregain_chan0", -30.0, -7.0, 0.25, 0, 100),
+        ("tx_hardwaregain_chan1", -30.0, -7.0, 0.25, 0, 100),
+        ("rx_lo", 2300000000, 2500000000, 1, 8, 100),
+        ("tx_lo", 2300000000, 2500000000, 1, 8, 100),
+        ("sample_rate", 30700000, 30740000, 1, 4, 20),
+        ("rx_rf_bandwidth", 16000000, 19000000, 1, 4, 10),
+        ("tx_rf_bandwidth", 16000000, 19000000, 1, 4, 10),
+    ],
+)
+def test_ad9361_attr(
+    test_attribute_single_value,
+    iio_uri,
+    classname,
+    attr,
+    start,
+    stop,
+    step,
+    tol,
+    repeats,
+):
+    test_attribute_single_value(
+        iio_uri, classname, attr, start, stop, step, tol, repeats
+    )
+
+
+@pytest.mark.iio_hardware(hardware)
+@pytest.mark.parametrize("classname", [(classname)])
+@pytest.mark.parametrize("channel", [0, 1])
+@pytest.mark.parametrize(
+    "dds_scale, min_rssi, max_rssi, param_set",
+    [
+        (
+            0.0,
+            75,
+            150,
+            dict(
+                sample_rate=30720000,
+                tx_lo=2300000000,
+                rx_lo=2400000000,
+                gain_control_mode_chan0="slow_attack",
+                gain_control_mode_chan1="slow_attack",
+                rx_rf_bandwidth=18000000,
+                tx_rf_bandwidth=18000000,
+            ),
+        ),
+        (
+            0.4,
+            10,
+            50,
+            dict(
+                gain_control_mode_chan0="slow_attack",
+                gain_control_mode_chan1="slow_attack",
+                rx_lo=2400000000,
+                tx_lo=2400000000,
+                tx_hardwaregain_chan0=-10,
+                tx_hardwaregain_chan1=-10,
+                sample_rate=30720000,
+                rx_rf_bandwidth=18000000,
+                tx_rf_bandwidth=18000000,
+            ),
+        ),
+    ],
+)
+def test_rssi(
+    test_gain_check,
+    iio_uri,
+    classname,
+    channel,
+    param_set,
+    dds_scale,
+    min_rssi,
+    max_rssi,
+):
+    test_gain_check(
+        iio_uri, classname, channel, param_set, dds_scale, min_rssi, max_rssi
+    )
+
+
+@pytest.mark.iio_hardware(hardware)
+@pytest.mark.parametrize("classname", [(classname)])
+@pytest.mark.parametrize("channel", [0, 1])
+@pytest.mark.parametrize(
+    "dds_scale, frequency, hardwaregain_low, hardwaregain_high",
+    [(0.0, 999859, 50, 80), (0.4, 999859, 0.0, 28)],
+)
+def test_hardware_gain(
+    test_hardwaregain,
+    iio_uri,
+    classname,
+    channel,
+    dds_scale,
+    frequency,
+    hardwaregain_low,
+    hardwaregain_high,
+):
+    test_hardwaregain(
+        iio_uri,
+        classname,
+        channel,
+        dds_scale,
+        frequency,
+        hardwaregain_low,
+        hardwaregain_high,
+    )
+
+
+@pytest.mark.iio_hardware(hardware)
+@pytest.mark.parametrize("classname", [(classname)])
+@pytest.mark.parametrize("channel", [0, 1])
+def test_ad9361_loopback(test_dma_loopback, iio_uri, classname, channel):
+    test_dma_loopback(iio_uri, classname, channel)
+
+
+@pytest.mark.iio_hardware(hardware)
+@pytest.mark.parametrize("classname", [(classname)])
+@pytest.mark.parametrize("channel", [0, 1])
+@pytest.mark.parametrize(
+    "param_set",
+    [
+        dict(
+            sample_rate=30720000,
+            tx_lo=2400000000,
+            rx_lo=2400000000,
+            gain_control_mode_chan0="slow_attack",
+            gain_control_mode_chan1="slow_attack",
+            tx_hardwaregain_chan0=-10,
+            tx_hardwaregain_chan1=-10,
+            rx_rf_bandwidth=18000000,
+            tx_rf_bandwidth=18000000,
+        ),
+    ],
+)
+def test_ad9361_iq_loopback(test_iq_loopback, iio_uri, classname, channel, param_set):
+    test_iq_loopback(iio_uri, classname, channel, param_set)
+
+
+@pytest.mark.iio_hardware(hardware)
+@pytest.mark.parametrize("classname", [(classname)])
+def test_dcxo(test_dcxo_calibration, classname, iio_uri):
+    test_dcxo_calibration(classname, iio_uri)
+
+
+@pytest.mark.iio_hardware(hardware)
+@pytest.mark.parametrize("classname", [(classname)])
+@pytest.mark.parametrize("channel", [0, 1])
+@pytest.mark.parametrize(
+    "param_set",
+    [
+        dict(
+            tx_lo=2400000000,
+            rx_lo=2400000000,
+            tx_hardwaregain_chan0=-10,
+            tx_hardwaregain_chan1=-10,
+            sample_rate=30720000,
+        )
+    ],
+)
+@pytest.mark.parametrize(
+    "low, high",
+    [([-20.0, -100.0, -110.0, -110.0, -110.0], [-10.0, -60.0, -75.0, -75.0, -80.0])],
+)
+def test_harmonic_values(
+    test_harmonics, classname, iio_uri, channel, param_set, low, high, plot=False
+):
+    test_harmonics(classname, iio_uri, channel, param_set, low, high, plot)


### PR DESCRIPTION
# Description

Production tests for fmcomms2/3, similar to the test profiles from iio-oscilloscope.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How has this been tested?

**Test Configuration**:
* Hardware: ADRV9361-ZC702
* OS: Ubuntu 20.04

# Documentation

If this is a new feature or example please mention or link any documentation. All new hardware interface classes require documentation.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
