### PR TITLE
Annotated buffers

### DIFF
--- a/adi/rx_tx.py
+++ b/adi/rx_tx.py
@@ -48,6 +48,8 @@ class phy(attribute):
 
 
 class rx_tx_common(attribute):
+    """Common functions for RX and TX"""
+
     def _annotate(self, data, cnames: List[str], echans: List[int]):
         return {cnames[ec]: data[i] for i, ec in enumerate(echans)}
 

--- a/adi/rx_tx.py
+++ b/adi/rx_tx.py
@@ -47,7 +47,12 @@ class phy(attribute):
         self._ctrl = []
 
 
-class rx(attribute):
+class rx_tx_common(attribute):
+    def _annotate(self, data, cnames: List[str], echans: List[int]):
+        return {cnames[ec]: data[i] for i, ec in enumerate(echans)}
+
+
+class rx(rx_tx_common):
     """Buffer handling for receive devices"""
 
     _rxadc: iio.Device = []
@@ -59,9 +64,10 @@ class rx(attribute):
     _rx_shift = 0
     __rx_buffer_size = 1024
     __rx_enabled_channels = [0]
-    rx_output_type = "raw"
+    _rx_output_type = "raw"
     __rxbuf = None
     _rx_unbuffered_data = False
+    _rx_annotated = False
 
     def __init__(self, rx_buffer_size=1024):
         if self._complex_data:
@@ -72,6 +78,28 @@ class rx(attribute):
         self._num_rx_channels = len(self._rx_channel_names)
         self.rx_enabled_channels = rx_enabled_channels
         self.rx_buffer_size = rx_buffer_size
+
+    @property
+    def rx_annotated(self) -> bool:
+        """rx_annotated: Set output data from rx() to be annotated"""
+        return self._rx_annotated
+
+    @rx_annotated.setter
+    def rx_annotated(self, value: bool):
+        """rx_annotated: Set output data from rx() to be annotated"""
+        self._rx_annotated = bool(value)
+
+    @property
+    def rx_output_type(self) -> str:
+        """rx_output_type: Set output data type from rx()"""
+        return self._rx_output_type
+
+    @rx_output_type.setter
+    def rx_output_type(self, value: str):
+        """rx_output_type: Set output data type from rx()"""
+        if value not in ["raw", "SI"]:
+            raise ValueError(f"Invalid rx_output_type: {value}. Must be raw or SI")
+        self._rx_output_type = value
 
     @property
     def rx_buffer_size(self):
@@ -134,12 +162,16 @@ class rx(attribute):
 
     def __rx_unbuffered_data(self):
         x = []
-        t = self._rx_data_si_type if self.rx_output_type == "SI" else self._rx_data_type
+        t = (
+            self._rx_data_si_type
+            if self._rx_output_type == "SI"
+            else self._rx_data_type
+        )
         for _ in range(len(self.rx_enabled_channels)):
             x.append(np.zeros(self.rx_buffer_size, dtype=t))
 
         # Get scalers first
-        if self.rx_output_type == "SI":
+        if self._rx_output_type == "SI":
             rx_scale = []
             rx_offset = []
             for i in self.rx_enabled_channels:
@@ -165,7 +197,7 @@ class rx(attribute):
                 s = self._get_iio_attr(
                     self._rx_channel_names[m], "raw", False, self._rxadc
                 )
-                if self.rx_output_type == "SI":
+                if self._rx_output_type == "SI":
                     x[i][samp] = rx_scale[i] * s + rx_offset[i]
                 else:
                     x[i][samp] = s
@@ -229,10 +261,10 @@ class rx(attribute):
         sig = []
         stride = len(self.rx_enabled_channels)
 
-        if self.rx_output_type == "raw":
+        if self._rx_output_type == "raw":
             for c in range(stride):
                 sig.append(x[c::stride])
-        elif self.rx_output_type == "SI":
+        elif self._rx_output_type == "SI":
             rx_scale = []
             rx_offset = []
             for i in self.rx_enabled_channels:
@@ -257,7 +289,7 @@ class rx(attribute):
                 raw = x[c::stride]
                 sig.append(raw * rx_scale[c] + rx_offset[c])
         else:
-            raise Exception("rx_output_type undefined")
+            raise Exception("_rx_output_type undefined")
 
         # Don't return list if a single channel
         if len(self.rx_enabled_channels) == 1:
