### PR TITLE
Add AD9081 Rx gains, Tx en, and DAC current API

### DIFF
--- a/adi/ad9081.py
+++ b/adi/ad9081.py
@@ -276,6 +276,35 @@ class ad9081(rx_tx, context_manager):
         )
 
     @property
+    def rx_main_6dB_digital_gains(self):
+        """rx_main_6dB_digital_gains: Enable 6dB of gain per CDDC"""
+        return self._get_iio_attr_vec(
+            self._rx_coarse_ddc_channel_names, "main_6db_digital_gain_en", False
+        )
+
+    @rx_main_6dB_digital_gains.setter
+    def rx_main_6dB_digital_gains(self, value):
+        self._set_iio_attr_int_vec(
+            self._rx_coarse_ddc_channel_names, "main_6db_digital_gain_en", False, value,
+        )
+
+    @property
+    def rx_channel_6dB_digital_gains(self):
+        """rx_channel_6dB_digital_gains: Enable 6dB of gain per FDDC"""
+        return self._get_iio_attr_vec(
+            self._rx_fine_ddc_channel_names, "channel_6db_digital_gain_en", False
+        )
+
+    @rx_channel_6dB_digital_gains.setter
+    def rx_channel_6dB_digital_gains(self, value):
+        self._set_iio_attr_int_vec(
+            self._rx_fine_ddc_channel_names,
+            "channel_6db_digital_gain_en",
+            False,
+            value,
+        )
+
+    @property
     def tx_channel_nco_frequencies(self):
         """tx_channel_nco_frequencies: Transmit path fine DUC NCO frequencies"""
         return self._get_iio_attr_vec(
@@ -435,6 +464,28 @@ class ad9081(rx_tx, context_manager):
         self._set_iio_attr_single(
             "voltage0_i", "main_ffh_mode", True, value,
         )
+
+    @property
+    def tx_dac_en(self):
+        """tx_dac_en: Enable DACs"""
+        return self._get_iio_attr_vec(self._tx_coarse_duc_channel_names, "en", True)
+
+    @tx_dac_en.setter
+    def tx_dac_en(self, value):
+        self._set_iio_attr_int_vec(
+            self._tx_coarse_duc_channel_names, "en", True, value,
+        )
+
+    @property
+    def tx_dac_full_scale_current(self):
+        """tx_dac_full_scale_current: Set full scale current of DACs. This value
+        is in microamps.
+        """
+        return self._get_iio_debug_attr("dac-full-scale-current-ua", self._rxadc)
+
+    @tx_dac_full_scale_current.setter
+    def tx_dac_full_scale_current(self, value):
+        self._set_iio_debug_attr("dac-full-scale-current-ua", value, self._rxadc)
 
     @property
     def loopback_mode(self):


### PR DESCRIPTION
Signed-off-by: Travis F. Collins <travis.collins@analog.com>

# Description

Add some missing properties for MxFE for RX gains and some TX controls.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How has this been tested?

- [x] Ran existing AD9081 tests, all passing

**Test Configuration**:
* Hardware: AD9081+ZCU102
* OS: Ubuntu 20.04

# Documentation

If this is a new feature or example please mention or link any documentation. All new hardware interface classes require documentation.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
