### PR TITLE
adi/ad9144.py: Our default configuration for the AD9144/9152 is M=2

### DIFF
--- a/adi/ad9144.py
+++ b/adi/ad9144.py
@@ -39,7 +39,7 @@ class ad9144(tx, context_manager):
     """ AD9144 High-Speed DAC """
 
     _complex_data = False
-    _tx_channel_names = ["voltage0", "voltage1", "voltage2", "voltage3"]
+    _tx_channel_names = ["voltage0", "voltage1"]
     _device_name = ""
 
     def __init__(self, uri=""):

--- a/test/test_daq2_p.py
+++ b/test/test_daq2_p.py
@@ -23,7 +23,7 @@ def test_daq2_rx_data(test_dma_rx, iio_uri, classname, channel):
 #########################################
 @pytest.mark.iio_hardware(hardware, True)
 @pytest.mark.parametrize("classname", [(classname)])
-@pytest.mark.parametrize("channel", [0, 1])
+@pytest.mark.parametrize("channel", [0])
 @pytest.mark.parametrize("param_set", [dict()])
 @pytest.mark.parametrize(
     "frequency, scale",


### PR DESCRIPTION
Up until recently the driver always registered 4 channels.
While the upper two were dis-functional.
Now the driver registers the number of channels supported in the
HDL build. The default is 2.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Hardware:
* OS:

# Documentation

If this is a new feature or example please mention or link any documentation. All new hardware interface classes require documentation.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