@@ -274,15 +306,20 @@ class rx(attribute):
             Data will be complex when using a complex data device.
         """
         if self._rx_unbuffered_data:
-            return self.__rx_unbuffered_data()
+            data = self.__rx_unbuffered_data()
         else:
             if self._complex_data:
-                return self.__rx_complex()
+                data = self.__rx_complex()
             else:
-                return self.__rx_non_complex()
+                data = self.__rx_non_complex()
+        if self._rx_annotated:
+            return self._annotate(
+                data, self._rx_channel_names, self.rx_enabled_channels
+            )
+        return data
 
 
-class tx(dds, attribute):
+class tx(dds, rx_tx_common):
     """Buffer handling for transmit devices"""
 
     _tx_buffer_size = 1024

--- a/doc/source/buffers/index.rst
+++ b/doc/source/buffers/index.rst
@@ -38,6 +38,72 @@ In many cases, it can be useful to continuously transmit a signal over and over,
 
 At this point, the transmitter will keep transmitting the create sinusoid indefinitely until the buffer is destroyed or the *sdr* object destructor is called. Once data is pushed to hardware with a cyclic buffer the buffer must be manually destroyed or an error will occur if more data push. To update the buffer use the **tx_destroy_buffer** method before passing a new vector to the **tx** method.
 
+Annotated Buffers
+------------------
+
+By default buffers appear as an array or a list of arrays. This can be confusing if all your channels do not produce similar data. For example, for IMUs like ADI16495 certain channels are for acceleration data and others are for angular velocity. To label this data the *rx_annotated* property can be used. When setting it to True the output of the **rx** method will be a dictionary with keys as channel names. Here an example:
+
+.. code-block:: python
+
+ import adi
+
+ dev = adi.adis16495()
+ dev.rx_enabled_channels = [0, 3]
+ print(dev.rx())
+ dev.rx_annotated = True
+ print(dev.rx())
+
+With output
+
+.. code-block:: bash
+
+   [array([    35681,     84055,   -175914,   -203645,    698249,    -51670,
+         -1770250,   1529968,   2586191,  -5353355,   -827741,  11736339,
+         -9847894, -17242014,  97421833, 277496774], dtype=int32),
+   array([     49151,     753663,    3571711,    9928703,   18956287,
+            25165823,   18612223,  -10125313,  -60850176, -114491392,
+         -131350528,  -61521920,  135069695,  466845695,  899235839,
+         1362378751], dtype=int32)]
+   {'accel_x': array([1775091711, 2072264703, 2147483647, 2147483647, 2147483647,
+         2147483647, 2143404031, 2125430783, 2123120639, 2130821119,
+         2139488255, 2144911359, 2147041279, 2147467263, 2147483647,
+         2147483647], dtype=int32),
+   'anglvel_x': array([357750219, 335109279, 323033231, 337667193, 337100396, 330408402,
+         333459194, 335322576, 333247166, 333223475, 333996322, 333805525,
+         333659152, 333664680, 333718473, 333895650], dtype=int32)}
+
+
+Buffer Units
+---------------
+
+For certain devices it is possible to convert types to scientific units, such as volts, degrees, or meters per second among others. This is controlled by setting the property **rx_output_type** to either *raw* or *SI*. If set to *SI*, returned data from the **rx** method will be in scientific units (assuming its supported by the driver). Below is an example using an IMU:
+
+.. code-block:: python
+
+ import adi
+
+ dev = adi.adis16495()
+ dev.rx_annotated = True  # Make channel names appear in data
+ dev.rx_enabled_channels = [3]  # channel 0 is angular velocity in the x direction
+ print(dev.rx())
+ dev.rx_output_type = "SI"
+ print(dev.rx())
+
+With output
+
+.. code-block:: bash
+
+ {'anglvel_x': array([    35644,     84039,   -175647,   -203867,    697612,    -50201,
+        -1770177,   1526291,   2589741,  -5349126,   -839188,  11738313,
+        -9824911, -17267701,  97333042, 277410285], dtype=int32)}
+ {'anglvel_x': array([9.29996712, 9.71257202, 9.40097973, 9.78345151, 9.77009362,
+       9.59662456, 9.67300333, 9.71593538, 9.65847317, 9.6580597 ,
+       9.68022501, 9.67715545, 9.67511814, 9.67609361, 9.67323293,
+       9.67104074])}
+
+
+To understand the exact scaling the driver documentation should be reviewed.
+
 Members
 --------------
 .. automodule:: adi.rx_tx

--- a/doc/source/buffers/index.rst
+++ b/doc/source/buffers/index.rst
@@ -5,7 +5,7 @@ Using buffers or transmitting and receiving data is done through interacting wit
 
 For receivers this is the **rx** method. How data is captured and therefore produced by this method is dependent on two main properties:
 
-* **rx_enabled_channels**: This is an array of integers and the number of elements in the array will determine the number of list items returned by **rx**. For devices with complex data types these are the indexes of the complex channels, not the individual I or Q channels.
+* **rx_enabled_channels**: This is an array of integers (or channel names) and the number of elements in the array will determine the number of list items returned by **rx**. For devices with complex data types these are the indexes of the complex channels, not the individual I or Q channels.
 * **rx_buffer_size**: This is the number of samples returned in each column. If the device produces complex data, like a transceiver, it will return complex data. This is defined by the author of each device specific class.
 
 For transmitters this is the **tx** method. How data is sent and therefore must be passed by this method is dependent on one main property:

--- a/test/dma_tests.py
+++ b/test/dma_tests.py
@@ -16,7 +16,9 @@ except:
     do_html_log = False
 
 
-def dma_rx(uri, classname, channel, use_rx2=False):
+def dma_rx(
+    uri, classname, channel, use_rx2=False, buffer_size=2 ** 15, annotated=False
+):
     """dma_rx: Construct RX buffers and verify data is non-zero when pulled.
     Collected buffer is of size 2**15 and 10 buffers are checked
 
