### PR TITLE
Added ad4630 support

### DIFF
--- a/adi/__init__.py
+++ b/adi/__init__.py
@@ -145,6 +145,8 @@ from adi.tdd import tdd
 
 from adi.lm75 import lm75
 
+from adi.ad4630 import ad4630
+
 try:
     from adi.jesd import jesd
 except ImportError:

--- a/adi/ad4630.py
+++ b/adi/ad4630.py
@@ -1,0 +1,231 @@
+# Copyright (C) 2022 Analog Devices, Inc.
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#     - Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     - Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#     - Neither the name of Analog Devices, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#     - The use of this software may or may not infringe the patent rights
+#       of one or more patent holders.  This license does not release you
+#       from the requirement that you obtain separate licenses from these
+#       patent holders to use this software.
+#     - Use of the software either in source or binary form, must be run
+#       on or directly connected to an Analog Devices Inc. component.
+#
+# THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED.
+#
+# IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, INTELLECTUAL PROPERTY
+# RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+import numpy as np
+from adi.attribute import attribute
+from adi.context_manager import context_manager
+from adi.rx_tx import rx
+
+
+def _sign_extend(value, nbits):
+    sign_bit = 1 << (nbits - 1)
+    return (value & (sign_bit - 1)) - (value & sign_bit)
+
+
+def _bitmask(nbits):
+    mask = 0
+    for i in range(0, nbits):
+        mask = (mask << 1) | 1
+    return mask
+
+
+class ad4630(rx, context_manager, attribute):
+
+    """ AD4630 is low power 24-bit precision SAR ADC """
+
+    _complex_data = False
+    _data_type = "voltage"
+    _device_name = ""
+    _rx_channel_names = []
+    _rx_data_type = np.uint32
+
+    """ Default part to initialize is ad4630-24. If you don't hardware test fails"""
+
+    def __init__(self, uri="", device_name="ad4630-24"):
+
+        context_manager.__init__(self, uri, self._device_name)
+
+        compatible_parts = ["ad4630-24", "ad4030-24", "ad4630-16"]
+
+        if device_name not in compatible_parts:
+            raise Exception(
+                "Not a compatible device: "
+                + device_name
+                + ". Please select from "
+                + str(compatible_parts)
+            )
+        else:
+            self._ctrl = self._ctx.find_device(device_name)
+            self._rxadc = self._ctx.find_device(device_name)
+
+        _channels = []
+        self.output_bits = []
+        for ch in self._ctrl.channels:
+            self.output_bits.append(ch.data_format.bits)
+            self._rx_channel_names.append(ch.id)
+            if "differential" in ch.name:
+                _channels.append((ch.id, self._diff_channel(self._ctrl, ch.id)))
+                if "0" in ch.name:
+                    self.chan0 = self._diff_channel(self._ctrl, ch.name)
+                if "1" in ch.name:
+                    self.chan1 = self._diff_channel(self._ctrl, ch.name)
+                continue
+
+        rx.__init__(self)
+
+    def rx(self):
+
+        if not self._rx__rxbuf:
+            self._rx_init_channels()
+        self._rx__rxbuf.refill()
+        buff = np.frombuffer(self._rx__rxbuf.read(), dtype=np.uint32)
+
+        data = [buff[0::2], buff[1::2]]
+        temp = []
+        if self._num_rx_channels != 2:
+            for ch in range(0, self._num_rx_channels):
+                nbits = self._ctrl.channels[ch].data_format.bits
+                shift = self._ctrl.channels[ch].data_format.shift
+                ch_data = np.zeros(data[int(ch / 2)].shape, dtype=np.uint32)
+                for index in range(0, len(data[int(ch / 2)])):
+                    ch_data[index] = (data[int(ch / 2)][index] >> shift) & _bitmask(
+                        nbits
+                    )
+                temp.append(np.vectorize(_sign_extend)(ch_data, nbits))
+            data = temp
+        else:
+            for idx, ch_data in enumerate(data):
+                nbits = self._ctrl.channels[idx].data_format.bits
+                temp.append(np.vectorize(_sign_extend)(ch_data, nbits))
+            data = np.vectorize(_sign_extend)(data, nbits)
+
+        return data
+
+    def output_data_mode(self):
+        """Determine the output data mode in which device is configured."""
+        if self.output_bits[0] == 30:
+            return "30bit_avg"
+        if self.output_bits[0] == 32:
+            return "32bit_test_pattern"
+        if self.output_bits[0] == 16:
+            return "16bit_diff_8bit_cm"
+        if len(self.output_bits) == 1 and self.output_bits[0] == 24:
+            return "24bit_diff"
+        if len(self.output_bits) == 2 and self.output_bits[0] == self.output_bits[1]:
+            return "24bit_diff"
+        else:
+            return "24bit_diff_8bit_cm"
+
+    @property
+    def sample_rate(self):
+        """Get/Set the sampling frequency."""
+        return self._get_iio_dev_attr("sampling_frequency")
+
+    @sample_rate.setter
+    def sample_rate(self, rate):
+        """Get/Set the sampling frequency."""
+        if str(rate) in str(self.sample_rate_avail):
+            self._set_iio_dev_attr("sampling_frequency", str(rate))
+        else:
+            raise ValueError(
+                "Error: Sample rate not supported \nUse one of: "
+                + str(self.sample_rate_avail)
+            )
+
+    @property
+    def sample_rate_avail(self):
+        """Get list of all the sampling frequency available."""
+        return self._get_iio_dev_attr("sampling_frequency_available")
+
+    @property
+    def operating_mode_avail(self):
+        """Get list of all the operating mode available."""
+        return self._get_iio_dev_attr_str("operating_mode_available")
+
+    @property
+    def operating_mode(self):
+        """Get/Set the operating mode."""
+        return self._get_iio_dev_attr_str("operating_mode")
+
+    @operating_mode.setter
+    def operating_mode(self, mode):
+        """Get/Set the operating mode."""
+        if mode in self.operating_mode_avail:
+            self._set_iio_dev_attr_str("operating_mode", mode)
+        else:
+            raise ValueError(
+                "Error: Operating mode not supported \nUse one of: "
+                + str(self.operating_mode_avail)
+            )
+
+    @property
+    def sample_averaging_avail(self):
+        """Get list of all the sample averaging values available. Only available in 30bit averaged mode."""
+        return self._get_iio_dev_attr("sample_averaging_available")
+
+    @property
+    def sample_averaging(self):
+        """Get/Set the sample averaging. Only available in 30bit averaged mode."""
+        return self._get_iio_dev_attr_str("sample_averaging")
+
+    @sample_averaging.setter
+    def sample_averaging(self, n_sample):
+        """Get/Set the sample averaging. Only available in 30bit averaged mode."""
+        if str(self.sample_averaging) != "OFF":
+            if str(n_sample) in str(self.sample_averaging_avail):
+                self._set_iio_dev_attr("sample_averaging", str(n_sample))
+            else:
+                raise ValueError(
+                    "Error: Number of avg samples not supported \nUse one of: "
+                    + str(self.sample_averaging_avail)
+                )
+        else:
+            raise Exception("Sample Averaging only available in 30bit averaged mode.")
+
+    class _diff_channel(attribute):
+        """AD4x30 differential channel."""
+
+        def __init__(self, ctrl, channel_name):
+            self.name = channel_name
+            self._ctrl = ctrl
+
+        @property
+        def hw_gain(self):
+            """Get/Set the hardwaregain of differential channel."""
+            return self._get_iio_attr(self.name, "hardwaregain", False)
+
+        @hw_gain.setter
+        def hw_gain(self, gain):
+            """Get/Set the hardwaregain of differential channel."""
+            self._set_iio_attr(self.name, "hardwaregain", False, int(gain))
+
+        @property
+        def offset(self):
+            """Get/Set the offset of differential channel."""
+            return self._get_iio_attr(self.name, "offset", False, self._ctrl)
+
+        @offset.setter
+        def offset(self, offset):
+            """Get/Set the offset of differential channel."""
+            self._set_iio_attr(self.name, "offset", False, int(offset), self._ctrl)

