### PR TITLE
Update save to eeprom functionality

### DIFF
--- a/requirements_prod_test.txt
+++ b/requirements_prod_test.txt
@@ -1,0 +1,16 @@
+black
+codespell
+flake8
+pre-commit
+isort
+pytest>=4.6
+scapy
+scipy
+pytest-cov
+coveralls
+pytest-libiio
+bump2version
+pytest-html
+plotly-express
+pyvisa
+tkinter

--- a/test/eeprom.py
+++ b/test/eeprom.py
@@ -1,0 +1,117 @@
+import tkinter as tk
+from datetime import date, datetime
+from tkinter import Button, Entry, Label
+
+import paramiko
+import pytest
+
+
+def save_to_eeprom(iio_uri, coarse, fine):
+    full_uri = iio_uri.split(":", 2)
+    if full_uri[0] != "ip":
+        pytest.skip("Tuning currently supported only for ip URIs")
+    ip = full_uri[1]
+
+    ssh_client = paramiko.SSHClient()
+    ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    ssh_client.connect(ip, username="root", password="analog")
+    ssh_stdin, ssh_stdout, ssh_stderr = ssh_client.exec_command(
+        "find /sys/ -name eeprom"
+    )
+    eeprom_path = ssh_stdout.readline().rstrip("\n")
+
+    if ssh_stderr.channel.recv_exit_status() != 0:
+        raise paramiko.SSHException("find_eeprom command did not execute properly")
+
+    this_day = date.today()
+    if this_day.year <= 1995:
+        pytest.skip(
+            "System date and time not in order. Please connect the device to internet to update."
+        )
+
+    sn = popup_txt()
+
+    hc = hex(coarse).lstrip("0x").rstrip("L")
+    if coarse <= 16:
+        hc = "0" + hc
+    hf = hex(fine).lstrip("0x").rstrip("L")
+    h = hc + hf
+
+    cmd = (
+        "fru-dump -i "
+        + eeprom_path
+        + " -o "
+        + eeprom_path
+        + " -s "
+        + sn
+        + " -d "
+        + datetime.now().strftime("%Y-%m-%dT%H:%M:%S-05:00")
+        + " -t "
+        + str(h)
+        + " 2>&1"
+    )
+    sshin, sshout, ssherr = ssh_client.exec_command(cmd)
+    if ssherr.channel.recv_exit_status() != 0:
+        raise paramiko.SSHException("fru-dump command did not execute properly")
+
+    ssh_client.close()
+
+
+def popup_txt():
+    popup = tk.Tk()
+    popup.wm_title("Serial Number")
+    label = Label(
+        popup, text="Please write the serial number below:", font=("Verdana", 10)
+    )
+    tVar = tk.StringVar()
+    label.pack(side="top", fill="x", pady=10)
+    tb = Entry(popup, textvariable=tVar)
+    tb.pack()
+    btn = Button(popup, text="OK", command=popup.destroy)
+    btn.pack()
+    popup.mainloop()
+    sn = tVar.get()
+    if sn.isalnum():
+        return sn
+    else:
+        pytest.skip("Invalid Serial Number")
+
+
+def load_from_eeprom(iio_uri):
+    full_uri = iio_uri.split(":", 2)
+    if full_uri[0] != "ip":
+        pytest.skip("Tuning currently supported only for ip URIs")
+    ip = full_uri[1]
+
+    ssh_client = paramiko.SSHClient()
+    ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    ssh_client.connect(ip, username="root", password="analog")
+    ssh_stdin, ssh_stdout, ssh_stderr = ssh_client.exec_command(
+        "find /sys/ -name eeprom"
+    )
+    eeprom_path = ssh_stdout.readline().rstrip("\n")
+
+    if ssh_stderr.channel.recv_exit_status() != 0:
+        raise paramiko.SSHException("find_eeprom command did not execute properly")
+
+    cmdin, cmdout, cmderr = ssh_client.exec_command(
+        "fru-dump -i " + eeprom_path + " -b"
+    )
+    if cmderr.channel.recv_exit_status() != 0:
+        raise paramiko.SSHException(
+            "fru-dump board info command did not execute properly"
+        )
+
+    field = cmdout.readline()
+    k = 0
+    while field[:6] != "Tuning":
+        field = cmdout.readline()
+        k += 1
+        # in case tuning parameters are not set, we shouldn't stay in the loop
+        if k >= 20:
+            print("No saved tuning values were found. Using defaults.")
+
+    field = field[6:].lstrip(" \t: ")
+    coarse = int("0x" + field[:2], 16)
+    fine = int("0x" + field[2:], 16)
+    return coarse, fine

--- a/test/scpi.py
+++ b/test/scpi.py
@@ -1,4 +1,6 @@
 import time
+from test.eeprom import load_from_eeprom, save_to_eeprom
+from tkinter.font import BOLD
 from weakref import finalize
 
 import iio
