### PR TITLE
Add better handling of 'other' JESD params

### DIFF
--- a/adi/jesd.py
+++ b/adi/jesd.py
@@ -35,7 +35,7 @@ from .sshfs import sshfs
 
 
 class jesd:
-    """ JESD Monitoring """
+    """JESD Monitoring"""
 
     def __init__(self, address, username="root", password="analog"):
         if "ip:" in address:
@@ -73,12 +73,13 @@ class jesd:
                 self.dirs.append(dir)
 
     def decode_status(self, status):
+        status = status.replace(",", "\n")
         status = status.split("\n")
         link_status = {}
         for s in status:
             if ":" in s:
                 o = s.split(":")
-                link_status[o[0]] = o[1].strip()
+                link_status[o[0].strip().replace("/", "")] = o[1].strip()
             if "Link is" in s:
                 link_status["enabled"] = s.split(" ")[-1].strip()
 
@@ -89,7 +90,9 @@ class jesd:
 
     def get_dev_lane_info(self, dir):
         return {
-            ldir: self.decode_status(self.fs.gettext(self.rootdir + dir + "/" + ldir))
+            ldir.replace("/", ""): self.decode_status(
+                self.fs.gettext(self.rootdir + dir + "/" + ldir)
+            )
             for ldir in self.lanes[dir]
         }
 


### PR DESCRIPTION
Signed-off-by: Travis F. Collins <travis.collins@analog.com>

# Description

Add better handling of JESD params. This fix handles multiple params that are all on one line like:
```
DID: 0, BID: 0, LID: 2, L: 4, SCR: 1, F: 4
K: 32, M: 8, N: 16, CS: 0, N': 16, S: 1, HD: 1
FCHK: 0x8C, CF: 0
ADJCNT: 0, PHADJ: 0, ADJDIR: 0, JESDV: 1, SUBCLASS: 1
```

With this code:
```python
import adi
j = adi.jesd("analog-2.local")
ls = j.get_all_link_statuses()
print(ls['84a90000.axi-jesd204-rx']['lane0_info'])
```
You get
```
{'Errors': '0', 'CGS state': 'DATA', 'Initial Frame Synchronization': 'Yes', 'Lane Latency': '1 Multi-frames and 28 Octets', 'Initial Lane Alignment Sequence': 'Yes', 'DID': '0', 'BID': '0', 'LID': '2', 'L': '4', 'SCR': '1', 'F': '4', 'K': '32', 'M': '8', 'N': '16', 'CS': '0', "N'": '16', 'S': '1', 'HD': '1', 'FCHK': '0x8C', 'CF': '0', 'ADJCNT': '0', 'PHADJ': '0', 'ADJDIR': '0', 'JESDV': '1', 'SUBCLASS': '1', 'FC': '10000000'}
```

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] AD9081 Test suite

**Test Configuration**:
* Hardware: AD9081+ZCU102
* OS: Ubuntu 20.04

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
