### PR TITLE
Added a condition to skip the interface gain narrowband test - ADRV9002

### DIFF
--- a/test/test_adrv9002_p.py
+++ b/test/test_adrv9002_p.py
@@ -136,6 +136,20 @@ def test_adrv9002_str_attr(
 def test_adrv9002_interface_gain_narrowband(
     test_attribute_multipe_values_with_depends, iio_uri, classname, attr, depends, val
 ):
+    from adi.adrv9002 import adrv9002
+
+    sdr = adrv9002(iio_uri)
+    if attr == "interface_gain_chan0":
+        if sdr.rx0_sample_rate > 1000000:
+            pytest.skip(
+                "Baseband RX1 Sample Rate should be less than 1MHz to run this test."
+            )
+    elif attr == "interface_gain_chan1":
+        if sdr.rx1_sample_rate > 1000000:
+            pytest.skip(
+                "Baseband RX2 Sample Rate should be less than 1MHz to run this test."
+            )
+
     test_attribute_multipe_values_with_depends(
         iio_uri, classname, attr, depends, val, 0
     )

--- a/test/test_adrv9002_p.py
+++ b/test/test_adrv9002_p.py
@@ -15,6 +15,7 @@ lte_40_lvds_stream = profile_path + "lte_40_lvds_api_48_26_4.stream"
 lte_5_cmos_profile = profile_path + "lte_5_cmos_api_48_26_4.json"
 lte_5_cmos_stream = profile_path + "lte_5_cmos_api_48_26_4.stream"
 
+
 #########################################
 @pytest.mark.iio_hardware(hardware)
 @pytest.mark.parametrize("classname", [(classname)])


### PR DESCRIPTION
# Description

Added a condition to skip the interface gain narrowband test if the baseband RX sample rate is greater than 1MHz. This answers the issue stated in [SDGSW-737](https://jira.analog.com/browse/SDGSW-737)

# How has this been tested?

Tested and verified in the Test Harness

- [x] [HW_pyadi_test #99](http://10.116.171.86:8080/blue/organizations/jenkins/HW_tests%2FHW_pyadi_test/detail/HW_pyadi_test/99/pipeline/583/)

**Test Configuration**:
* Hardware: Zed + ADRV9002, ZCU102 + ADRV9002
* OS: ADI-Kuiper-Linux

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