@@ -28,9 +30,15 @@ def dma_rx(uri, classname, channel, use_rx2=False):
         channel: type=list
             List of integers or list of list of integers of channels to
             enable through rx_enabled_channels
+        use_rx2: type=bool
+            If True, use rx2() instead of rx()
+        buffer_size: type=int
+            Size of RX buffer in samples. Defaults to 2**15
+        annotated: type=bool
+            If True, annotated output is provided (dict)
     """
     sdr = eval(classname + "(uri='" + uri + "')")
-    N = 2 ** 15
+    N = buffer_size
 
     if use_rx2:
         sdr.rx2_enabled_channels = channel if isinstance(channel, list) else [channel]
@@ -39,14 +47,23 @@ def dma_rx(uri, classname, channel, use_rx2=False):
         sdr.rx_enabled_channels = channel if isinstance(channel, list) else [channel]
         sdr.rx_buffer_size = N * len(sdr.rx_enabled_channels)
 
+    sdr.rx_annotated = annotated
     try:
         for _ in range(10):
             data = sdr.rx2() if use_rx2 else sdr.rx()
-            if isinstance(data, list):
-                for chan in data:
-                    assert np.sum(np.abs(chan)) > 0
+            if annotated:
+                print(data)
+                assert list(data.keys()) == [
+                    sdr._rx_channel_names[ec] for ec in sdr.rx_enabled_channels
+                ]
+                for ci in sdr.rx_enabled_channels:
+                    assert np.sum(np.abs(data[sdr._rx_channel_names[ci]])) > 0
             else:
-                assert np.sum(np.abs(data)) > 0
+                if isinstance(data, list):
+                    for chan in data:
+                        assert np.sum(np.abs(chan)) > 0
+                else:
+                    assert np.sum(np.abs(data)) > 0
     except Exception as e:
         del sdr
         raise Exception(e)
@@ -761,29 +778,29 @@ def gain_check(uri, classname, channel, param_set, dds_scale, min_rssi, max_rssi
 def hardwaregain(
     uri, classname, channel, dds_scale, frequency, hardwaregain_low, hardwaregain_high
 ):
-    """ hadwaregain: Test loopback with connected cables and verify
-        calculated hardware gain, by measuring changes in the AGC. This is only applicable
-        for devices with RSSI calculations onboard. This test also requires a devices
-        with TX and RX onboard where the transmit signal can be recovered. TX FPGA
-        DDSs are used to generate a sinusoid which is then received on the RX side.
+    """hadwaregain: Test loopback with connected cables and verify
+    calculated hardware gain, by measuring changes in the AGC. This is only applicable
+    for devices with RSSI calculations onboard. This test also requires a devices
+    with TX and RX onboard where the transmit signal can be recovered. TX FPGA
+    DDSs are used to generate a sinusoid which is then received on the RX side.
 
-        parameters:
-            uri: type=string
-                URI of IIO context of target board/system
-            classname: type=string
-                Name of pyadi interface class which contain attribute
-            channel: type=list
-                List of integers or list of list of integers of channels to
-                enable through tx_enabled_channels
-            dds_scale: type=float
-                Scale of DDS tone. Range [0,1]
-            frequency:
-                Frequency in hertz of the generated tone. This must be
-                less than 1/2 the sample rate.
-            hardwaregain_low: type=float
-                Minimum acceptable value of hardwaregain attribute
-            hardwaregain_high: type=float
-                Maximum acceptable value of hardwaregain attribute
+    parameters:
+        uri: type=string
+            URI of IIO context of target board/system
+        classname: type=string
+            Name of pyadi interface class which contain attribute
+        channel: type=list
+            List of integers or list of list of integers of channels to
+            enable through tx_enabled_channels
+        dds_scale: type=float
+            Scale of DDS tone. Range [0,1]
+        frequency:
+            Frequency in hertz of the generated tone. This must be
+            less than 1/2 the sample rate.
+        hardwaregain_low: type=float
+            Minimum acceptable value of hardwaregain attribute
+        hardwaregain_high: type=float
+            Maximum acceptable value of hardwaregain attribute
 
     """
     sdr = eval(classname + "(uri='" + uri + "')")
