### PR TITLE
AD9081 Sync Start Updates

### DIFF
--- a/adi/ad9081.py
+++ b/adi/ad9081.py
@@ -35,6 +35,7 @@ from typing import Dict, List
 
 from adi.context_manager import context_manager
 from adi.rx_tx import rx_tx
+from adi.sync_start import sync_start
 
 
 def _map_to_dict(paths, ch):
@@ -78,7 +79,7 @@ def _sortconv(chans_names, noq=False, dds=False):
     return chans_names_out
 
 
-class ad9081(rx_tx, context_manager):
+class ad9081(rx_tx, context_manager, sync_start):
     """AD9081 Mixed-Signal Front End (MxFE)"""
 
     _complex_data = True
@@ -148,6 +149,7 @@ class ad9081(rx_tx, context_manager):
                     self._tx_fine_duc_channel_names += channels
 
         rx_tx.__init__(self)
+        sync_start.__init__(self)
         self.rx_buffer_size = 2 ** 16
 
     def _get_iio_attr_str_single(self, channel_name, attr, output):

--- a/adi/ad9081.py
+++ b/adi/ad9081.py
@@ -517,7 +517,7 @@ class ad9081(rx_tx, context_manager):
         between RX and TX must be identical and only use a single
         link.
         """
-        return self._get_iio_dev_attr_single("powerdown")
+        return self._get_iio_dev_attr_single("loopback_mode")
 
     @loopback_mode.setter
     def loopback_mode(self, value):

--- a/adi/ad9081_mc.py
+++ b/adi/ad9081_mc.py
@@ -38,6 +38,7 @@ from adi.attribute import attribute
 from adi.context_manager import context_manager
 from adi.one_bit_adc_dac import one_bit_adc_dac
 from adi.rx_tx import rx_tx
+from adi.sync_start import sync_start
 
 
 def _map_to_dict(paths, ch, dev_name):
@@ -189,6 +190,7 @@ class ad9081_mc(ad9081):
 
         # Bring up DMA and DDS interfaces
         rx_tx.__init__(self)
+        sync_start.__init__(self)
         self.rx_buffer_size = 2 ** 16
 
     def _map_unique(self, paths):

--- a/adi/rx_tx.py
+++ b/adi/rx_tx.py
@@ -38,7 +38,6 @@ import iio
 import numpy as np
 from adi.attribute import attribute
 from adi.dds import dds
-from adi.sync_start import sync_start
 
 
 class phy(attribute):
@@ -55,7 +54,7 @@ class rx_tx_common(attribute):
         return {cnames[ec]: data[i] for i, ec in enumerate(echans)}
 
 
-class rx(rx_tx_common, sync_start):
+class rx(rx_tx_common):
     """Buffer handling for receive devices"""
 
     _rxadc: iio.Device = []
@@ -81,7 +80,6 @@ class rx(rx_tx_common, sync_start):
         self._num_rx_channels = len(self._rx_channel_names)
         self.rx_enabled_channels = rx_enabled_channels
         self.rx_buffer_size = rx_buffer_size
-        sync_start.__init__(self)
 
     @property
     def rx_channel_names(self) -> List[str]:
@@ -360,7 +358,7 @@ class rx(rx_tx_common, sync_start):
         return data
 
 
-class tx(dds, rx_tx_common, sync_start):
+class tx(dds, rx_tx_common):
     """Buffer handling for transmit devices"""
 
     _tx_buffer_size = 1024
@@ -379,7 +377,6 @@ class tx(dds, rx_tx_common, sync_start):
         self.tx_enabled_channels = tx_enabled_channels
         self.tx_cyclic_buffer = tx_cyclic_buffer
         dds.__init__(self)
-        sync_start.__init__(self)
 
     def __del__(self):
         self.__txbuf = []

--- a/adi/sync_start.py
+++ b/adi/sync_start.py
@@ -36,24 +36,27 @@ from adi.attribute import attribute
 
 
 class sync_start(attribute):
+    """ Synchronization Control: This class allows for synchronous transfers
+        between transmit and receive data movement or captures.
+    """
+
     @property
     def tx_sync_start(self):
         """ tx_sync_start: Issue a synchronisation request
+
         Possible values are:
-        - arm: Writing this key will arm the trigger mechanism sensitive to an
-            external sync signal. Once the external sync signal goes high
-            it synchronizes channels within a DAC, and across multiple
-            instances. This bit has an effect only the EXT_SYNC
-            synthesis parameter is set.
-
-        - disarm: Writing this key will disarm the trigger mechanism
-            sensitive to an external sync signal. This bit has an
-            effect only the EXT_SYNC synthesis parameter is set.
-
-        - trigger_manual: Writing this key will issue an external sync event
-            if it is hooked up inside the fabric. This key has an effect
-            only the EXT_SYNC synthesis parameter is set.
-            This key self clears.
+            - **arm**: Writing this key will arm the trigger mechanism sensitive to an
+              external sync signal. Once the external sync signal goes high
+              it synchronizes channels within a DAC, and across multiple
+              instances. This bit has an effect only the EXT_SYNC
+              synthesis parameter is set.
+            - **disarm**: Writing this key will disarm the trigger mechanism
+              sensitive to an external sync signal. This bit has an
+              effect only the EXT_SYNC synthesis parameter is set.
+            - **trigger_manual**: Writing this key will issue an external sync event
+              if it is hooked up inside the fabric. This key has an effect
+              only the EXT_SYNC synthesis parameter is set.
+              This key self clears.
         """
         try:
             return self._get_iio_dev_attr_str("sync_start_enable", _ctrl=self._txdac)
@@ -84,21 +87,20 @@ class sync_start(attribute):
     @property
     def rx_sync_start(self):
         """ rx_sync_start: Issue a synchronisation request
