### PR TITLE
Change black language version to python3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     rev: 19.10b0
     hooks:
     - id: black
-      language_version: python3.6
+      language_version: python3
 -   repo: https://github.com/asottile/blacken-docs
     rev: v1.3.0
     hooks:


### PR DESCRIPTION
Switch pre-commit black to use python3 and not a specific python3 subversion.

Signed-off-by: Travis F. Collins <travis.collins@analog.com>