--- a/adi/ad4630.py
+++ b/adi/ad4630.py
@@ -71,7 +71,7 @@ class ad4630(rx, context_manager, attribute):
         if device_name not in compatible_parts:
             raise Exception(
                 "Not a compatible device: "
-                + device_name
+                + str(device_name)
                 + ". Please select from "
                 + str(compatible_parts)
             )
@@ -90,7 +90,6 @@ class ad4630(rx, context_manager, attribute):
                     self.chan0 = self._diff_channel(self._ctrl, ch.name)
                 if "1" in ch.name:
                     self.chan1 = self._diff_channel(self._ctrl, ch.name)
-                continue
 
         rx.__init__(self)
 

--- a/doc/source/devices/adi.ad4630.rst
+++ b/doc/source/devices/adi.ad4630.rst
@@ -1,0 +1,7 @@
+ad4630
+=================
+
+.. automodule:: adi.ad4630
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/source/devices/index.rst
+++ b/doc/source/devices/index.rst
@@ -8,6 +8,7 @@ Supported Devices
    :maxdepth: 4
 
    adi.QuadMxFE_multi
+   adi.ad4630
    adi.ad5627
    adi.ad5686
    adi.ad6676

--- a/examples/ad4630/ad4630_example_all_mode.py
+++ b/examples/ad4630/ad4630_example_all_mode.py
@@ -1,0 +1,168 @@
+# Copyright (C) 2022 Analog Devices, Inc.
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#     - Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     - Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#     - Neither the name of Analog Devices, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#     - The use of this software may or may not infringe the patent rights
+#       of one or more patent holders.  This license does not release you
+#       from the requirement that you obtain separate licenses from these
+#       patent holders to use this software.
+#     - Use of the software either in source or binary form, must be run
+#       on or directly connected to an Analog Devices Inc. component.
+#
+# THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED.
+#
+# IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, INTELLECTUAL PROPERTY
+# RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+import time
+
+import adi
+import matplotlib.pyplot as plt
+import numpy as np
+import sin_params as sp
+
+device_name = "ad4030-24"
+fs = 2000000  # Sampling Frequency
+N = 65536  # Length of rx buffer
+
+
+def main():
+    """ Instantiate the device and set th parameters."""
+    adc = adi.ad4630(
+        uri="ip:169.254.92.202", device_name=device_name
+    )  # To connect via ip address 169.254.92.202
+    adc.rx_buffer_size = N
+    adc.sample_rate = fs
+
+    """To switch the device b/w low_power_mode and normal_operating_mode."""
+    adc.operating_mode = "normal_operating_mode"
+
+    """sample_averaging is only supported by 30bit mode. and in this mode it cannot be OFF."""
+    if adc.output_data_mode == "30bit_avg":
+        adc.sample_averaging = 16
+
+    """ Prints Current output data mode"""
+    print(adc.output_data_mode)
+
+    """ Differential Channel attributes"""
+    adc.chan0.hw_gain = 2
+    adc.chan0.offset = 2
+    if device_name == "ad4630-24":
+        adc.chan1.hw_gain = 2
+        adc.chan1.offset = 2
+
+    data = adc.rx()  # Receive the data
+    adc.rx_destroy_buffer()  # Destroy the remaining data in buffer
+
+    for ch in range(0, len(data)):
+        x = np.arange(0, len(data[ch]))
+        plt.figure(
+            adc._ctrl.channels[ch]._name
+        )  # Using hidden functions in example code is not advised
+        plt.plot(x * (100 / fs), data[ch])
+
+    plt.show()
+
+    if adc.output_data_mode == "30bit_avg":
+        diff_bits = 30
+    elif adc.output_data_mode == "16bit_diff_8bit_cm":
+        diff_bits = 16
+    else:
+        diff_bits = 24
+
+    if adc.output_data_mode == "32bit_test_pattern":
+        test_pattern_analysis(data[0])
+        if device_name == "ad4630-24":
+            test_pattern_analysis(data[1])
+    else:
+        analysis(diff_bits, data[0])
+        if device_name == "ad4630-24":
+            if (
+                adc.output_data_mode == "16bit_diff_8bit_cm"
+                or adc.output_data_mode == "24bit_diff_8bit_cm"
+            ):
+                analysis(diff_bits, data[2])
+            else:
+                analysis(diff_bits, data[1])
+
+
+def analysis(bits, op_data):
+    """Does the SNR Analysis and plots FFT"""
+
+    adc_amplitude_adj = 2 ** (bits - 1)  # x**y is same as x^y
+    adc_amplitude_peak = max(op_data) - min(op_data)
+    mag_adj = adc_amplitude_peak / (2 * adc_amplitude_adj)
+    mag_adj_db = 20 * np.log10(mag_adj)
+
+    """SNR Analysis"""
+    harmonics, snr, thd, sinad, enob, sfdr, floor = sp.sin_params(op_data)
+    f1_freq = (harmonics[1][1]) * (fs / N)
+
+    sig_amp = np.sqrt(abs(harmonics[1][0]))
+    fund_dbfs = 20 * np.log10(sig_amp / 2 ** (bits - 1))
+    f2 = 20 * np.log10((np.sqrt(abs(harmonics[2][0]))) / adc_amplitude_adj)
+    f3 = 20 * np.log10((np.sqrt(abs(harmonics[3][0]))) / adc_amplitude_adj)
+    f4 = 20 * np.log10((np.sqrt(abs(harmonics[4][0]))) / adc_amplitude_adj)
+    f5 = 20 * np.log10((np.sqrt(abs(harmonics[5][0]))) / adc_amplitude_adj)
+
+    floor += fund_dbfs
+    max_code = max(op_data)
+    min_code = min(op_data)
+    bin_width = fs / N
+    snr_adj = snr - fund_dbfs
+    thd_calc = 10 * np.log10(
+        (10 ** (f2 / 10)) + (10 ** (f3 / 10)) + (10 ** (f4 / 10)) + (10 ** (f5 / 10))
+    )
+    sinad_calc = -10 * np.log10((10 ** (-snr_adj / 10)) + (10 ** (thd_calc / 10)))
+    enob_calc = (sinad_calc - 1.76) / 6.02
+    sfdr_adj = sfdr - fund_dbfs
+
+    """ Print the actual and calculated parameters"""
+    print("Binwidth = ", bin_width)
+    print("SNR (dB) = ", snr)
+    print("SNR of Adjacent chan (dB) =", snr_adj)
+    print("thd = " + str(thd) + " calculated thd = " + thd_calc)
+    print("sfdr = " + str(sfdr) + " adjacent chan sfdr = " + sfdr_adj)
+    print("ENOB = " + str(enob) + " calculated ENOB = " + enob_calc)
+    print("sinad = " + str(sinad) + " calculated sinad = " + sinad_calc)
+    print("Max code = " + str(max_code) + "Min code = " + str(min_code))
+    print("Lent of each captured array =", len(op_data))
+
+
+def test_pattern_analysis(data_op):
+    """Perform analysis in 32bit test pattern output data mode."""
+
+    print("32 bit pattern data from CHA = " + hex(data_op[int(N / 2)]))
+    print("32 bit pattern data from CHB = " + hex(data_op[int(N / 2)]))
+    custom_pattern_data = 0xFADB02EC
+    custom_pattern_data_hex = hex(custom_pattern_data)
+    custom_pattern_data_hex_3 = "0x" + custom_pattern_data_hex[2:4]
+    custom_pattern_data_hex_2 = "0x" + custom_pattern_data_hex[4:6]
+    custom_pattern_data_hex_1 = "0x" + custom_pattern_data_hex[6:8]
+    custom_pattern_data_hex_0 = "0x" + custom_pattern_data_hex[8:10]
+    adc._ctrl.reg_write(0x0026, int(custom_pattern_data_hex_3, 16))
+    adc._ctrl.reg_write(0x0025, int(custom_pattern_data_hex_2, 16))
+    adc._ctrl.reg_write(0x0024, int(custom_pattern_data_hex_1, 16))
+    adc._ctrl.reg_write(0x0023, int(custom_pattern_data_hex_0, 16))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/ad4630/ad4630_example_simple_plot.py
+++ b/examples/ad4630/ad4630_example_simple_plot.py
@@ -1,0 +1,56 @@
+# Copyright (C) 2022 Analog Devices, Inc.
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#     - Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     - Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#     - Neither the name of Analog Devices, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#     - The use of this software may or may not infringe the patent rights
+#       of one or more patent holders.  This license does not release you
+#       from the requirement that you obtain separate licenses from these
+#       patent holders to use this software.
+#     - Use of the software either in source or binary form, must be run
+#       on or directly connected to an Analog Devices Inc. component.
+#
+# THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED.
+#
+# IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, INTELLECTUAL PROPERTY
+# RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+import adi
+import matplotlib.pyplot as plt
+import numpy as np
+
+device_name = "ad4630-23"
+
+adc = ad4630(uri="ip:192.168.0.130", device_name=device_name)
+adc.rx_buffer_size = 500
+adc.sample_rate = 2000000
+
+try:
+    adc.sample_averaging = 16
+except:
+    print("Sample average not supported in this mode")
+
+data = adc.rx()
+
+for ch in range(0, len(data)):
+    x = np.arange(0, len(data[ch]))
+    plt.figure(adc._ctrl._channels[ch]._name)
+    plt.plot(x, data[ch])
+plt.show()