@@ -81,8 +83,9 @@ def get_clk_rate(classname, iio_uri):
     ssh_client = paramiko.SSHClient()
     ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
     ssh_client.connect(ip, username="root", password="analog")
+    dev = classname[4:]
     ssh_stdin, ssh_stdout, ssh_stderr = ssh_client.exec_command(
-        "cat /sys/kernel/debug/clk/ad9361_ext_refclk/clk_rate"
+        "cat /sys/kernel/debug/clk/" + dev + "_ext_refclk/clk_rate"
     )
 
     if ssh_stderr.channel.recv_exit_status() != 0:
@@ -93,88 +96,16 @@ def get_clk_rate(classname, iio_uri):
     return float(clk_rate)
 
 
-def save_to_eeprom(iio_uri, coarse, fine):
-    full_uri = iio_uri.split(":", 2)
-    if full_uri[0] != "ip":
-        pytest.skip("Tuning currently supported only for ip URIs")
-    ip = full_uri[1]
-
-    ssh_client = paramiko.SSHClient()
-    ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-    ssh_client.connect(ip, username="root", password="analog")
-    ssh_stdin, ssh_stdout, ssh_stderr = ssh_client.exec_command(
-        "find /sys/ -name eeprom"
-    )
-    eeprom_path = ssh_stdout.readline().rstrip("\n")
-
-    if ssh_stderr.channel.recv_exit_status() != 0:
-        raise paramiko.SSHException("find_eeprom command did not execute properly")
-
-    hc = hex(coarse).lstrip("0x").rstrip("L")
-    if coarse <= 16:
-        hc = "0" + hc
-    hf = hex(fine).lstrip("0x").rstrip("L")
-    h = hc + hf
-    cmd = (
-        "fru-dump -i " + eeprom_path + " -o " + eeprom_path + " -t " + str(h) + " 2>&1"
-    )
-    sshin, sshout, ssherr = ssh_client.exec_command(cmd)
-    if ssherr.channel.recv_exit_status() != 0:
-        raise paramiko.SSHException("fru-dump command did not execute properly")
-
-    ssh_client.close()
-
-
-def load_from_eeprom(iio_uri):
-    full_uri = iio_uri.split(":", 2)
-    if full_uri[0] != "ip":
-        pytest.skip("Tuning currently supported only for ip URIs")
-    ip = full_uri[1]
-
-    ssh_client = paramiko.SSHClient()
-    ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-    ssh_client.connect(ip, username="root", password="analog")
-    ssh_stdin, ssh_stdout, ssh_stderr = ssh_client.exec_command(
-        "find /sys/ -name eeprom"
-    )
-    eeprom_path = ssh_stdout.readline().rstrip("\n")
-
-    if ssh_stderr.channel.recv_exit_status() != 0:
-        raise paramiko.SSHException("find_eeprom command did not execute properly")
-
-    cmdin, cmdout, cmderr = ssh_client.exec_command(
-        "fru-dump -i " + eeprom_path + " -b"
-    )
-    if cmderr.channel.recv_exit_status() != 0:
-        raise paramiko.SSHException(
-            "fru-dump board info command did not execute properly"
-        )
-
-    field = cmdout.readline()
-    k = 0
-    while field[:6] != "Tuning":
-        field = cmdout.readline()
-        k += 1
-        # in case tuning parameters are not set, we shouldn't stay in the loop
-        if k >= 20:
-            print("No saved tuning values were found. Using defaults.")
-
-    field = field[6:].lstrip(" \t: ")
-    coarse = int("0x" + field[:2], 16)
-    fine = int("0x" + field[2:], 16)
-    return coarse, fine
-
-
 def dcxo_calibrate(classname, iio_uri):
     prev_diff = 0
     diff = 0
     finetune = False
     step = 1
     direction = -2
-    coarse, fine = load_from_eeprom(iio_uri)
+
     # setting initial values at half the value from eeprom to make the tuning process faster
-    coarse = round(coarse / 2)
-    fine = 4095 + round((fine - 4090) / 2)
+    coarse = 4
+    fine = 4095
 
     instr = find_instrument()
     if instr is None:
@@ -185,7 +116,6 @@ def dcxo_calibrate(classname, iio_uri):
 
     sdr._set_iio_dev_attr("dcxo_tune_coarse", coarse, sdr._ctrl)
     sdr._set_iio_dev_attr("dcxo_tune_fine", fine, sdr._ctrl)
-
     while 1:
         current_frq = get_freq(instr)
 


### PR DESCRIPTION
Signed-off-by: Ramona Alexandra Nechita <ramona.nechita@analog.com>

# Description

When running the production tests, at the end of the calibration procedure a window is prompted to introduce the serial number of the device and then eeprom is written accordingly. All functions related to the eeprom are moved to a separate file. It also includes minor fixes.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:
* Hardware: ADRV9361-ZC702
* OS: Ubuntu 20.04

# Documentation

If this is a new feature or example please mention or link any documentation. All new hardware interface classes require documentation.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
