### PR TITLE
Mirror DAQ2's, DAQ3's Manual Tests and Added Support for Pure Real Data in spec.py

### DIFF
--- a/test/rf/spec.py
+++ b/test/rf/spec.py
@@ -1,5 +1,6 @@
 from __future__ import division
 
+import numpy as np
 from numpy import (
     absolute,
     argmax,
@@ -15,7 +16,6 @@ from numpy import (
 from numpy.fft import fft, fftfreq, fftshift
 from scipy import signal
 from scipy.signal import find_peaks
-import numpy as np
 
 
 def spec_est(x, fs, ref=2 ** 15, plot=False):
@@ -35,8 +35,8 @@ def spec_est(x, fs, ref=2 ** 15, plot=False):
 
     # ampl and freqs for real data
     if not np.iscomplexobj(x):
-        ampl = ampl[0:len(ampl) // 2]
-        freqs = freqs[0:len(freqs) // 2]
+        ampl = ampl[0 : len(ampl) // 2]
+        freqs = freqs[0 : len(freqs) // 2]
 
     if plot:
         # Plot signal, showing how endpoints wrap from one chunk to the next
@@ -61,7 +61,7 @@ def spec_est(x, fs, ref=2 ** 15, plot=False):
 def find_peaks_cust(x, num_peaks=4):
 
     loc = argmax(x)
-    print(x[loc: loc + 10])
+    print(x[loc : loc + 10])
     for p in range(1, num_peaks):
         l_loc = loc - 1
         r_loc = loc + 1

--- a/test/rf/spec.py
+++ b/test/rf/spec.py
@@ -55,7 +55,7 @@ def spec_est(x, fs, ref=2 ** 15, plot=False):
 def find_peaks_cust(x, num_peaks=4):
 
     loc = argmax(x)
-    print(x[loc : loc + 10])
+    print(x[loc: loc + 10])
     for p in range(1, num_peaks):
         l_loc = loc - 1
         r_loc = loc + 1

--- a/test/rf/spec.py
+++ b/test/rf/spec.py
@@ -15,6 +15,7 @@ from numpy import (
 from numpy.fft import fft, fftfreq, fftshift
 from scipy import signal
 from scipy.signal import find_peaks
+import numpy as np
 
 
 def spec_est(x, fs, ref=2 ** 15, plot=False):
@@ -31,6 +32,11 @@ def spec_est(x, fs, ref=2 ** 15, plot=False):
 
     # FFT frequency bins
     freqs = fftfreq(N, 1 / fs)
+
+    # ampl and freqs for real data
+    if not np.iscomplexobj(x):
+        ampl = ampl[0:len(ampl) // 2]
+        freqs = freqs[0:len(freqs) // 2]
 
     if plot:
         # Plot signal, showing how endpoints wrap from one chunk to the next

--- a/test/test_daq2_p.py
+++ b/test/test_daq2_p.py
@@ -24,9 +24,18 @@ def test_daq2_rx_data(test_dma_rx, iio_uri, classname, channel):
 @pytest.mark.iio_hardware(hardware)
 @pytest.mark.parametrize("classname", [(classname)])
 @pytest.mark.parametrize("channel", [0, 1])
-@pytest.mark.parametrize("frequency, scale", [(200000000, 0.5)])
 @pytest.mark.parametrize("param_set", [dict()])
-@pytest.mark.parametrize("peak_min", [-40])
+@pytest.mark.parametrize(
+    "frequency, scale, peak_min",
+    [
+        (5000000, 0.12, -21),
+        (10000000, 0.06, -27),
+        (10000000, 0.12, -21),
+        (15000000, 0.12, -21),
+        (15000000, 0.5, -15),
+        (200000000, 0.5, -40),
+    ],
+)
 def test_daq2_dds_loopback(
     test_dds_loopback,
     iio_uri,
@@ -47,7 +56,7 @@ def test_daq2_dds_loopback(
 @pytest.mark.parametrize("classname", [(classname)])
 @pytest.mark.parametrize("channel", [0, 1])
 @pytest.mark.parametrize(
-    "param_set", [dict(),],
+    "param_set", [dict(), ],
 )
 def test_daq2_cw_loopback(test_cw_loopback, iio_uri, classname, channel, param_set):
     test_cw_loopback(iio_uri, classname, channel, param_set)

--- a/test/test_daq2_p.py
+++ b/test/test_daq2_p.py
@@ -56,7 +56,7 @@ def test_daq2_dds_loopback(
 @pytest.mark.parametrize("classname", [(classname)])
 @pytest.mark.parametrize("channel", [0, 1])
 @pytest.mark.parametrize(
-    "param_set", [dict(), ],
+    "param_set", [dict(),],
 )
 def test_daq2_cw_loopback(test_cw_loopback, iio_uri, classname, channel, param_set):
     test_cw_loopback(iio_uri, classname, channel, param_set)

--- a/test/test_daq3_p.py
+++ b/test/test_daq3_p.py
@@ -24,9 +24,18 @@ def test_daq3_rx_data(test_dma_rx, iio_uri, classname, channel):
 @pytest.mark.iio_hardware(hardware)
 @pytest.mark.parametrize("classname", [(classname)])
 @pytest.mark.parametrize("channel", [0, 1])
-@pytest.mark.parametrize("frequency, scale", [(200000000, 0.5)])
 @pytest.mark.parametrize("param_set", [dict()])
-@pytest.mark.parametrize("peak_min", [-40])
+@pytest.mark.parametrize(
+    "frequency, scale, peak_min",
+    [
+        (5000000, 0.12, -21),
+        (10000000, 0.06, -27),
+        (10000000, 0.12, -21),
+        (15000000, 0.12, -21),
+        (15000000, 0.5, -15),
+        (200000000, 0.5, -40),
+    ],
+)
 def test_daq3_dds_loopback(
     test_dds_loopback,
     iio_uri,


### PR DESCRIPTION
# Description

spec: Add support for pure data - added lines of code on test/rf/spec.py to select the frequency on the right-hand side of the spectrum only.
test_daq2_p.py: Mirrored the manual test case and some little formatting changes

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
