### PR TITLE
Ad9081 nyquist zone per adc

### DIFF
--- a/adi/ad9081.py
+++ b/adi/ad9081.py
@@ -267,12 +267,14 @@ class ad9081(rx_tx, context_manager):
     @property
     def rx_nyquist_zone(self):
         """rx_nyquist_zone: ADC nyquist zone. Options are: odd, even"""
-        return self._get_iio_attr_str_single("voltage0_i", "nyquist_zone", False)
+        return self._get_iio_attr_str_vec(
+            self._rx_coarse_ddc_channel_names, "nyquist_zone", False
+        )
 
     @rx_nyquist_zone.setter
     def rx_nyquist_zone(self, value):
-        self._set_iio_attr_single(
-            "voltage0_i", "nyquist_zone", False, value,
+        self._set_iio_attr_str_vec(
+            self._rx_coarse_ddc_channel_names, "nyquist_zone", False, value,
         )
 
     @property

--- a/adi/attribute.py
+++ b/adi/attribute.py
@@ -131,6 +131,15 @@ class attribute:
         for i, v in enumerate(values):
             self._set_iio_attr_int(channel_names[i], attr_name, output, v, _ctrl)
 
+    def _set_iio_attr_str_vec(
+        self, channel_names, attr_name, output, values, _ctrl=None
+    ):
+        """ Set channel attribute with list of strings """
+        if not isinstance(values, list):
+            raise Exception("Value must be a list")
+        for i, v in enumerate(list(values)):
+            self._set_iio_attr(channel_names[i], attr_name, output, v, _ctrl)
+
     def _get_iio_attr_str(self, channel_name, attr_name, output, _ctrl=None):
         """ Get channel attribute as string """
         if _ctrl:
@@ -152,6 +161,14 @@ class attribute:
         vals = []
         for chn in channel_names:
             v = self._get_iio_attr(chn, attr_name, output, _ctrl)
+            vals.append(v)
+        return vals
+
+    def _get_iio_attr_str_vec(self, channel_names, attr_name, output, _ctrl=None):
+        """ Get channel attributes as list of numbers """
+        vals = []
+        for chn in channel_names:
+            v = self._get_iio_attr_str(chn, attr_name, output, _ctrl)
             vals.append(v)
         return vals
 

--- a/examples/QuadMxFE_dual_example.py
+++ b/examples/QuadMxFE_dual_example.py
@@ -131,7 +131,7 @@ multi.hmc7044_car_output_delay(9, 1, 0)
 for dev in multi.secondaries + [multi.primary]:
 
     # Number of MxFE Devices
-    D = len(dev.rx_nyquist_zone)
+    D = len(dev.rx_test_mode)
 
     # Total number of channels
     N_RX = len(dev.rx_channel_nco_frequencies["axi-ad9081-rx-3"]) * D
@@ -179,7 +179,7 @@ for dev in multi.secondaries + [multi.primary]:
 
     dev.rx_enabled_channels = RX_CHAN_EN
     dev.tx_enabled_channels = [1] * N_TX
-    dev.rx_nyquist_zone = ["even"] * D
+    dev.rx_nyquist_zone = ["even"] * NM_TX
 
     dev.rx_buffer_size = 2 ** 12
     dev.tx_cyclic_buffer = True

--- a/examples/QuadMxFE_example.py
+++ b/examples/QuadMxFE_example.py
@@ -88,7 +88,7 @@ def measure_and_adjust_phase_offset(chan0, chan1, phase_correction):
 dev = adi.QuadMxFE("ip:10.44.3.52", calibration_board_attached=True)
 
 # Number of MxFE Devices
-D = len(dev.rx_nyquist_zone)
+D = len(dev.rx_test_mode)
 
 # Total number of channels
 N_RX = len(dev.rx_channel_nco_frequencies["axi-ad9081-rx-3"]) * D
@@ -134,7 +134,7 @@ dev.tx_main_nco_frequencies = [3000000000] * NM_TX
 
 dev.rx_enabled_channels = RX_CHAN_EN
 dev.tx_enabled_channels = [1] * N_TX
-dev.rx_nyquist_zone = ["even"] * D
+dev.rx_nyquist_zone = ["even"] * NM_TX
 
 dev.rx_buffer_size = 2 ** 12
 dev.tx_cyclic_buffer = True

--- a/examples/ad9081_dma_example.py
+++ b/examples/ad9081_dma_example.py
@@ -60,7 +60,7 @@ dev.tx_main_nco_frequencies = [1000000000] * 4
 
 dev.rx_enabled_channels = [0]
 dev.tx_enabled_channels = [0]
-dev.rx_nyquist_zone = "odd"
+dev.rx_nyquist_zone = ["odd"] * 4
 
 dev.rx_buffer_size = 2 ** 16
 dev.tx_cyclic_buffer = True

--- a/examples/ad9081_example.py
+++ b/examples/ad9081_example.py
@@ -51,7 +51,7 @@ dev.tx_main_nco_frequencies = [1000000000] * 4
 
 dev.rx_enabled_channels = [0]
 dev.tx_enabled_channels = [0]
-dev.rx_nyquist_zone = "odd"
+dev.rx_nyquist_zone = ["odd"] * 4
 
 dev.rx_buffer_size = 2 ** 16
 dev.tx_cyclic_buffer = True

--- a/test/common.py
+++ b/test/common.py
@@ -111,9 +111,14 @@ def dev_interface(uri, classname, val, attr, tol):
     setattr(sdr, attr, val)
     rval = getattr(sdr, attr)
 
+    del sdr
+
     if not isinstance(rval, str) and not is_list:
         rval = float(rval)
-    del sdr
+
+    if is_list and isinstance(rval[0], str):
+        return val == rval
+
     if not isinstance(val, str):
         abs_val = np.argmax(abs(np.array(val) - np.array(rval)))
         if abs_val > tol:

--- a/test/test_ad9081.py
+++ b/test/test_ad9081.py
@@ -104,7 +104,7 @@ def test_ad9081_tx_data(test_dma_tx, iio_uri, classname, channel):
     [
         dict(
             loopback_mode=0,
-            rx_nyquist_zone="odd",
+            rx_nyquist_zone=["odd", "odd", "odd", "odd"],
             tx_channel_nco_gain_scales=[0.5, 0.5, 0.5, 0.5],
             rx_main_nco_frequencies=[1000000000, 1000000000, 1000000000, 1000000000],
             tx_main_nco_frequencies=[1000000000, 1000000000, 1000000000, 1000000000],


### PR DESCRIPTION
# Description

Starting with the next API release the rx_nyquist_zone can be controlled individually per ADC.
This feature should be backwards compatible.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.


- [X] New feature (non-breaking change which adds functionality)

# How has this been tested?

Tested on HW

**Test Configuration**:
* Hardware:
* OS:

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have signed off all commits and they contain "Signed-off by: <insert name>"