@@ -797,28 +814,28 @@ def hardwaregain(
 
 
 def harmonic_vals(classname, uri, channel, param_set, low, high, plot=False):
-    """ harmonic_vals: Test first five harmonics and check to be within
-        certain intervals. This test also requires a devices with TX and RX
-        onboard where thetransmit signal can be recovered.Sinuoidal data is
-        passed to DMAs, which is then estimated on the RX side.
+    """harmonic_vals: Test first five harmonics and check to be within
+    certain intervals. This test also requires a devices with TX and RX
+    onboard where thetransmit signal can be recovered.Sinuoidal data is
+    passed to DMAs, which is then estimated on the RX side.
 
-        parameters:
-            uri: type=string
-                URI of IIO context of target board/system
-            classname: type=string
-                Name of pyadi interface class which contain attribute
-            channel: type=list
-                List of integers or list of list of integers of channels to
-                enable through tx_enabled_channels
-            param_set: type=dict
-                Dictionary of attribute and values to be set before tone is
-                generated and received
-            low: type=list
-                List of minimum values for certain harmonics
-            high: type=list
-                List of maximum values for certain harmonics
-            plot: type=boolean
-                Boolean, if set the values are also plotted
+    parameters:
+        uri: type=string
+            URI of IIO context of target board/system
+        classname: type=string
+            Name of pyadi interface class which contain attribute
+        channel: type=list
+            List of integers or list of list of integers of channels to
+            enable through tx_enabled_channels
+        param_set: type=dict
+            Dictionary of attribute and values to be set before tone is
+            generated and received
+        low: type=list
+            List of minimum values for certain harmonics
+        high: type=list
+            List of maximum values for certain harmonics
+        plot: type=boolean
+            Boolean, if set the values are also plotted
     """
     sdr = eval(classname + "(uri='" + uri + "')")
     for p in param_set.keys():

--- a/test/test_adis16495_p.py
+++ b/test/test_adis16495_p.py
@@ -45,9 +45,15 @@ def test_adis16495_attr(
     test_attribute_single_value(iio_uri, classname, attr, start, stop, step, tol)
 
 
-@pytest.mark.skip(reason="Test is currently failing...")
 @pytest.mark.iio_hardware(hardware)
 @pytest.mark.parametrize("classname", [(classname)])
 @pytest.mark.parametrize("channel", [0, 1, 2, 3, 4, 5])
 def test_adis16495_rx_data(test_dma_rx, iio_uri, classname, channel):
-    test_dma_rx(iio_uri, classname, channel)
+    test_dma_rx(iio_uri, classname, channel, buffer_size=16)
+
+
+@pytest.mark.iio_hardware(hardware)
+@pytest.mark.parametrize("classname", [(classname)])
+@pytest.mark.parametrize("channel", [0, 1, 2, 3, 4, 5, [0, 1]])
+def test_adis16495_rx_data_annotated(test_dma_rx, iio_uri, classname, channel):
+    test_dma_rx(iio_uri, classname, channel, buffer_size=16, annotated=True)


### PR DESCRIPTION
# Description

PR adds support for annotated rx/tx buffers (doc+test included), also selecting enabled channels with strings, and documents **rx_output_type** usage.

Fixes #290 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] test_adis16495_rx_data_annotated was added to address new features

**Test Configuration**:
* Hardware: ADIS16495-3 + RPI
* OS: Ubuntu 20.04

# Documentation

New doc was added and updated for address features

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
