### PR TITLE
Mirror AD9361's and AD9364's Manual Tests

### DIFF
--- a/test/test_ad9361_p.py
+++ b/test/test_ad9361_p.py
@@ -155,7 +155,7 @@ def test_ad9361_loopback_attr(
 
 
 #########################################
-@pytest.mark.iio_hardware(hardware)
+@pytest.mark.iio_hardware(hardware, True)
 @pytest.mark.parametrize("classname", [(classname)])
 @pytest.mark.parametrize("channel", [0, 1, [0, 1]])
 def test_ad9361_rx_data(test_dma_rx, iio_uri, classname, channel):
@@ -171,7 +171,7 @@ def test_ad9361_tx_data(test_dma_tx, iio_uri, classname, channel):
 
 
 #########################################
-@pytest.mark.iio_hardware(hardware)
+@pytest.mark.iio_hardware(hardware, True)
 @pytest.mark.parametrize("classname", [(classname)])
 @pytest.mark.parametrize("channel", [0, 1])
 def test_ad9361_loopback(test_dma_loopback, iio_uri, classname, channel):
@@ -179,7 +179,7 @@ def test_ad9361_loopback(test_dma_loopback, iio_uri, classname, channel):
 
 
 #########################################
-@pytest.mark.iio_hardware(hardware)
+@pytest.mark.iio_hardware(hardware, True)
 @pytest.mark.parametrize("classname", [(classname)])
 @pytest.mark.parametrize("channel", [0])
 @pytest.mark.parametrize(
@@ -213,7 +213,7 @@ def test_ad9361_sfdr(test_sfdr, iio_uri, classname, channel, param_set, sfdr_min
 
 
 #########################################
-@pytest.mark.iio_hardware(hardware)
+@pytest.mark.iio_hardware(hardware, True)
 @pytest.mark.parametrize("classname", [(classname)])
 @pytest.mark.parametrize("channel", [0, 1])
 @pytest.mark.parametrize(
@@ -293,7 +293,7 @@ def test_ad9361_dds_gain_check_vary_power(
 
 
 #########################################
-@pytest.mark.iio_hardware(hardware)
+@pytest.mark.iio_hardware(hardware, True)
 @pytest.mark.parametrize("classname", [(classname)])
 @pytest.mark.parametrize("channel", [0, 1])
 @pytest.mark.parametrize(
@@ -320,7 +320,7 @@ def test_ad9361_dds_gain_check_agc(
 
 
 #########################################
-@pytest.mark.iio_hardware(hardware)
+@pytest.mark.iio_hardware(hardware, True)
 @pytest.mark.parametrize("classname", [(classname)])
 @pytest.mark.parametrize("channel", [0, 1])
 @pytest.mark.parametrize(
@@ -360,7 +360,7 @@ def test_ad9361_dds_loopback(
 
 
 #########################################
-@pytest.mark.iio_hardware(hardware)
+@pytest.mark.iio_hardware(hardware, True)
 @pytest.mark.parametrize("classname", [(classname)])
 @pytest.mark.parametrize("channel", [0])
 @pytest.mark.parametrize(

--- a/test/test_ad9361_p.py
+++ b/test/test_ad9361_p.py
@@ -3,6 +3,116 @@ import pytest
 hardware = ["packrf", "adrv9361", "fmcomms2", "ad9361"]
 classname = "adi.ad9361"
 
+params = dict(
+    one_cw_tone_manual=dict(
+        tx_lo=2300000000,
+        rx_lo=2300000000,
+        sample_rate=30720000,
+        tx_rf_bandwidth=18000000,
+        rx_rf_bandwidth=18000000,
+        gain_control_mode_chan0="manual",
+        gain_control_mode_chan1="manual",
+        rx_hardwaregain_chan0=0,
+        rx_hardwaregain_chan1=0,
+        tx_hardwaregain_chan0=0,
+        tx_hardwaregain_chan1=0,
+    ),
+    one_cw_tone_slow_attack=dict(
+        tx_lo=2300000000,
+        rx_lo=2300000000,
+        sample_rate=30720000,
+        tx_rf_bandwidth=18000000,
+        rx_rf_bandwidth=18000000,
+        gain_control_mode_chan0="slow_attack",
+        gain_control_mode_chan1="slow_attack",
+        tx_hardwaregain_chan0=-10,
+        tx_hardwaregain_chan1=-10,
+    ),
+    change_attenuation_20dB_slow_attack=dict(
+        tx_lo=2300000000,
+        rx_lo=2300000000,
+        sample_rate=30720000,
+        tx_rf_bandwidth=18000000,
+        rx_rf_bandwidth=18000000,
+        gain_control_mode_chan0="slow_attack",
+        gain_control_mode_chan1="slow_attack",
+        tx_hardwaregain_chan0=-20,
+        tx_hardwaregain_chan1=-20,
+    ),
+    change_attenuation_0dB_slow_attack=dict(
+        tx_lo=2300000000,
+        rx_lo=2300000000,
+        sample_rate=30720000,
+        tx_rf_bandwidth=18000000,
+        rx_rf_bandwidth=18000000,
+        gain_control_mode_chan0="slow_attack",
+        gain_control_mode_chan1="slow_attack",
+        tx_hardwaregain_chan0=0,
+        tx_hardwaregain_chan1=0,
+    ),
+    change_sampling_rate_60MSPS_slow_attack=dict(
+        tx_lo=2300000000,
+        rx_lo=2300000000,
+        sample_rate=60710000,
+        tx_rf_bandwidth=18000000,
+        rx_rf_bandwidth=18000000,
+        gain_control_mode_chan0="slow_attack",
+        gain_control_mode_chan1="slow_attack",
+        tx_hardwaregain_chan0=-10,
+        tx_hardwaregain_chan1=-10,
+    ),
+    change_sampling_rate_15MSPS_slow_attack=dict(
+        tx_lo=2300000000,
+        rx_lo=2300000000,
+        sample_rate=15000000,
+        tx_rf_bandwidth=18000000,
+        rx_rf_bandwidth=18000000,
+        gain_control_mode_chan0="slow_attack",
+        gain_control_mode_chan1="slow_attack",
+        tx_hardwaregain_chan0=-10,
+        tx_hardwaregain_chan1=-10,
+    ),
+    change_attenuation_10dB_manual=dict(
+        tx_lo=2300000000,
+        rx_lo=2300000000,
+        sample_rate=30720000,
+        tx_rf_bandwidth=18000000,
+        rx_rf_bandwidth=18000000,
+        gain_control_mode_chan0="manual",
+        gain_control_mode_chan1="manual",
+        rx_hardwaregain_chan0=0,
+        rx_hardwaregain_chan1=0,
+        tx_hardwaregain_chan0=-10,
+        tx_hardwaregain_chan1=-10,
+    ),
+    change_attenuation_5dB_manual=dict(
+        tx_lo=2300000000,
+        rx_lo=2300000000,
+        sample_rate=30720000,
+        tx_rf_bandwidth=18000000,
+        rx_rf_bandwidth=18000000,
+        gain_control_mode_chan0="manual",
+        gain_control_mode_chan1="manual",
+        rx_hardwaregain_chan0=0,
+        rx_hardwaregain_chan1=0,
+        tx_hardwaregain_chan0=-5,
+        tx_hardwaregain_chan1=-5,
+    ),
+    change_rf_gain_5dB_manual=dict(
+        tx_lo=2300000000,
+        rx_lo=2300000000,
+        sample_rate=30720000,
+        tx_rf_bandwidth=18000000,
+        rx_rf_bandwidth=18000000,
+        gain_control_mode_chan0="manual",
+        gain_control_mode_chan1="manual",
+        rx_hardwaregain_chan0=5,
+        rx_hardwaregain_chan1=5,
+        tx_hardwaregain_chan0=0,
+        tx_hardwaregain_chan1=0,
+    ),
+)
+
 
 #########################################
 @pytest.mark.iio_hardware(hardware)
@@ -73,20 +183,31 @@ def test_ad9361_loopback(test_dma_loopback, iio_uri, classname, channel):
 @pytest.mark.parametrize("classname", [(classname)])
 @pytest.mark.parametrize("channel", [0])
 @pytest.mark.parametrize(
-    "param_set",
+    "param_set, sfdr_min",
     [
-        dict(
-            sample_rate=4000000,
-            tx_lo=1000000000,
-            rx_lo=1000000000,
-            gain_control_mode_chan0="slow_attack",
-            tx_hardwaregain_chan0=-20,
-            gain_control_mode_chan1="slow_attack",
-            tx_hardwaregain_chan1=-20,
-        )
+        (
+            dict(
+                sample_rate=4000000,
+                tx_lo=1000000000,
+                rx_lo=1000000000,
+                gain_control_mode_chan0="slow_attack",
+                tx_hardwaregain_chan0=-20,
+                gain_control_mode_chan1="slow_attack",
+                tx_hardwaregain_chan1=-20,
+            ),
+            40,
+        ),
+        (params["one_cw_tone_manual"], 23),
+        (params["change_attenuation_10dB_manual"], 37),
+        (params["change_attenuation_5dB_manual"], 29),
+        (params["change_rf_gain_5dB_manual"], 23),
+        (params["one_cw_tone_slow_attack"], 23),
+        (params["change_attenuation_20dB_slow_attack"], 43),
+        (params["change_attenuation_0dB_slow_attack"], 23),
+        (params["change_sampling_rate_60MSPS_slow_attack"], 51),
+        (params["change_sampling_rate_15MSPS_slow_attack"], 52),
     ],
 )
-@pytest.mark.parametrize("sfdr_min", [40])
 def test_ad9361_sfdr(test_sfdr, iio_uri, classname, channel, param_set, sfdr_min):
     test_sfdr(iio_uri, classname, channel, param_set, sfdr_min)
 
@@ -125,7 +246,149 @@ def test_ad9361_sfdr(test_sfdr, iio_uri, classname, channel, param_set, sfdr_min
             gain_control_mode_chan1="slow_attack",
             tx_hardwaregain_chan1=-20,
         ),
+        params["one_cw_tone_manual"],
+        params["change_attenuation_10dB_manual"],
+        params["change_attenuation_5dB_manual"],
+        params["change_rf_gain_5dB_manual"],
+        params["one_cw_tone_slow_attack"],
+        params["change_attenuation_20dB_slow_attack"],
+        params["change_attenuation_0dB_slow_attack"],
+        params["change_sampling_rate_60MSPS_slow_attack"],
+        params["change_sampling_rate_15MSPS_slow_attack"],
     ],
 )
 def test_ad9361_iq_loopback(test_iq_loopback, iio_uri, classname, channel, param_set):
     test_iq_loopback(iio_uri, classname, channel, param_set)
+
+
+#########################################
+@pytest.mark.iio_hardware(hardware)
+@pytest.mark.parametrize("classname", [(classname)])
+@pytest.mark.parametrize("channel", [0, 1])
+@pytest.mark.parametrize(
+    "param_set, dds_scale, min_rssi, max_rssi",
+    [
+        (params["one_cw_tone_manual"], 0.12, 23.25, 25.25),
+        (params["one_cw_tone_manual"], 0.25, 17, 20),
+        (params["one_cw_tone_manual"], 0.25, 17, 20),
+        (params["one_cw_tone_manual"], 0.06, 28, 31.5),
+        (params["change_rf_gain_5dB_manual"], 0.25, 21, 23),
+        (params["change_attenuation_10dB_manual"], 0.25, 25, 28),
+        (params["change_attenuation_5dB_manual"], 0.25, 21, 24),
+    ],
+)
+def test_ad9361_dds_gain_check_vary_power(
+    test_gain_check,
+    iio_uri,
+    classname,
+    channel,
+    param_set,
+    dds_scale,
+    min_rssi,
+    max_rssi,
+):
+    test_gain_check(
+        iio_uri, classname, channel, param_set, dds_scale, min_rssi, max_rssi
+    )
+
+
+#########################################
+@pytest.mark.iio_hardware(hardware)
+@pytest.mark.parametrize("classname", [(classname)])
+@pytest.mark.parametrize("channel", [0, 1])
+@pytest.mark.parametrize(
+    "param_set, dds_scale, min_rssi, max_rssi",
+    [
+        (params["one_cw_tone_slow_attack"], 0.06, 42.75, 45.75),
+        (params["change_attenuation_20dB_slow_attack"], 0.06, 53.75, 56.75),
+        (params["change_attenuation_0dB_slow_attack"], 0.06, 32, 35),
+    ],
+)
+def test_ad9361_dds_gain_check_agc(
+    test_gain_check,
+    iio_uri,
+    classname,
+    channel,
+    param_set,
+    dds_scale,
+    min_rssi,
+    max_rssi,
+):
+    test_gain_check(
+        iio_uri, classname, channel, param_set, dds_scale, min_rssi, max_rssi
+    )
+
+
+#########################################
+@pytest.mark.iio_hardware(hardware)
+@pytest.mark.parametrize("classname", [(classname)])
+@pytest.mark.parametrize("channel", [0, 1])
+@pytest.mark.parametrize(
+    "param_set, frequency, scale, peak_min",
+    [
+        (params["one_cw_tone_manual"], 2000000, 0.12, -45),
+        (params["one_cw_tone_manual"], 2000000, 0.25, -40),
+        (params["one_cw_tone_manual"], 2000000, 0.06, -50),
+        (params["change_attenuation_10dB_manual"], 2000000, 0.25, -48),
+        (params["change_attenuation_5dB_manual"], 2000000, 0.25, -43.5),
+        (params["change_rf_gain_5dB_manual"], 2000000, 0.25, -34),
+        (params["one_cw_tone_slow_attack"], 500000, 0.06, -41.5),
+        (params["one_cw_tone_slow_attack"], 1000000, 0.06, -41.5),
+        (params["one_cw_tone_slow_attack"], 2000000, 0.06, -41.5),
+        (params["one_cw_tone_slow_attack"], 2000000, 0.12, -41.5),
+        (params["one_cw_tone_slow_attack"], 3000000, 0.25, -41.5),
+        (params["one_cw_tone_slow_attack"], 4000000, 0.5, -41.5),
+        (params["change_sampling_rate_60MSPS_slow_attack"], 2000000, 0.06, -41.5),
+        (params["change_sampling_rate_15MSPS_slow_attack"], 2000000, 0.06, -41.5),
+        (params["change_attenuation_20dB_slow_attack"], 1000000, 0.06, -43),
+        (params["change_attenuation_0dB_slow_attack"], 1000000, 0.06, -43),
+    ],
+)
+def test_ad9361_dds_loopback(
+    test_dds_loopback,
+    iio_uri,
+    classname,
+    param_set,
+    channel,
+    frequency,
+    scale,
+    peak_min,
+):
+    test_dds_loopback(
+        iio_uri, classname, param_set, channel, frequency, scale, peak_min
+    )
+
+
+#########################################
+@pytest.mark.iio_hardware(hardware)
+@pytest.mark.parametrize("classname", [(classname)])
+@pytest.mark.parametrize("channel", [0])
+@pytest.mark.parametrize(
+    "param_set, frequency1, scale1, peak_min1, frequency2, scale2, peak_min2",
+    [(params["one_cw_tone_slow_attack"], 1000000, 0.06, -20, 2000000, 0.12, -40,)],
+)
+def test_ad9361_two_tone_loopback(
+    test_dds_two_tone,
+    iio_uri,
+    classname,
+    channel,
+    param_set,
+    frequency1,
+    scale1,
+    peak_min1,
+    frequency2,
+    scale2,
+    peak_min2,
+):
+    test_dds_two_tone(
+        iio_uri,
+        classname,
+        channel,
+        param_set,
+        frequency1,
+        scale1,
+        peak_min1,
+        frequency2,
+        scale2,
+        peak_min2,
+    )

--- a/test/test_ad9364_p.py
+++ b/test/test_ad9364_p.py
@@ -280,7 +280,7 @@ def test_ad9364_dds_gain_check_agc(
 
 
 #########################################
-@pytest.mark.iio_hardware(hardware)
+@pytest.mark.iio_hardware(hardware, True)
 @pytest.mark.parametrize("classname", [(classname)])
 @pytest.mark.parametrize("channel", [0])
 @pytest.mark.parametrize(
@@ -332,7 +332,7 @@ def test_ad9364_dds_loopback(
 
 
 #########################################
-@pytest.mark.iio_hardware(hardware)
+@pytest.mark.iio_hardware(hardware, True)
 @pytest.mark.parametrize("classname", [(classname)])
 @pytest.mark.parametrize("channel", [0])
 @pytest.mark.parametrize(
@@ -375,7 +375,7 @@ def test_ad9364_iq_loopback(test_iq_loopback, iio_uri, classname, channel, param
 
 
 #########################################
-@pytest.mark.iio_hardware(hardware)
+@pytest.mark.iio_hardware(hardware, True)
 @pytest.mark.parametrize("classname", [(classname)])
 @pytest.mark.parametrize("channel", [0])
 @pytest.mark.parametrize(

--- a/test/test_ad9364_p.py
+++ b/test/test_ad9364_p.py
@@ -3,6 +3,94 @@ import pytest
 hardware = ["fmcomms4", "adrv9364", "pluto", "adrv9361"]
 classname = "adi.ad9364"
 
+params = dict(
+    one_cw_tone_manual=dict(
+        tx_lo=2300000000,
+        rx_lo=2300000000,
+        sample_rate=30720000,
+        tx_rf_bandwidth=18000000,
+        rx_rf_bandwidth=18000000,
+        gain_control_mode_chan0="manual",
+        rx_hardwaregain_chan0=0,
+        tx_hardwaregain_chan0=0,
+    ),
+    change_attenuation_10dB_manual=dict(
+        tx_lo=2300000000,
+        rx_lo=2300000000,
+        sample_rate=30720000,
+        tx_rf_bandwidth=18000000,
+        rx_rf_bandwidth=18000000,
+        gain_control_mode_chan0="manual",
+        rx_hardwaregain_chan0=0,
+        tx_hardwaregain_chan0=-10,
+    ),
+    change_attenuation_5dB_manual=dict(
+        tx_lo=2300000000,
+        rx_lo=2300000000,
+        sample_rate=30720000,
+        tx_rf_bandwidth=18000000,
+        rx_rf_bandwidth=18000000,
+        gain_control_mode_chan0="manual",
+        rx_hardwaregain_chan0=0,
+        tx_hardwaregain_chan0=-5,
+    ),
+    change_rf_gain_5dB_manual=dict(
+        tx_lo=2300000000,
+        rx_lo=2300000000,
+        sample_rate=30720000,
+        tx_rf_bandwidth=18000000,
+        rx_rf_bandwidth=18000000,
+        gain_control_mode_chan0="manual",
+        rx_hardwaregain_chan0=5,
+        tx_hardwaregain_chan0=0,
+    ),
+    one_cw_tone_slow_attack=dict(
+        tx_lo=2300000000,
+        rx_lo=2300000000,
+        sample_rate=30720000,
+        tx_rf_bandwidth=18000000,
+        rx_rf_bandwidth=18000000,
+        gain_control_mode_chan0="slow_attack",
+        tx_hardwaregain_chan0=-10,
+    ),
+    change_sampling_rate_60MSPS_slow_attack=dict(
+        tx_lo=2300000000,
+        rx_lo=2300000000,
+        sample_rate=60710000,
+        tx_rf_bandwidth=18000000,
+        rx_rf_bandwidth=18000000,
+        gain_control_mode_chan0="slow_attack",
+        tx_hardwaregain_chan0=-10,
+    ),
+    change_sampling_rate_15MSPS_slow_attack=dict(
+        tx_lo=2300000000,
+        rx_lo=2300000000,
+        sample_rate=15000000,
+        tx_rf_bandwidth=18000000,
+        rx_rf_bandwidth=18000000,
+        gain_control_mode_chan0="slow_attack",
+        tx_hardwaregain_chan0=-10,
+    ),
+    change_attenuation_0dB_slow_attack=dict(
+        tx_lo=2300000000,
+        rx_lo=2300000000,
+        sample_rate=30720000,
+        tx_rf_bandwidth=18000000,
+        rx_rf_bandwidth=18000000,
+        gain_control_mode_chan0="slow_attack",
+        tx_hardwaregain_chan0=0,
+    ),
+    change_attenuation_20dB_slow_attack=dict(
+        tx_lo=2300000000,
+        rx_lo=2300000000,
+        sample_rate=30720000,
+        tx_rf_bandwidth=18000000,
+        rx_rf_bandwidth=18000000,
+        gain_control_mode_chan0="slow_attack",
+        tx_hardwaregain_chan0=-20,
+    ),
+)
+
 
 #########################################
 @pytest.mark.iio_hardware(hardware)
@@ -101,45 +189,133 @@ def test_ad9364_loopback(test_dma_loopback, iio_uri, classname, channel):
     test_dma_loopback(iio_uri, classname, channel)
 
 
-#########################################
+########################################
 @pytest.mark.iio_hardware(hardware, True)
 @pytest.mark.parametrize("classname", [(classname)])
 @pytest.mark.parametrize("channel", [0])
 @pytest.mark.parametrize(
-    "param_set",
+    "param_set, sfdr_min",
     [
-        dict(
-            tx_lo=1000000000,
-            rx_lo=1000000000,
-            gain_control_mode_chan0="slow_attack",
-            tx_hardwaregain_chan0=-20,
-            sample_rate=4000000,
-        )
+        (
+            dict(
+                tx_lo=1000000000,
+                rx_lo=1000000000,
+                gain_control_mode_chan0="slow_attack",
+                tx_hardwaregain_chan0=-20,
+                sample_rate=4000000,
+            ),
+            40,
+        ),
+        (params["one_cw_tone_manual"], 27),
+        (params["one_cw_tone_slow_attack"], 40),
+        (params["change_attenuation_20dB_slow_attack"], 44),
+        (params["change_attenuation_0dB_slow_attack"], 27),
+        (params["change_sampling_rate_60MSPS_slow_attack"], 49),
+        (params["change_sampling_rate_15MSPS_slow_attack"], 51),
+        (params["change_attenuation_10dB_manual"], 40),
+        (params["change_attenuation_5dB_manual"], 32),
+        (params["change_rf_gain_5dB_manual"], 28),
     ],
 )
-@pytest.mark.parametrize("sfdr_min", [40])
 def test_ad9364_sfdr(test_sfdr, iio_uri, classname, channel, param_set, sfdr_min):
     test_sfdr(iio_uri, classname, channel, param_set, sfdr_min)
 
 
+########################################
+@pytest.mark.iio_hardware(hardware, True)
+@pytest.mark.parametrize("classname", [(classname)])
+@pytest.mark.parametrize("channel", [0])
+@pytest.mark.parametrize(
+    "param_set, dds_scale, min_rssi, max_rssi",
+    [
+        (params["one_cw_tone_manual"], 0.12, 24, 27),
+        (params["one_cw_tone_manual"], 0.25, 18, 21),
+        (params["one_cw_tone_manual"], 0.25, 17.5, 21.5),
+        (params["one_cw_tone_manual"], 0.06, 30, 32.5),
+        (params["change_rf_gain_5dB_manual"], 0.25, 21, 24),
+        (params["change_attenuation_10dB_manual"], 0.25, 27, 30),
+        (params["change_attenuation_5dB_manual"], 0.25, 22.5, 25.5),
+    ],
+)
+def test_ad9364_dds_gain_check_vary_power(
+    test_gain_check,
+    iio_uri,
+    classname,
+    channel,
+    param_set,
+    dds_scale,
+    min_rssi,
+    max_rssi,
+):
+    test_gain_check(
+        iio_uri, classname, channel, param_set, dds_scale, min_rssi, max_rssi
+    )
+
+
 #########################################
 @pytest.mark.iio_hardware(hardware, True)
 @pytest.mark.parametrize("classname", [(classname)])
 @pytest.mark.parametrize("channel", [0])
-@pytest.mark.parametrize("frequency, scale", [(1000000, 1)])
 @pytest.mark.parametrize(
-    "param_set",
+    "param_set, dds_scale, min_rssi, max_rssi",
     [
-        dict(
-            tx_lo=1000000000,
-            rx_lo=1000000000,
-            gain_control_mode_chan0="slow_attack",
-            tx_hardwaregain_chan0=-30,
-            sample_rate=4000000,
-        )
+        (params["one_cw_tone_slow_attack"], 0.06, 42.5, 45.5),
+        (params["change_attenuation_20dB_slow_attack"], 0.06, 53.5, 55.5),
+        (params["change_attenuation_0dB_slow_attack"], 0.06, 33.5, 35.5),
     ],
 )
-@pytest.mark.parametrize("peak_min", [-40])
+def test_ad9364_dds_gain_check_agc(
+    test_gain_check,
+    iio_uri,
+    classname,
+    channel,
+    param_set,
+    dds_scale,
+    min_rssi,
+    max_rssi,
+):
+    test_gain_check(
+        iio_uri, classname, channel, param_set, dds_scale, min_rssi, max_rssi
+    )
+
+
+#########################################
+@pytest.mark.iio_hardware(hardware)
+@pytest.mark.parametrize("classname", [(classname)])
+@pytest.mark.parametrize("channel", [0])
+@pytest.mark.parametrize(
+    "param_set, frequency, scale, peak_min",
+    [
+        (
+            dict(
+                tx_lo=1000000000,
+                rx_lo=1000000000,
+                gain_control_mode_chan0="slow_attack",
+                tx_hardwaregain_chan0=-30,
+                sample_rate=4000000,
+            ),
+            1000000,
+            0.9,
+            -40,
+        ),
+        (params["one_cw_tone_manual"], 2000000, 0.12, -45),
+        (params["one_cw_tone_manual"], 2000000, 0.25, -39),
+        (params["one_cw_tone_manual"], 2000000, 0.06, -51),
+        (params["change_attenuation_10dB_manual"], 2000000, 0.25, -47.5),
+        (params["change_attenuation_5dB_manual"], 2000000, 0.25, -43.5),
+        (params["change_rf_gain_5dB_manual"], 2000000, 0.25, -34),
+        (params["one_cw_tone_slow_attack"], 500000, 0.06, -40),
+        (params["one_cw_tone_slow_attack"], 1000000, 0.06, -40),
+        (params["one_cw_tone_slow_attack"], 2000000, 0.06, -40),
+        (params["one_cw_tone_slow_attack"], 2000000, 0.12, -40),
+        (params["one_cw_tone_slow_attack"], 3000000, 0.25, -40),
+        (params["one_cw_tone_slow_attack"], 4000000, 0.5, -40),
+        (params["change_sampling_rate_60MSPS_slow_attack"], 2000000, 0.06, -40),
+        (params["change_sampling_rate_15MSPS_slow_attack"], 2000000, 0.06, -40),
+        (params["change_attenuation_20dB_slow_attack"], 1000000, 0.06, -40),
+        (params["change_attenuation_0dB_slow_attack"], 1000000, 0.06, -40),
+    ],
+)
 def test_ad9364_dds_loopback(
     test_dds_loopback,
     iio_uri,
@@ -156,7 +332,7 @@ def test_ad9364_dds_loopback(
 
 
 #########################################
-@pytest.mark.iio_hardware(hardware, True)
+@pytest.mark.iio_hardware(hardware)
 @pytest.mark.parametrize("classname", [(classname)])
 @pytest.mark.parametrize("channel", [0])
 @pytest.mark.parametrize(
@@ -183,7 +359,51 @@ def test_ad9364_dds_loopback(
             tx_hardwaregain_chan0=-20,
             sample_rate=4000000,
         ),
+        params["one_cw_tone_manual"],
+        params["change_attenuation_10dB_manual"],
+        params["change_attenuation_5dB_manual"],
+        params["change_rf_gain_5dB_manual"],
+        params["one_cw_tone_slow_attack"],
+        params["change_attenuation_20dB_slow_attack"],
+        params["change_attenuation_0dB_slow_attack"],
+        params["change_sampling_rate_60MSPS_slow_attack"],
+        params["change_sampling_rate_15MSPS_slow_attack"],
     ],
 )
 def test_ad9364_iq_loopback(test_iq_loopback, iio_uri, classname, channel, param_set):
     test_iq_loopback(iio_uri, classname, channel, param_set)
+
+
+#########################################
+@pytest.mark.iio_hardware(hardware)
+@pytest.mark.parametrize("classname", [(classname)])
+@pytest.mark.parametrize("channel", [0])
+@pytest.mark.parametrize(
+    "param_set, frequency1, scale1, peak_min1, frequency2, scale2, peak_min2",
+    [(params["one_cw_tone_slow_attack"], 1000000, 0.06, -20, 2000000, 0.12, -40,)],
+)
+def test_ad9364_two_tone_loopback(
+    test_dds_two_tone,
+    iio_uri,
+    classname,
+    channel,
+    param_set,
+    frequency1,
+    scale1,
+    peak_min1,
+    frequency2,
+    scale2,
+    peak_min2,
+):
+    test_dds_two_tone(
+        iio_uri,
+        classname,
+        channel,
+        param_set,
+        frequency1,
+        scale1,
+        peak_min1,
+        frequency2,
+        scale2,
+        peak_min2,
+    )

--- a/test/test_fmcomms2-3_prod.py
+++ b/test/test_fmcomms2-3_prod.py
@@ -8,6 +8,8 @@ hardware = ["packrf", "adrv9361", "fmcomms3", "ad9361"]
 classname = "adi.ad9361"
 
 ##################################
+
+
 @pytest.mark.iio_hardware(hardware)
 @pytest.mark.parametrize(
     "voltage_raw, low, high",


### PR DESCRIPTION
# Description

Mirrored the manual tests for AD9361 and AD9364 from FMCOMMS2-3's and FMCOMMS4's respectively


# How has this been tested?

Tested in the Test Harness

- [x] http://10.116.171.86:8080/job/HW_tests/job/HW_pyadi_test/95/
- [x] http://10.116.171.86:8080/job/HW_tests/job/HW_pyadi_test/94/

**Test Configuration**:
* Hardware: zynq-zed-adv7511-ad9361-fmcomms2-3. zynq-zed-adv7511-ad9364-fmcomms4
* OS: ADI-KUIPER-Linux

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
