### PR TITLE
Fmcomms5 test fixes

### DIFF
--- a/adi/fmcomms5.py
+++ b/adi/fmcomms5.py
@@ -34,6 +34,7 @@
 from adi.ad936x import ad9361
 from adi.context_manager import context_manager
 from adi.rx_tx import rx_tx
+import ad9361 as libad9361
 
 
 class FMComms5(ad9361):
@@ -72,7 +73,8 @@ class FMComms5(ad9361):
         self._rxadc_chip_b = self._ctx.find_device("cf-ad9361-B")
         self._txdac_chip_b = self._ctx.find_device("cf-ad9361-dds-core-B")
         rx_tx.__init__(self)
-
+        libad9361.fmcomms5_multichip_sync(self._ctx, 2)
+        
     @property
     def filter(self):
         """Load FIR filter file. Provide path to filter file to attribute"""
@@ -104,7 +106,7 @@ class FMComms5(ad9361):
     def gain_control_mode_chip_b_chan0(self):
         """gain_control_mode_chip_b_chan0: Mode of receive path AGC of second transceiver.
         Options are: slow_attack, fast_attack, manual"""
-        return self._get_iio_attr("voltage0", "gain_control_mode", False, self._ctrl_b)
+        return self._get_iio_attr_str("voltage0", "gain_control_mode", False, self._ctrl_b)
 
     @gain_control_mode_chip_b_chan0.setter
     def gain_control_mode_chip_b_chan0(self, value):
@@ -114,7 +116,7 @@ class FMComms5(ad9361):
     def gain_control_mode_chip_b_chan1(self):
         """gain_control_mode_chip_b_chan1: Mode of receive path AGC of second transceiver.
         Options are: slow_attack, fast_attack, manual"""
-        return self._get_iio_attr("voltage1", "gain_control_mode", False, self._ctrl_b)
+        return self._get_iio_attr_str("voltage1", "gain_control_mode", False, self._ctrl_b)
 
     @gain_control_mode_chip_b_chan1.setter
     def gain_control_mode_chip_b_chan1(self, value):

--- a/adi/fmcomms5.py
+++ b/adi/fmcomms5.py
@@ -31,10 +31,14 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import ad9361 as libad9361
 from adi.ad936x import ad9361
 from adi.context_manager import context_manager
 from adi.rx_tx import rx_tx
+
+try:
+    import ad9361 as libad9361
+except ImportError:
+    libad9361 = None
 
 
 class FMComms5(ad9361):
@@ -73,7 +77,8 @@ class FMComms5(ad9361):
         self._rxadc_chip_b = self._ctx.find_device("cf-ad9361-B")
         self._txdac_chip_b = self._ctx.find_device("cf-ad9361-dds-core-B")
         rx_tx.__init__(self)
-        libad9361.fmcomms5_multichip_sync(self._ctx, 3)
+        if libad9361:
+            libad9361.fmcomms5_multichip_sync(self._ctx, 3)
 
     @property
     def filter(self):

--- a/adi/fmcomms5.py
+++ b/adi/fmcomms5.py
@@ -73,7 +73,7 @@ class FMComms5(ad9361):
         self._rxadc_chip_b = self._ctx.find_device("cf-ad9361-B")
         self._txdac_chip_b = self._ctx.find_device("cf-ad9361-dds-core-B")
         rx_tx.__init__(self)
-        libad9361.fmcomms5_multichip_sync(self._ctx, 2)
+        libad9361.fmcomms5_multichip_sync(self._ctx, 3)
 
     @property
     def filter(self):

--- a/adi/fmcomms5.py
+++ b/adi/fmcomms5.py
@@ -31,10 +31,10 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import ad9361 as libad9361
 from adi.ad936x import ad9361
 from adi.context_manager import context_manager
 from adi.rx_tx import rx_tx
-import ad9361 as libad9361
 
 
 class FMComms5(ad9361):
@@ -74,7 +74,7 @@ class FMComms5(ad9361):
         self._txdac_chip_b = self._ctx.find_device("cf-ad9361-dds-core-B")
         rx_tx.__init__(self)
         libad9361.fmcomms5_multichip_sync(self._ctx, 2)
-        
+
     @property
     def filter(self):
         """Load FIR filter file. Provide path to filter file to attribute"""
@@ -106,7 +106,9 @@ class FMComms5(ad9361):
     def gain_control_mode_chip_b_chan0(self):
         """gain_control_mode_chip_b_chan0: Mode of receive path AGC of second transceiver.
         Options are: slow_attack, fast_attack, manual"""
-        return self._get_iio_attr_str("voltage0", "gain_control_mode", False, self._ctrl_b)
+        return self._get_iio_attr_str(
+            "voltage0", "gain_control_mode", False, self._ctrl_b
+        )
 
     @gain_control_mode_chip_b_chan0.setter
     def gain_control_mode_chip_b_chan0(self, value):
@@ -116,7 +118,9 @@ class FMComms5(ad9361):
     def gain_control_mode_chip_b_chan1(self):
         """gain_control_mode_chip_b_chan1: Mode of receive path AGC of second transceiver.
         Options are: slow_attack, fast_attack, manual"""
-        return self._get_iio_attr_str("voltage1", "gain_control_mode", False, self._ctrl_b)
+        return self._get_iio_attr_str(
+            "voltage1", "gain_control_mode", False, self._ctrl_b
+        )
 
     @gain_control_mode_chip_b_chan1.setter
     def gain_control_mode_chip_b_chan1(self, value):

--- a/test/test_fmcomms5_p.py
+++ b/test/test_fmcomms5_p.py
@@ -10,7 +10,7 @@ classname = "adi.FMComms5"
 @pytest.mark.parametrize(
     "attr, start, stop, step, tol",
     [
-        ("tx_hardwaregain", -86, 0.0, 0.25, 0),
+        ("tx_hardwaregain_chan0", -86, 0.0, 0.25, 0),
         ("rx_lo", 70000000, 6000000000, 1, 8),
         ("tx_lo", 47000000, 6000000000, 1, 8),
         ("sample_rate", 2084000, 61440000, 1, 4),
@@ -162,7 +162,7 @@ def test_fmcomms5_iq_loopback(test_iq_loopback, iio_uri, classname, channel, par
 @pytest.mark.parametrize(
     "attr, start, stop, step, tol",
     [
-        ("tx_hardwaregain_chip_b", -86, 0.0, 0.25, 0),
+        ("tx_hardwaregain_chip_b_chan0", -86, 0.0, 0.25, 0),
         ("rx_lo_chip_b", 70000000, 6000000000, 1, 8),
         ("tx_lo_chip_b", 47000000, 6000000000, 1, 8),
         ("sample_rate", 2084000, 61440000, 1, 4),
@@ -247,7 +247,7 @@ def test_fmcomms5_dds_chip_b_loopback(
 #########################################
 @pytest.mark.iio_hardware(hardware)
 @pytest.mark.parametrize("classname", [(classname)])
-@pytest.mark.parametrize("channel", [3])
+@pytest.mark.parametrize("channel", [2])
 @pytest.mark.parametrize(
     "param_set",
     [


### PR DESCRIPTION
# Description

This PR includes fixes to fmcomms5 test, also added libad9361 fmcomms5 multiple chip sync function to fmcomms5 class to ensure both chips are in sync. May have to install the libad9361 python binding from the source, not yet available on pip.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Ran the test code on fmcomms5 hardware

# Documentation

No change is needed.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