--- a/examples/ad4630/sin_params.py
+++ b/examples/ad4630/sin_params.py
@@ -1,0 +1,335 @@
+# --------------------LICENSE AGREEMENT----------------------------------------
+# Copyright (c) 2020 Analog Devices, Inc.  All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#   - Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+#   - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#   - Modified versions of the software must be conspicuously marked as such.
+#   - This software is licensed solely and exclusively for use with
+#   processors/products manufactured by or for Analog Devices, Inc.
+#   - This software may not be combined or merged with other code in any manner
+#   that would cause the software to become subject to terms and conditions
+#   which differ from those listed here.
+#   - Neither the name of Analog Devices, Inc. nor the names of its
+#   contributors may be used to endorse or promote products derived from this
+#   software without specific prior written permission.
+#   - The use of this software may or may not infringe the patent rights of
+#   one or more patent holders.  This license does not release you from the
+#   requirement that you obtain separate licenses from these patent holders
+#   to use this software.
+#
+# THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# NON-INFRINGEMENT, TITLE, MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL ANALOG DEVICES, INC. OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# DAMAGES ARISING OUT OF CLAIMS OF INTELLECTUAL PROPERTY RIGHTS INFRINGEMENT;
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# 2020-02-24-7CBSD SLA
+# -----------------------------------------------------------------------------
+
+import math as m
+
+import numpy as np
+
+NONE = 0x00
+HAMMING = 0x10
+HANN = 0x11
+BLACKMAN = 0x20
+BLACKMAN_EXACT = 0x21
+BLACKMAN_HARRIS_70 = 0x22
+FLAT_TOP = 0x23
+BLACKMAN_HARRIS_92 = 0x30
+
+DEF_WINDOW_TYPE = BLACKMAN_HARRIS_92
+
+BW = 3
+
+
+def sin_params(
+    data, window_type=DEF_WINDOW_TYPE, mask=None, num_harms=9, spur_in_harms=True
+):
+    fft_data = windowed_fft_mag(data, window_type)
+    harm_bins, harms, harm_bws = find_harmonics(fft_data, num_harms)
+    spur, spur_bw = find_spur(
+        spur_in_harms, harm_bins[0], harms, harm_bws, fft_data, window_type
+    )
+
+    if mask is None:
+        mask = calculate_auto_mask(fft_data, harm_bins, window_type)
+    noise, noise_bins = masked_sum_of_sq(fft_data, mask)
+
+    average_noise = noise / max(1, noise_bins)
+    noise = average_noise * (len(fft_data) - 1)
+
+    # create a dictionary where key is harmonic number and value is tuple of harm and bin
+    harmonics = {}
+    for i, (h, (b, bw)) in enumerate(zip(harms, zip(harm_bins, harm_bws))):
+        h -= average_noise * bw
+        if h > 0:
+            harmonics[i + 1] = (h, b)
+        elif i < 9:
+            harmonics[i + 1] = (h, b)
+
+    spur -= average_noise * spur_bw
+
+    signal = harmonics[1][0]
+    floor = 10 * m.log10(average_noise / signal)  # dBc
+    snr = 10 * m.log10(signal / noise)
+    harm_dist = (
+        harmonics.get(2, (0, 0))[0]
+        + harmonics.get(3, (0, 0))[0]
+        + harmonics.get(4, (0, 0))[0]
+        + harmonics.get(5, (0, 0))[0]
+    )
+    thd = 10 * m.log10(harm_dist / signal) if harm_dist > 0 else 0
+    sinad = 10 * m.log10(signal / (harm_dist + noise))
+    enob = (sinad - 1.76) / 6.02
+    sfdr = 10 * m.log10(signal / spur) if spur > 0 else 0
+
+    return (harmonics, snr, thd, sinad, enob, sfdr, floor)
+
+
+def window(size, window_type=DEF_WINDOW_TYPE):
+    if window_type == NONE:
+        return None
+    if window_type == HAMMING:
+        return _one_cos(size, 0.54, 0.46, 1.586303)
+    elif window_type == HANN:
+        return _one_cos(size, 0.50, 0.50, 1.632993)
+    elif window_type == BLACKMAN:
+        return _two_cos(size, 0.42, 0.50, 0.08, 1.811903)
+    elif window_type == BLACKMAN_EXACT:
+        return _two_cos(size, 42659071, 0.49656062, 0.07684867, 1.801235)
+    elif window_type == BLACKMAN_HARRIS_70:
+        return _two_cos(size, 0.42323, 0.49755, 0.07922, 1.807637)
+    elif window_type == FLAT_TOP:
+        return _two_cos(size, 0.2810639, 0.5208972, 0.1980399, 2.066037)
+    elif window_type == BLACKMAN_HARRIS_92:
+        return _three_cos(size, 0.35875, 0.48829, 0.14128, 0.01168, 1.968888)
+    else:
+        raise ValueError("Unknown window type")
+
+
+def _one_cos(n, a0, a1, norm):
+    t = np.linspace(0, 1, n, False)
+    win = a0 - a1 * np.cos(2 * np.pi * t)
+    return win * norm
+
+
+def _two_cos(n, a0, a1, a2, norm):
+    t = np.linspace(0, 1, n, False)
+    win = a0 - a1 * np.cos(2 * np.pi * t) + a2 * np.cos(4 * np.pi * t)
+    return win * norm
+
+
+def _three_cos(n, a0, a1, a2, a3, norm):
+    t = np.linspace(0, 1, n, False)
+    win = (
+        a0
+        - a1 * np.cos(2 * np.pi * t)
+        + a2 * np.cos(4 * np.pi * t)
+        - a3 * np.cos(6 * np.pi * t)
+    )
+    return win * norm
+
+
+def windowed_fft_mag(data, window_type=BLACKMAN_HARRIS_92):
+    n = len(data)
+    data = np.array(data, dtype=np.float64)
+    data -= np.mean(data)
+    w = window(n, window_type)
+    if w is not None:
+        data = data * w
+    n_by_2 = (int)(n / 2)
+    fft_data = np.fft.fft(data)[0 : n_by_2 + 1]
+    fft_data = abs(fft_data) / n
+    fft_data[1:n_by_2] *= 2
+    return fft_data
+
+
+def find_harmonics(fft_data, max_harms):
+    BW = 3
+    harm_bins = np.zeros(max_harms, dtype=int)
+    harms = np.zeros(max_harms)
+    harm_bws = np.zeros(max_harms, dtype=int)
+
+    _, fund_bin = get_max(fft_data)
+    harm_bins[0] = fund_bin
+
+    for h in range(1, max_harms + 1):
+        # first find the location by taking max in area of uncertainty
+        mask = init_mask(len(fft_data), False)
+        nominal_bin = h * fund_bin
+        h_2 = h / 2
+        if h > 1:
+            mask = set_mask(mask, nominal_bin - h_2, nominal_bin + h_2)
+            for i in range(h - 1):
+                mask = clear_mask(mask, harm_bins[i], harm_bins[i])
+            _, harm_bins[h - 1] = masked_max(fft_data, mask)
+
+        mask = clear_mask(mask, nominal_bin - h_2, nominal_bin + h_2)
+        mask = set_mask(mask, harm_bins[h - 1] - BW, harm_bins[h - 1] + BW)
+        for i in range(h - 1):
+            mask = clear_mask(mask, harm_bins[i] - BW, harm_bins[i] + BW)
+        harms[h - 1], harm_bws[h - 1] = masked_sum_of_sq(fft_data, mask)
+    return (harm_bins, harms, harm_bws)
+
+
+def calculate_auto_mask(fft_data, harm_bins, window_type):
+    BANDWIDTH_DIVIDER = 80
+    NUM_INITAL_NOISE_HARMS = 5
+    n = len(fft_data)
+    bw = n / BANDWIDTH_DIVIDER
+
+    mask = init_mask(n)
+    for i in range(NUM_INITAL_NOISE_HARMS):
+        clear_mask(mask, harm_bins[i] - bw, harm_bins[i] + bw)
+    mask[0] = False
+
+    noise_est, noise_bins = masked_sum(fft_data, mask)
+    noise_est /= noise_bins
+
+    mask = init_mask(n)
+    clear_mask_at_dc(mask, window_type)
+    for h in harm_bins:
+        if mask[h] == 0:
+            continue
+
+        j = 1
+        while (
+            h - j > 0
+            and mask[h - j] == 1
+            and sum(fft_data[(h - j) : (h - j + 3)]) / 3 > noise_est
+        ):
+            j += 1
+        low = h - j + 1
+
+        j = 1
+        while (
+            h + j < n
+            and mask[h + j] == 1
+            and sum(fft_data[(h + j - 2) : (h + j + 1)]) / 3 > noise_est
+        ):
+            j += 1
+        high = h + j - 1
+
+        clear_mask(mask, low, high)
+
+    return mask
+
+
+def find_spur(find_in_harms, fund_bin, harms, harm_bws, fft_data, window_type):
+    if find_in_harms:
+        spur, index = get_max(harms[1:])
+        return (spur, harm_bws[index + 1])
+    else:
+        return find_spur_in_data(fft_data, window_type, fund_bin)
+
+
+def find_spur_in_data(fft_data, window_type, fund_bin):
+    BW = 3
+    n = len(fft_data)
+    mask = init_mask(n)
+    mask = clear_mask_at_dc(mask, window_type)
+    mask = clear_mask(mask, fund_bin - BW, fund_bin + BW)
+
+    index = 0
+    for i, v in enumerate(mask):
+        if v:
+            index = i
+            break
+
+    max_value = masked_sum_of_sq(fft_data, mask, index - BW, index + BW)
+    max_index = index
+
+    while index < len(fft_data):
+        if mask[index]:
+            value = masked_sum_of_sq(fft_data, mask, index - BW, index + BW)
+            if value > max_value:
+                max_value = value
+                max_index = index
+        index += 1
+    _, spur_bin = masked_max(fft_data, mask, max_index - BW, max_index + BW)
+    spur, spur_bw = masked_sum_of_sq(fft_data, mask, spur_bin - BW, spur_bin + BW)
+    return (spur, spur_bw)
+
+
+def clear_mask_at_dc(mask, window_type):
+    return clear_mask(mask, 0, window_type >> 4)
+
+
+def init_mask(n, initial_value=True):
+    if initial_value:
+        return np.ones(n, dtype=bool)
+    else:
+        return np.zeros(n, dtype=bool)
+
+
+def set_mask(mask, start, end, set_value=True):
+    nyq = len(mask)
+    mask[map_nyquist(np.array(range(int(start), int(end) + 1)), nyq)] = set_value
+    return mask
+
+
+def clear_mask(mask, start, end):
+    return set_mask(mask, start, end, False)
+
+
+def map_nyquist(indices, nyq):
+    n = 2 * (nyq - 1)
+    indices = np.mod(indices + n, n)
+    if isinstance(indices, np.ndarray):
+        indices[indices > nyq] = n - indices[indices > nyq]
+    else:
+        indices = n - indices if indices > nyq else indices
+    return indices
+
+
+def masked_max(data, mask, start=0, finish=None):
+    if finish is None:
+        finish = len(data) - 1
+    _, indices = masked_subset(mask, start, finish)
+    [value, i] = get_max(data[indices])
+    return (value, indices[i])
+
+
+def masked_sum(data, mask, start=0, finish=None):
+    if finish is None:
+        finish = len(data) - 1
+    mask, indices = masked_subset(mask, start, finish)
+    value = sum(data[indices])
+    return value, len(indices)
+
+
+def masked_sum_of_sq(data, mask, start=0, finish=None):
+    if finish is None:
+        finish = len(data) - 1
+    mask, indices = masked_subset(mask, start, finish)
+    value = sum(data[indices] * data[indices])
+    return value, len(indices)
+
+
+def masked_subset(mask, start, finish):
+    nyq = len(mask) - 1
+    mapped_subset = map_nyquist(np.array(range(start, finish)), nyq)
+    indices = np.array(range(0, finish))
+    indices = indices[mapped_subset]
+    mask = mask[mapped_subset]
+    indices = indices[mask]
+    return (mask, indices)
+
+
+def get_max(data):
+    index = np.argmax(data)
+    return (data[index], index)

