### PR TITLE
adi/QuadMxFE_multi: Add Multi QuadMxFE support

### DIFF
--- a/adi/QuadMxFE_multi.py
+++ b/adi/QuadMxFE_multi.py
@@ -1,0 +1,366 @@
+# Copyright (C) 2021 Analog Devices, Inc.
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#     - Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     - Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#     - Neither the name of Analog Devices, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#     - The use of this software may or may not infringe the patent rights
+#       of one or more patent holders.  This license does not release you
+#       from the requirement that you obtain separate licenses from these
+#       patent holders to use this software.
+#     - Use of the software either in source or binary form, must be run
+#       on or directly connected to an Analog Devices Inc. component.
+#
+# THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED.
+#
+# IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, INTELLECTUAL PROPERTY
+# RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import time
+from typing import List
+
+from adi.ad9081_mc import QuadMxFE
+
+
+class QuadMxFE_multi(object):
+    """ADQUADMXFExEBZ Multi-SOM Manager
+
+    parameters:
+        primary_uri: type=string
+            URI of primary ADQUADMXFExEBZ. Parent HMC7044 is connected
+            to this SOM
+        secondary_uris: type=list[string]
+            URI(s) of secondary ADQUADMXFExEBZ(s).
+        primary_jesd: type=adi.jesd
+            JESD object associated with primary ADQUADMXFExEBZ
+        secondary_jesds: type=list[adi.jesd]
+            JESD object(s) associated with secondary ADQUADMXFExEBZ(s)
+    """
+
+    __rx_buffer_size_multi = 2 ** 14
+    secondaries: List[QuadMxFE] = []
+
+    def __init__(
+        self,
+        primary_uri="",
+        secondary_uris=[],
+        primary_jesd=None,
+        secondary_jesds=[None],
+    ):
+
+        if not isinstance(secondary_uris, list):
+            Exception("secondary_uris must be a list")
+        if not isinstance(secondary_jesds, list):
+            Exception("secondary_jesds must be a list")
+
+        self._dma_show_arming = False
+        self._jesd_show_status = False
+        self._jesd_fsm_show_status = False
+        self._clk_chip_show_cap_bank_sel = False
+        self._resync_tx = False
+        self._rx_initialized = False
+        self._request_sysref_carrier = False
+        self.primary = QuadMxFE(uri=primary_uri)
+        self.secondaries = []
+        self.samples_primary = []
+        self.samples_secondary = []
+        for uri in secondary_uris:
+            self.secondaries.append(QuadMxFE(uri=uri))
+
+        for dev in self.secondaries + [self.primary]:
+            dev._rxadc.set_kernel_buffers_count(1)
+
+        self.primary._clock_chip_ext = self.primary._ctx.find_device("hmc7044-ext")
+
+    def reinitialize(self):
+        """ reinitialize: reinitialize all transceivers """
+        for dev in self.secondaries + [self.primary]:
+            property_names = [p for p in dir(dev) if "reinitialize" in p]
+            for p in property_names:
+                eval("dev." + p + "()")
+
+    @property
+    def rx_buffer_size(self):
+        """rx_buffer_size: Size of receive buffer in samples for each device"""
+        return self.__rx_buffer_size_multi
+
+    @rx_buffer_size.setter
+    def rx_buffer_size(self, value):
+        self.__rx_buffer_size_multi = value
+        for dev in self.secondaries + [self.primary]:
+            dev.rx_buffer_size = value
+
+    def __read_jesd_status_all_devs(self, attr, islink=False):
+        for dev in self.secondaries + [self.primary]:
+            if islink:
+                devs = dev._jesd.get_all_link_statuses()
+                for dev in devs:
+                    lanes = devs[dev]
+                    print("JESD {}: ".format(dev), end="")
+                    for lane in lanes:
+                        if attr in lanes[lane]:
+                            print(" {}".format(lanes[lane][attr]), end="")
+                    print("")
+            else:
+                s = dev._jesd.get_all_statuses()
+                for dev in s:
+                    if attr in s[dev]:
+                        print("JESD {}: {} ({})".format(attr, s[dev][attr], dev))
+
+    def __read_jesd_status(self):
+        self.__read_jesd_status_all_devs("Link status")
+        self.__read_jesd_status_all_devs("SYSREF captured")
+        self.__read_jesd_status_all_devs("SYSREF alignment error")
+
+    def __read_jesd_link_status(self):
+        self.__read_jesd_status_all_devs("Errors", True)
+        self.__read_jesd_status_all_devs("Initial Lane Alignment Sequence", True)
+        self.__read_jesd_status_all_devs("Initial Frame Synchronization", True)
+
+    def _device_is_running(self, dev, index, verbose):
+        err = dev.jesd204_fsm_error
+        paused = dev.jesd204_fsm_paused
+        state = dev.jesd204_fsm_state
+
+        if verbose:
+            print(
+                "%s: DEVICE%d: Is <%s> in state <%s> with status <%d>"
+                % (dev.uri, index, "Paused" if paused else "Running", state, err)
+            )
+
+        if err:
+            print(
+                "\nERROR %s: DEVICE%d: Is <%s> in state <%s> with status <%d>\n"
+                % (dev.uri, index, "Paused" if paused else "Running", state, err)
+            )
+            return "error"
+
+        state_last = state == "opt_post_running_stage"
+
+        if (state_last == 0) and (paused == 0):
+            return "running"
+
+        if (state_last == 0) and (paused == 1):
+            return "paused"
+
+        if (state_last == 1) and (paused == 0):
+            return "done"
+
+        assert False
+
+    def __jesd204_fsm_is_done(self):
+        cnt = 0
+        for index, dev in enumerate([self.primary] + self.secondaries):
+            ret = self._device_is_running(dev, index, 0)
+            if index == 0:
+                statep = dev.jesd204_fsm_state
+            else:
+                state = dev.jesd204_fsm_state
+                assert state == statep
+
+            if ret == "done":
+                cnt += 1
+
+        if cnt == len([self.primary] + self.secondaries):
+            return "done"
+
+    def _jesd204_fsm_sync(self):
+        while True:
+            stat = self.__jesd204_fsm_is_done()
+            if stat == "done":
+                return "done"
+
+            for index, dev in enumerate(self.secondaries + [self.primary]):
+                ret = self._device_is_running(dev, index, self._jesd_fsm_show_status)
+                if ret == "paused":
+                    dev.jesd204_fsm_resume = "1"
+
+                if ret == "error":
+                    return ret
+
+    def __unsync(self):
+        for dev in [self.primary] + self.secondaries:
+            dev._clock_chip.attrs["sleep_request"].value = "1"
+
+        self.primary._clock_chip_ext.attrs["sleep_request"].value = "1"
+        time.sleep(0.1)
+        self.primary._clock_chip_ext.attrs["sleep_request"].value = "0"
+
+        for dev in [self.primary] + self.secondaries:
+            dev._clock_chip.attrs["sleep_request"].value = "0"
+
+    def hmc7044_cap_sel(self):
+        vals = []
+        for dev in [self.primary] + self.secondaries:
+            vals.append(dev._clock_chip.reg_read(0x8C))
+
+        vals.append(self.primary._clock_chip_ext.reg_read(0x8C))
+        return vals
+
+    def hmc7044_set_cap_sel(self, vals):
+        """hmc7044_set_cap_sel:
+
+        parameters:
+            vals: type=list
+                Forces certain Capacitor bank seletions.
+                Typically the list returned form hmc7044_cap_sel
+        """
+        for dev in [self.primary] + self.secondaries:
+            dev._clock_chip.reg_write(0xB2, vals.pop(0) << 2 | 1)
+
+        self.primary._clock_chip_ext.reg_write(0xB2, vals.pop(0) << 2 | 1)
+
+    def hmc7044_ext_output_delay(self, chan, digital, analog_ps):
+        """hmc7044_ext_output_delay:
+
+        parameters:
+            digital: type=int
+                Digital delay. Adjusts the phase of the divider signal
+                by up to 17 half cycles of the VCO.
+            analog_ps: type=int
+                Analog delay. Adjusts the delay of the divider signal in
+                increments of ~25 ps. Range is from 100ps to 700ps.
+        """
+        assert 0 <= chan <= 13
+        if analog_ps - 100 >= 0:
+            enable = 1
+            val = (analog_ps - 100) / 25
+        else:
+            enable = 0
+            val = 0
+
+        offs = chan * 10
+        self.primary._clock_chip_ext.reg_write(0xCF + offs, enable)
+        self.primary._clock_chip_ext.reg_write(0xCB + offs, int(val) & 0x1F)
+        self.primary._clock_chip_ext.reg_write(0xCC + offs, int(digital) & 0x1F)
+
+    def hmc7044_car_output_delay(self, chan, digital, analog_ps):
+        """hmc7044_car_output_delay:
+
+        parameters:
+            digital: type=int
+                Digital delay. Adjusts the phase of the divider signal
+                by up to 17 half cycles of the VCO.
+            analog_ps: type=int
+                Analog delay. Adjusts the delay of the divider signal in
+                increments of ~25 ps. Range is from 100ps to 700ps.
+        """
+        assert 0 <= chan <= 13
+        if analog_ps - 100 >= 0:
+            enable = 1
+            val = (analog_ps - 100) / 25
+        else:
+            enable = 0
+            val = 0
+
+        offs = chan * 10
+
+        for dev in [self.primary] + self.secondaries:
+            dev._clock_chip.reg_write(0xCF + offs, enable)
+            dev._clock_chip.reg_write(0xCB + offs, int(val) & 0x1F)
+            dev._clock_chip.reg_write(0xCC + offs, int(digital) & 0x1F)
+
+    def __rx_dma_arm(self):
+        for dev in self.secondaries + [self.primary]:
+            if self._dma_show_arming:
+                print("--DMA ARMING--", dev.uri)
+            dev._rxadc.reg_write(0x80000044, 0x8)
+            while dev._rxadc.reg_read(0x80000068) == 0:
+                dev._rxadc.reg_write(0x80000044, 0x8)
+                if self._dma_show_arming:
+                    print(".", end="")
+            if self._dma_show_arming:
+                print("\n--DMA ARMED--", dev.uri)
+
+    def __dds_sync_enable(self, enable):
+        for dev in self.secondaries + [self.primary]:
+            if self._dma_show_arming:
+                print("--DAC SYNC ARMING--", dev.uri)
+            chan = dev._txdac.find_channel("altvoltage0", True)
+            chan.attrs["raw"].value = str(enable)
+
+    def sysref_request(self):
+        """ sysref_request: Sysref request for parent HMC7044 """
+        self.primary._clock_chip_ext.attrs["sysref_request"].value = "1"
+
+    def __refill_samples(self, dev, is_primary):
+        if is_primary:
+            self.samples_primary = dev.rx()
+        else:
+            self.samples_secondary = dev.rx()
+
+    def _pre_rx_setup(self):
+        retries = 10
+        for _ in range(retries):
+            try:
+                for dev in [self.primary] + self.secondaries:
+                    dev.jesd204_fsm_ctrl = 0
+
+                self.__unsync()
+
+                for dev in [self.primary] + self.secondaries:
+                    dev.jesd204_fsm_ctrl = 1
+
+                self._jesd204_fsm_sync()
+
+                if not self._resync_tx:
+                    self.__dds_sync_enable(1)
+
+                if self._clk_chip_show_cap_bank_sel:
+                    print("HMC7044s CAP bank select: ", self.hmc7044_cap_sel())
+
+                if self._jesd_show_status:
+                    self.__read_jesd_status()
+                    self.__read_jesd_link_status()
+
+                for dev in [self.primary] + self.secondaries:
+                    dev.rx_destroy_buffer()
+                    dev._rx_init_channels()
+                return
+            except:  # noqa: E722
+                print("Re-initializing due to lock-up")
+                self.reinitialize()
+        raise Exception("Unable to initialize (Board reboot required)")
+
+    def rx(self):
+        """Receive data from multiple hardware buffers for each channel index in
+        rx_enabled_channels of each child object (primary,secondaries[indx]).
+
+        returns: type=numpy.array or list of numpy.array
+            An array or list of arrays when more than one receive channel
+            is enabled containing samples from a channel or set of channels.
+            Data will be complex when using a complex data device.
+        """
+        if not self._rx_initialized:
+            self._pre_rx_setup()
+            self._rx_initialized = True
+        data = []
+        self.__rx_dma_arm()
+        # Recreate all buffers
+        for dev in [self.primary] + self.secondaries:
+            dev.rx_destroy_buffer()
+            dev._rx_init_channels()
+
+        if self._resync_tx:
+            self.__dds_sync_enable(1)
+
+        self.sysref_request()
+
+        for dev in [self.primary] + self.secondaries:
+            data += dev.rx()
+        return data