+
         Possible values are:
-        - arm: Writing this key will arm the trigger mechanism sensitive to an
-            external sync signal. Once the external sync signal goes high
-            it synchronizes channels within a ADC, and across multiple
-            instances. This bit has an effect only the EXT_SYNC
-            synthesis parameter is set.
-
-        - disarm: Writing this key will disarm the trigger mechanism
-            sensitive to an external sync signal. This bit has an
-            effect only the EXT_SYNC synthesis parameter is set.
-
-        - trigger_manual: Writing this key will issue an external sync event
-            if it is hooked up inside the fabric. This key has an effect
-            only the EXT_SYNC synthesis parameter is set.
-            This key self clears.
+            - **arm**: Writing this key will arm the trigger mechanism sensitive to an
+              external sync signal. Once the external sync signal goes high
+              it synchronizes channels within a ADC, and across multiple
+              instances. This bit has an effect only the EXT_SYNC
+              synthesis parameter is set.
+            - **disarm**: Writing this key will disarm the trigger mechanism
+              sensitive to an external sync signal. This bit has an
+              effect only the EXT_SYNC synthesis parameter is set.
+            - **trigger_manual**: Writing this key will issue an external sync event
+              if it is hooked up inside the fabric. This key has an effect
+              only the EXT_SYNC synthesis parameter is set.
+              This key self clears.
         """
         try:
             return self._get_iio_dev_attr_str("sync_start_enable", _ctrl=self._rxadc)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -46,6 +46,7 @@ extensions = [
     "sphinx_rtd_theme",
     "myst_parser",
     "sphinx-favicon",
+    "sphinxcontrib.mermaid",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/source/fpga/dma_sync.mmd
+++ b/doc/source/fpga/dma_sync.mmd
@@ -1,0 +1,7 @@
+flowchart LR
+    A[ARM DMA\n-set rx_sync_start to arm\n-set tx_sync_start to arm] --> B[Reset Buffers\n-tx_destroy_buffer\n-rx_destroy_buffer]
+    B --> C[Initialize RX buffer\n-_rx_init_channel]
+    C --> D[Fill TX DMA\n-Call tx method]
+    D --> E[Trigger TX DMA\n-set tx_sync_start to trigger_manual]
+    E --> F[Collect RX Buffer\n-Call rx method]
+    F --> A

--- a/doc/source/fpga/index.rst
+++ b/doc/source/fpga/index.rst
@@ -36,7 +36,25 @@ To configure DDSs individually a list of scales can be passed to the properties 
  sdr.dds_frequencies = [dds_freq_hz] * n
  sdr.dds_scales = [0.9] * n
 
-Methods
+DDS Methods
 ---------------------------
 .. automodule:: adi.dds
+   :members:
+
+
+DMA Synchronization
+---------------------------
+
+In certain HDL reference designs it is possible to synchronize transfers between the transmit and receive data paths. This is useful for applications such as radar processing, communications, instrumentation, and general tests.
+
+This works by leveraging special control signals inside the HDL design to trigger receive captures from transmitted buffers. These are controlled through the **sync_start** class, which provide explicit control over when data is transmitted or released from the DMA in the FPGA fabric. This transmit or trigger will in turn allow data into the receive DMA at this moment in time. The exact methods and their sequence are described in the flowchart below.
+
+.. mermaid:: dma_sync.mmd
+
+
+A full example that leverages this control is `ad9081_sync_start_example.py <https://github.com/analogdevicesinc/pyadi-iio/blob/master/examples/ad9081_sync_start_example.py>`_.
+
+Sync_Start Methods
+---------------------------
+.. automodule:: adi.sync_start
    :members:

--- a/doc/update_devs.py
+++ b/doc/update_devs.py
@@ -44,6 +44,7 @@ def update_devs():
         "rx_tx",
         "sshfs",
         "jesd_internal",
+        "sync_start",
     ]
     adi_rst_path = os.path.join(root, "source", "devices", "adi.rst")
     with open(adi_rst_path, "r") as f:

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -3,3 +3,4 @@ sphinx-rtd-theme
 myst-parser
 furo
 sphinx-favicon
+sphinxcontrib-mermaid


### PR DESCRIPTION
# Description

This PR fixes failing tests for AD9081 related to sync_start changes. It also moves sync_start to AD9081 only for now as it doesn't work across all designs. Finally, doc is added around sync_start in the FPGA section.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] All test/test_ad9081.py tests

**Test Configuration**:
* Hardware: AD9081 Emulated
* OS: Ubuntu 20.04

# Documentation

If this is a new feature or example please mention or link any documentation. All new hardware interface classes require documentation.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
