### PR TITLE
Update DAC current API of AD9081 to reflect read-only

### DIFF
--- a/adi/ad9081.py
+++ b/adi/ad9081.py
@@ -476,16 +476,16 @@ class ad9081(rx_tx, context_manager):
             self._tx_coarse_duc_channel_names, "en", True, value,
         )
 
-    @property
-    def tx_dac_full_scale_current(self):
+    def set_tx_dac_full_scale_current(self, value):
         """tx_dac_full_scale_current: Set full scale current of DACs. This value
         is in microamps.
         """
-        return self._get_iio_debug_attr("dac-full-scale-current-ua", self._rxadc)
+        self._set_iio_debug_attr_str(
+            "dac-full-scale-current-ua", str(value), self._rxadc
+        )
 
-    @tx_dac_full_scale_current.setter
-    def tx_dac_full_scale_current(self, value):
-        self._set_iio_debug_attr("dac-full-scale-current-ua", value, self._rxadc)
+    # we cannot read current as the driver will just throw EPERM
+    tx_dac_full_scale_current = property(None, set_tx_dac_full_scale_current)
 
     @property
     def loopback_mode(self):


### PR DESCRIPTION
Signed-off-by: Travis F. Collins <travis.collins@analog.com>

# Description

Fix AD9081 DAC current API to be read-only like the attribute

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran built-in test suite

**Test Configuration**:
* Hardware: AD9081+ZCU102
* OS: Ubuntu 18.04

# Documentation

If this is a new feature or example please mention or link any documentation. All new hardware interface classes require documentation.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