--- a/supported_parts.md
+++ b/supported_parts.md
@@ -10,6 +10,7 @@
 [[Wiki](https://wiki.analog.com/resources/tools-software/linux-software/pyadi-iio)]
 
 ### Currently supported hardware
+- AD4630
 - AD5310R
 - AD5311R
 - AD5627

--- a/test/test_ad4630.py
+++ b/test/test_ad4630.py
@@ -1,0 +1,27 @@
+import pytest
+
+hardware = ["ad4030-24", "ad4630-24"]
+classname = "adi.ad4630"
+
+#########################################
+@pytest.mark.iio_hardware(hardware)
+@pytest.mark.parametrize("classname", [(classname)])
+@pytest.mark.parametrize("channel", [0])
+def test_ad4630_rx_data(test_dma_rx, iio_uri, classname, channel):
+    test_dma_rx(iio_uri, classname, channel)
+
+
+#########################################
+@pytest.mark.iio_hardware(hardware)
+@pytest.mark.parametrize("classname", [(classname)])
+@pytest.mark.parametrize(
+    "attr, val",
+    [
+        (
+            "sample_rate",
+            [10000, 50000, 100000, 200000, 500000, 1000000, 1750000, 2000000],
+        ),
+    ],
+)
+def test_ad4630_attr(test_attribute_multipe_values, iio_uri, classname, attr, val):
+    test_attribute_multipe_values(iio_uri, classname, attr, val, 0)


### PR DESCRIPTION
# Description

Added Initial support of ad4630-24 & ad4030-24. pyadi device interface, examples, device doc and hardware test was added.

Fixes # (issue)
Previous developer version i.e. branch ad463x(that was never added to main) did not have channel attributes and was not compatible with ad4030-24

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] pytest hardware test - dma_rx test and multiple values attribute test

**Test Configuration**:
* Hardware: Physcially Eval-ad4630 and EVal-4030 were tested to produce result equivalent to lab test/graphs.


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

@mthoren-adi