--- a/adi/__init__.py
+++ b/adi/__init__.py
@@ -107,6 +107,8 @@ from adi.adf4371 import adf4371
 
 from adi.adpd188 import adpd188
 
+from adi.QuadMxFE_multi import QuadMxFE_multi
+
 try:
     from adi.jesd import jesd
 except ImportError:

--- a/adi/ad9081.py
+++ b/adi/ad9081.py
@@ -174,6 +174,14 @@ class ad9081(rx_tx, context_manager):
         # This is overridden by subclasses
         return self._set_iio_dev_attr(attr, value)
 
+    def _get_iio_dev_attr_str_single(self, attr):
+        # This is overridden by subclasses
+        return self._get_iio_dev_attr_str(attr)
+
+    def _set_iio_dev_attr_str_single(self, attr, value):
+        # This is overridden by subclasses
+        return self._set_iio_dev_attr_str(attr, value)
+
     @property
     def path_map(self):
         """ path_map: Map of channelizers both coarse and fine to
@@ -473,3 +481,36 @@ class ad9081(rx_tx, context_manager):
     def dac_frequency(self):
         """dac_frequency: DAC frequency in Hz"""
         return self._get_iio_attr_single("voltage0_i", "dac_frequency", True)
+
+    @property
+    def jesd204_fsm_ctrl(self):
+        """jesd204_fsm_ctrl: jesd204-fsm control"""
+        return self._get_iio_dev_attr("jesd204_fsm_ctrl", self._rxadc)
+
+    @jesd204_fsm_ctrl.setter
+    def jesd204_fsm_ctrl(self, value):
+        self._set_iio_dev_attr("jesd204_fsm_ctrl", value, self._rxadc)
+
+    @property
+    def jesd204_fsm_resume(self):
+        """jesd204_fsm_resume: jesd204-fsm resume"""
+        return self._get_iio_dev_attr("jesd204_fsm_resume", self._rxadc)
+
+    @jesd204_fsm_resume.setter
+    def jesd204_fsm_resume(self, value):
+        self._set_iio_dev_attr_str("jesd204_fsm_resume", value, self._rxadc)
+
+    @property
+    def jesd204_fsm_state(self):
+        """jesd204_fsm_state: jesd204-fsm state"""
+        return self._get_iio_dev_attr_str("jesd204_fsm_state", self._rxadc)
+
+    @property
+    def jesd204_fsm_paused(self):
+        """jesd204_fsm_paused: jesd204-fsm paused"""
+        return self._get_iio_dev_attr("jesd204_fsm_paused", self._rxadc)
+
+    @property
+    def jesd204_fsm_error(self):
+        """jesd204_fsm_error: jesd204-fsm error"""
+        return self._get_iio_dev_attr("jesd204_fsm_error", self._rxadc)

--- a/adi/ad9081_mc.py
+++ b/adi/ad9081_mc.py
@@ -126,6 +126,7 @@ class ad9081_mc(ad9081):
 
     def __init__(self, uri="", phy_dev_name=""):
 
+        self._rx_channel_names: List[str] = []
         context_manager.__init__(self, uri, self._device_name)
 
         if not phy_dev_name:
@@ -328,6 +329,8 @@ class QuadMxFE(ad9081_mc):
     def __init__(self, uri="", calibration_board_attached=False):
         ad9081_mc.__init__(self, uri=uri, phy_dev_name="axi-ad9081-rx-3")
         one_bit_adc_dac.__init__(self, uri)
+
+        self._clock_chip = self._ctx.find_device("hmc7043")
 
         self._rx_dsa = self._ctx.find_device("hmc425a")
         if not self._rx_dsa:

--- a/adi/fmcomms5.py
+++ b/adi/fmcomms5.py
@@ -34,6 +34,7 @@
 from adi.ad936x import ad9361
 from adi.context_manager import context_manager
 from adi.rx_tx import rx_tx
+import ad9361 as libad9361
 
 
 class FMComms5(ad9361):
@@ -72,7 +73,8 @@ class FMComms5(ad9361):
         self._rxadc_chip_b = self._ctx.find_device("cf-ad9361-B")
         self._txdac_chip_b = self._ctx.find_device("cf-ad9361-dds-core-B")
         rx_tx.__init__(self)
-
+        libad9361.fmcomms5_multichip_sync(self._ctx, 2)
+        
     @property
     def filter(self):
         """Load FIR filter file. Provide path to filter file to attribute"""
@@ -104,7 +106,7 @@ class FMComms5(ad9361):
     def gain_control_mode_chip_b_chan0(self):
         """gain_control_mode_chip_b_chan0: Mode of receive path AGC of second transceiver.
         Options are: slow_attack, fast_attack, manual"""
-        return self._get_iio_attr("voltage0", "gain_control_mode", False, self._ctrl_b)
+        return self._get_iio_attr_str("voltage0", "gain_control_mode", False, self._ctrl_b)
 
     @gain_control_mode_chip_b_chan0.setter
     def gain_control_mode_chip_b_chan0(self, value):
@@ -114,7 +116,7 @@ class FMComms5(ad9361):
     def gain_control_mode_chip_b_chan1(self):
         """gain_control_mode_chip_b_chan1: Mode of receive path AGC of second transceiver.
         Options are: slow_attack, fast_attack, manual"""
-        return self._get_iio_attr("voltage1", "gain_control_mode", False, self._ctrl_b)
+        return self._get_iio_attr_str("voltage1", "gain_control_mode", False, self._ctrl_b)
 
     @gain_control_mode_chip_b_chan1.setter
     def gain_control_mode_chip_b_chan1(self, value):

--- a/adi/fmcomms5.py
+++ b/adi/fmcomms5.py
@@ -31,10 +31,14 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import ad9361 as libad9361
 from adi.ad936x import ad9361
 from adi.context_manager import context_manager
 from adi.rx_tx import rx_tx
+
+try:
+    import ad9361 as libad9361
+except ImportError:
+    libad9361 = None
 
 
 class FMComms5(ad9361):
@@ -73,7 +77,8 @@ class FMComms5(ad9361):
         self._rxadc_chip_b = self._ctx.find_device("cf-ad9361-B")
         self._txdac_chip_b = self._ctx.find_device("cf-ad9361-dds-core-B")
         rx_tx.__init__(self)
-        libad9361.fmcomms5_multichip_sync(self._ctx, 3)
+        if libad9361:
+            libad9361.fmcomms5_multichip_sync(self._ctx, 3)
 
     @property
     def filter(self):

--- a/adi/fmcomms5.py
+++ b/adi/fmcomms5.py
@@ -73,7 +73,7 @@ class FMComms5(ad9361):
         self._rxadc_chip_b = self._ctx.find_device("cf-ad9361-B")
         self._txdac_chip_b = self._ctx.find_device("cf-ad9361-dds-core-B")
         rx_tx.__init__(self)
-        libad9361.fmcomms5_multichip_sync(self._ctx, 2)
+        libad9361.fmcomms5_multichip_sync(self._ctx, 3)
 
     @property
     def filter(self):

--- a/adi/fmcomms5.py
+++ b/adi/fmcomms5.py
@@ -31,10 +31,10 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import ad9361 as libad9361
 from adi.ad936x import ad9361
 from adi.context_manager import context_manager
 from adi.rx_tx import rx_tx
-import ad9361 as libad9361
 
 
 class FMComms5(ad9361):
@@ -74,7 +74,7 @@ class FMComms5(ad9361):
         self._txdac_chip_b = self._ctx.find_device("cf-ad9361-dds-core-B")
         rx_tx.__init__(self)
         libad9361.fmcomms5_multichip_sync(self._ctx, 2)
-        
+
     @property
     def filter(self):
         """Load FIR filter file. Provide path to filter file to attribute"""
@@ -106,7 +106,9 @@ class FMComms5(ad9361):
     def gain_control_mode_chip_b_chan0(self):
         """gain_control_mode_chip_b_chan0: Mode of receive path AGC of second transceiver.
         Options are: slow_attack, fast_attack, manual"""
-        return self._get_iio_attr_str("voltage0", "gain_control_mode", False, self._ctrl_b)
+        return self._get_iio_attr_str(
+            "voltage0", "gain_control_mode", False, self._ctrl_b
+        )
 
     @gain_control_mode_chip_b_chan0.setter
     def gain_control_mode_chip_b_chan0(self, value):
@@ -116,7 +118,9 @@ class FMComms5(ad9361):
     def gain_control_mode_chip_b_chan1(self):
         """gain_control_mode_chip_b_chan1: Mode of receive path AGC of second transceiver.
         Options are: slow_attack, fast_attack, manual"""
-        return self._get_iio_attr_str("voltage1", "gain_control_mode", False, self._ctrl_b)
+        return self._get_iio_attr_str(
+            "voltage1", "gain_control_mode", False, self._ctrl_b
+        )
 
     @gain_control_mode_chip_b_chan1.setter
     def gain_control_mode_chip_b_chan1(self, value):

--- a/examples/QuadMxFE_dual_example.py
+++ b/examples/QuadMxFE_dual_example.py
@@ -1,0 +1,430 @@
+# Copyright (C) 2021 Analog Devices, Inc.
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#     - Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     - Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#     - Neither the name of Analog Devices, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#     - The use of this software may or may not infringe the patent rights
+#       of one or more patent holders.  This license does not release you
+#       from the requirement that you obtain separate licenses from these
+#       patent holders to use this software.
+#     - Use of the software either in source or binary form, must be run
+#       on or directly connected to an Analog Devices Inc. component.
+#
+# THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED.
+#
+# IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, INTELLECTUAL PROPERTY
+# RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import time
+from datetime import datetime
+
+import adi
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy import signal
+
+
+def measure_phase_and_delay(chan0, chan1, window=None):
+    assert len(chan0) == len(chan1)
+    if window == None:
+        window = len(chan0)
+    phases = []
+    delays = []
+    indx = 0
+    sections = len(chan0) // window
+    for sec in range(sections):
+        chan0_tmp = chan0[indx : indx + window]
+        chan1_tmp = chan1[indx : indx + window]
+        indx = indx + window + 1
+        cor = np.correlate(chan0_tmp, chan1_tmp, "full")
+        # plt.plot(np.real(cor))
+        # plt.plot(np.imag(cor))
+        # plt.plot(np.abs(cor))
+        # plt.plot(chan0_tmp)
+        # plt.plot(chan0)
+        # plt.show()
+        i = np.argmax(np.abs(cor))
+        m = cor[i]
+        sample_delay = len(chan0_tmp) - i - 1
+        phases.append(np.angle(m) * 180 / np.pi)
+        delays.append(sample_delay)
+    return (np.mean(phases), np.mean(delays))
+
+
+def measure_phase(chan0, chan1):
+    assert len(chan0) == len(chan1)
+    errorV = np.angle(chan0 * np.conj(chan1)) * 180 / np.pi
+    error = np.mean(errorV)
+    return error
+
+
+def sub_phases(x, y):
+    return [e1 - e2 for (e1, e2) in zip(x, y)]
+
+
+def measure_and_adjust_phase_offset(
+    chan0, chan1, phase_correction, skip=None, window=None
+):
+    assert len(chan0) == len(chan1)
+    if skip == None:
+        skip = 0
+
+    (p, s) = measure_phase_and_delay(chan0[skip:], chan1[skip:], window)
+    p = round(p, 2)
+    # print("Across Chips Sample delay: ",s)
+    # print("Phase delay: ",p,"(Degrees)")
+    # print(phase_correction)
+    return (sub_phases(phase_correction, [int(p * 1000)] * 4), s)
+
+
+def adjust_gain(x, skip=None):
+    if skip == None:
+        skip = 0
+    c0 = np.amax(x[0][skip:])
+    for i in range(len(x)):
+        c1 = np.amax(x[i][skip:])
+        x[i] = x[i] * c0.real / c1.real
+    return c0.real
+
+
+primary = "ip:10.44.3.52"
+secondary = "ip:10.44.3.55"
+
+primary_jesd = (None,)
+secondary_jesd = ([None],)
+
+print("--Connecting to devices")
+multi = adi.QuadMxFE_multi(primary, [secondary], primary_jesd, [secondary_jesd])
+
+multi._dma_show_arming = False
+multi._jesd_show_status = False
+multi._jesd_fsm_show_status = False
+multi._resync_tx = True
+run_plot = False
+
+round_trip_delay_samples = 450
+captures = 40
+np_corr_window = 256
+
+multi.hmc7044_ext_output_delay(7, 1, 0)
+multi.hmc7044_ext_output_delay(10, 1, 0)
+
+
+multi.hmc7044_car_output_delay(9, 1, 0)
+
+for dev in multi.secondaries + [multi.primary]:
+
+    # Number of MxFE Devices
+    D = len(dev.rx_nyquist_zone)
+
+    # Total number of channels
+    N_RX = len(dev.rx_channel_nco_frequencies["axi-ad9081-rx-3"]) * D
+    N_TX = len(dev.tx_channel_nco_frequencies["axi-ad9081-rx-3"]) * D
+
+    # Total number of CDDCs/CDUCs
+    NM_RX = len(dev.rx_main_nco_frequencies["axi-ad9081-rx-3"]) * D
+    NM_TX = len(dev.tx_main_nco_frequencies["axi-ad9081-rx-3"]) * D
+
+    # Enable the first RX of each MxFE
+    RX_CHAN_EN = []
+    for i in range(N_RX):
+        if i % (N_RX / D) == 0:
+            RX_CHAN_EN = RX_CHAN_EN + [i]
+
+    # In case the channelizers are not used (bypassed) compensate phase offsets using the main NCOs
+    channelizer_bypass = (
+        dev._rxadc.find_channel("voltage0_i")
+        .attrs["channel_nco_frequency_available"]
+        .value
+    )
+    if channelizer_bypass == "[0 1 0]":
+        COMPENSATE_MAIN_PHASES = True
+    else:
+        COMPENSATE_MAIN_PHASES = False
+
+    # Configure properties
+    print("--Setting up " + dev.uri)
+
+    # Loop Combined Tx Channels Back Into Combined Rx Path
+    dev.gpio_ctrl_ind = 1
+    dev.gpio_5045_v1 = 1
+    dev.gpio_5045_v2 = 1
+    dev.gpio_ctrl_rx_combined = 0
+
+    # -12dB attenuation
+    dev.rx_dsa_gain = -12
+
+    # Set NCOs
+    dev.rx_channel_nco_frequencies = [0] * N_RX
+    dev.tx_channel_nco_frequencies = [0] * N_TX
+
+    dev.rx_main_nco_frequencies = [1000000000] * NM_RX
+    dev.tx_main_nco_frequencies = [3000000000] * NM_TX
+
+    dev.rx_enabled_channels = RX_CHAN_EN
+    dev.tx_enabled_channels = [1] * N_TX
+    dev.rx_nyquist_zone = ["even"] * D
+
+    dev.rx_buffer_size = 2 ** 12
+    dev.tx_cyclic_buffer = True
+
+    fs = int(dev.tx_sample_rate["axi-ad9081-rx-3"])
+
+    # Set single DDS tone for TX on one transmitter
+    dev.dds_single_tone(fs / 6, 0.5, channel=0)
+
+phases_a = []
+phases_b = []
+phases_c = []
+phases_d = []
+phases_e = []
+phases_f = []
+phases_g = []
+phases_h = []
+
+so_a = []
+so_b = []
+so_c = []
+so_d = []
+so_e = []
+so_f = []
+so_g = []
+so_h = []
+
+for i in range(captures):
+    multi._rx_initialized = False
+
+    if True:
+        if COMPENSATE_MAIN_PHASES:
+            multi.primary.rx_main_nco_phases = [0] * NM_RX
+            rx_nco_phases_p = multi.primary.rx_main_nco_phases
+            multi.secondaries[0].rx_main_nco_phases = [0] * NM_RX
+            rx_nco_phases_s = multi.secondaries[0].rx_main_nco_phases
+        else:
+            multi.primary.rx_channel_nco_phases = [0] * N_RX
+            rx_nco_phases_p = multi.primary.rx_channel_nco_phases
+            multi.secondaries[0].rx_channel_nco_phases = [0] * N_RX
+            rx_nco_phases_s = multi.secondaries[0].rx_channel_nco_phases
+
+    for r in range(2):
+        # Collect data
+        x = multi.rx()
+        if r == 1:
+            max = adjust_gain(x, round_trip_delay_samples)
+
+            if max < 1000:
+                print("Continue!")
+                continue
+
+        rx_nco_phases_p["axi-ad9081-rx-1"], s_b = measure_and_adjust_phase_offset(
+            x[0],
+            x[1],
+            rx_nco_phases_p["axi-ad9081-rx-1"],
+            round_trip_delay_samples,
+            np_corr_window,
+        )
+        rx_nco_phases_p["axi-ad9081-rx-2"], s_c = measure_and_adjust_phase_offset(
+            x[0],
+            x[2],
+            rx_nco_phases_p["axi-ad9081-rx-2"],
+            round_trip_delay_samples,
+            np_corr_window,
+        )
+        rx_nco_phases_p["axi-ad9081-rx-3"], s_d = measure_and_adjust_phase_offset(
+            x[0],
+            x[3],
+            rx_nco_phases_p["axi-ad9081-rx-3"],
+            round_trip_delay_samples,
+            np_corr_window,
+        )
+
+        rx_nco_phases_s["axi-ad9081-rx-0"], s_e = measure_and_adjust_phase_offset(
+            x[0],
+            x[4],
+            rx_nco_phases_s["axi-ad9081-rx-0"],
+            round_trip_delay_samples,
+            np_corr_window,
+        )
+        rx_nco_phases_s["axi-ad9081-rx-1"], s_f = measure_and_adjust_phase_offset(
+            x[0],
+            x[5],
+            rx_nco_phases_s["axi-ad9081-rx-1"],
+            round_trip_delay_samples,
+            np_corr_window,
+        )
+        rx_nco_phases_s["axi-ad9081-rx-2"], s_g = measure_and_adjust_phase_offset(
+            x[0],
+            x[6],
+            rx_nco_phases_s["axi-ad9081-rx-2"],
+            round_trip_delay_samples,
+            np_corr_window,
+        )
+        rx_nco_phases_s["axi-ad9081-rx-3"], s_h = measure_and_adjust_phase_offset(
+            x[0],
+            x[7],
+            rx_nco_phases_s["axi-ad9081-rx-3"],
+            round_trip_delay_samples,
+            np_corr_window,
+        )
+
+        phase_b = (
+            str(rx_nco_phases_p["axi-ad9081-rx-1"][0] / 1000) + ":" + str(int(s_b))
+        )
+        phase_c = (
+            str(rx_nco_phases_p["axi-ad9081-rx-2"][0] / 1000) + ":" + str(int(s_c))
+        )
+        phase_d = (
+            str(rx_nco_phases_p["axi-ad9081-rx-3"][0] / 1000) + ":" + str(int(s_d))
+        )
+
+        phase_e = (
+            str(rx_nco_phases_s["axi-ad9081-rx-0"][0] / 1000) + ":" + str(int(s_e))
+        )
+        phase_f = (
+            str(rx_nco_phases_s["axi-ad9081-rx-1"][0] / 1000) + ":" + str(int(s_f))
+        )
+        phase_g = (
+            str(rx_nco_phases_s["axi-ad9081-rx-2"][0] / 1000) + ":" + str(int(s_g))
+        )
+        phase_h = (
+            str(rx_nco_phases_s["axi-ad9081-rx-3"][0] / 1000) + ":" + str(int(s_h))
+        )
+
+        phases_a.insert(i, rx_nco_phases_p["axi-ad9081-rx-0"][0] / 1000)
+        phases_b.insert(i, rx_nco_phases_p["axi-ad9081-rx-1"][0] / 1000)
+        phases_c.insert(i, rx_nco_phases_p["axi-ad9081-rx-2"][0] / 1000)
+        phases_d.insert(i, rx_nco_phases_p["axi-ad9081-rx-3"][0] / 1000)
+
+        phases_e.insert(i, rx_nco_phases_s["axi-ad9081-rx-0"][0] / 1000)
+        phases_f.insert(i, rx_nco_phases_s["axi-ad9081-rx-1"][0] / 1000)
+        phases_g.insert(i, rx_nco_phases_s["axi-ad9081-rx-2"][0] / 1000)
+        phases_h.insert(i, rx_nco_phases_s["axi-ad9081-rx-3"][0] / 1000)
+
+        so_a.insert(i, 0)
+        so_b.insert(i, s_b)
+        so_c.insert(i, s_c)
+        so_d.insert(i, s_d)
+
+        so_e.insert(i, s_e)
+        so_f.insert(i, s_f)
+        so_g.insert(i, s_g)
+        so_h.insert(i, s_h)
+
+        result = (
+            str(i)
+            + "/"
+            + str(captures)
+            + ": "
+            + datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            + "\t"
+            + phase_b
+            + "\t"
+            + phase_c
+            + "\t"
+            + phase_d
+            + "\t"
+            + phase_e
+            + "\t"
+            + phase_f
+            + "\t"
+            + phase_g
+            + "\t"
+            + phase_h
+            + "\n"
+        )
+        print(result)
+
+        with open("test.txt", "a") as myfile:
+            myfile.write(result)
+
+        if run_plot == True:
+            plt.xlim(400, 600)
+            plt.plot(np.real(x[0]), label="(1) reference", alpha=0.7)
+            plt.plot(np.real(x[1]), label="(2) phase " + phase_b, alpha=0.7)
+            plt.plot(np.real(x[2]), label="(3) phase " + phase_c, alpha=0.7)
+            plt.plot(np.real(x[3]), label="(4) phase " + phase_d, alpha=0.7)
+
+            plt.plot(np.real(x[4]), label="(5) phase " + phase_e, alpha=0.7)
+            plt.plot(np.real(x[5]), label="(6) phase " + phase_f, alpha=0.7)
+            plt.plot(np.real(x[6]), label="(7) phase " + phase_g, alpha=0.7)
+            plt.plot(np.real(x[7]), label="(8) phase " + phase_h, alpha=0.7)
+
+            plt.legend()
+            plt.title("Dual QuadMxFE Phase Sync @ " + str(fs / 1000000) + " MSPS")
+            plt.show()
+            print("FYI: Close figure to do next capture")
+
+        if True:
+            if COMPENSATE_MAIN_PHASES:
+                multi.primary.rx_main_nco_phases = rx_nco_phases_p
+                multi.secondaries[0].rx_main_nco_phases = rx_nco_phases_s
+            else:
+                multi.primary.rx_channel_nco_phases = rx_nco_phases_p
+                multi.secondaries[0].rx_channel_nco_phases = rx_nco_phases_s
+
+if True:
+
+    i = 0
+    fig, axs = plt.subplots(2, 4)
+
+    for phases in (
+        phases_a,
+        phases_b,
+        phases_c,
+        phases_d,
+        phases_e,
+        phases_f,
+        phases_g,
+        phases_h,
+    ):
+        phases_rounded = [round(num, 1) for num in phases]
+        axs[i // 4, i % 4].hist(phases_rounded, 50, facecolor="green", alpha=0.75)
+        axs[i // 4, i % 4].set_title("MxFE" + str(i))
+        i = i + 1
+
+    plt.tight_layout()
+    plt.show()
+
+    plt.xlim(0, captures)
+    plt.plot(phases_a, label="(1) MxFE0 phase", alpha=0.7)
+    plt.plot(phases_b, label="(2) MxFE1 phase", alpha=0.7)
+    plt.plot(phases_c, label="(3) MxFE2 phase", alpha=0.7)
+    plt.plot(phases_d, label="(4) MxFE3 phase", alpha=0.7)
+
+    plt.plot(phases_e, label="(5) MxFE0 phase", alpha=0.7)
+    plt.plot(phases_f, label="(6) MxFE1 phase", alpha=0.7)
+    plt.plot(phases_g, label="(7) MxFE2 phase", alpha=0.7)
+    plt.plot(phases_h, label="(8) MxFE3 phase", alpha=0.7)
+    if False:
+        plt.plot(so_a, label="(1) MxFE0 Samp. Offset", alpha=0.7)
+        plt.plot(so_b, label="(2) MxFE1 Samp. Offset", alpha=0.7)
+        plt.plot(so_c, label="(3) MxFE2 Samp. Offset", alpha=0.7)
+        plt.plot(so_d, label="(4) MxFE3 Samp. Offset", alpha=0.7)
+
+        plt.plot(so_e, label="(5) MxFE0 Samp. Offset", alpha=0.7)
+        plt.plot(so_f, label="(6) MxFE1 Samp. Offset", alpha=0.7)
+        plt.plot(so_g, label="(7) MxFE2 Samp. Offset", alpha=0.7)
+        plt.plot(so_h, label="(8) MxFE3 Samp. Offset", alpha=0.7)
+
+    plt.legend()
+    plt.title("Dual QuadMxFE Phase Sync @ " + str(fs / 1000000) + " MSPS")
+    plt.show()
+    print("FYI: Close figure to do next capture")
+
+input("Press Enter to exit...")

--- a/test/test_fmcomms5_p.py
+++ b/test/test_fmcomms5_p.py
@@ -10,7 +10,7 @@ classname = "adi.FMComms5"
 @pytest.mark.parametrize(
     "attr, start, stop, step, tol",
     [
-        ("tx_hardwaregain", -86, 0.0, 0.25, 0),
+        ("tx_hardwaregain_chan0", -86, 0.0, 0.25, 0),
         ("rx_lo", 70000000, 6000000000, 1, 8),
         ("tx_lo", 47000000, 6000000000, 1, 8),
         ("sample_rate", 2084000, 61440000, 1, 4),
@@ -162,7 +162,7 @@ def test_fmcomms5_iq_loopback(test_iq_loopback, iio_uri, classname, channel, par
 @pytest.mark.parametrize(
     "attr, start, stop, step, tol",
     [
-        ("tx_hardwaregain_chip_b", -86, 0.0, 0.25, 0),
+        ("tx_hardwaregain_chip_b_chan0", -86, 0.0, 0.25, 0),
         ("rx_lo_chip_b", 70000000, 6000000000, 1, 8),
         ("tx_lo_chip_b", 47000000, 6000000000, 1, 8),
         ("sample_rate", 2084000, 61440000, 1, 4),
@@ -247,7 +247,7 @@ def test_fmcomms5_dds_chip_b_loopback(
 #########################################
 @pytest.mark.iio_hardware(hardware)
 @pytest.mark.parametrize("classname", [(classname)])
-@pytest.mark.parametrize("channel", [3])
+@pytest.mark.parametrize("channel", [2])
 @pytest.mark.parametrize(
     "param_set",
     [


### PR DESCRIPTION
# Description

 * Add JESD204-FSM controls to ad9081 base class
 * Add HMC7043 clock chip to QuadMxFE class
 * Add QuadMxFE_multi class
 * Add Quad_MxFE_dual_example using the QuadMxFE_multi class

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How has this been tested?

Tested on HW
# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have signed off all commits and they contain "Signed-off by: <insert name>"
