### PR TITLE
Fixed numpy deprecation warnings

### DIFF
--- a/adi/adis16495.py
+++ b/adi/adis16495.py
@@ -50,7 +50,7 @@ class adis16495(rx, context_manager):
     ]
     _device_name = ""
     _rx_data_type = ">i4"
-    _rx_data_si_type = np.float
+    _rx_data_si_type = float
 
     def __init__(self, uri="", name="adis16495-3"):
         """Initialize an adis16495 object.

--- a/adi/adis16507.py
+++ b/adi/adis16507.py
@@ -50,7 +50,7 @@ class adis16507(rx, context_manager):
     ]
     _device_name = ""
     _rx_data_type = ">i4"
-    _rx_data_si_type = np.float
+    _rx_data_si_type = float
 
     def __init__(
         self, uri="", imu_dev_name="adis16507-3", trigger_name="adis16507-3-dev0"

--- a/adi/adxl345.py
+++ b/adi/adxl345.py
@@ -45,7 +45,7 @@ class adxl345(rx, context_manager, attribute):
     _device_name = "adxl345"
     _rx_data_type = np.int32
     _rx_unbuffered_data = True
-    _rx_data_si_type = np.float
+    _rx_data_si_type = float
 
     def __init__(self, uri=""):
 

--- a/adi/adxl355.py
+++ b/adi/adxl355.py
@@ -45,7 +45,7 @@ class adxl355(rx, context_manager, attribute):
     _device_name = "adxl355"
     _rx_data_type = np.int32
     _rx_unbuffered_data = True
-    _rx_data_si_type = np.float
+    _rx_data_si_type = float
 
     def __init__(self, uri=""):
 

--- a/adi/adxrs290.py
+++ b/adi/adxrs290.py
@@ -43,7 +43,7 @@ class adxrs290(rx, context_manager, attribute):
     _device_name = "ADXRS290"
     _rx_data_type = np.int16
     _rx_unbuffered_data = True
-    _rx_data_si_type = np.float
+    _rx_data_si_type = float
 
     def __init__(self, uri=""):
 

--- a/adi/cn0540.py
+++ b/adi/cn0540.py
@@ -55,7 +55,7 @@ class cn0540(rx, context_manager):
     """CN0540 CBM DAQ Board"""
 
     _rx_data_type = np.int32
-    _rx_data_si_type = np.float
+    _rx_data_si_type = float
     _complex_data = False
     _rx_channel_names = ["voltage0"]
     _device_name = ""

--- a/adi/ltc2983.py
+++ b/adi/ltc2983.py
@@ -15,7 +15,7 @@ class ltc2983(rx, context_manager):
     _device_name = "ltc2983"
     _rx_unbuffered_data = True
     _rx_data_type = np.int32
-    _rx_data_si_type = np.float
+    _rx_data_si_type = float
 
     def __init__(self, uri=""):
         context_manager.__init__(self, uri, self._device_name)
@@ -46,7 +46,7 @@ class ltc2983(rx, context_manager):
         @property
         def scale(self):
             """Channel scale factor"""
-            return np.float(self._get_iio_attr_str(self.name, "scale", False))
+            return float(self._get_iio_attr_str(self.name, "scale", False))
 
         @property
         def value(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-numpy
-pylibiio
-fs.sshfs
+numpy>=1.20
+pylibiio==0.23.1
+paramiko

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
     url="https://github.com/analogdevicesinc/pyadi-iio",
     packages=setuptools.find_packages(exclude=["test*"]),
     python_requires=">=3.6",
-    install_requires=["numpy", "pylibiio==0.23.1"],
+    install_requires=["numpy>=1.20", "pylibiio==0.23.1"],
     extras_require={"jesd": ["paramiko"]},
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Numpy 1.20 deprecated built-in equivalent types which now generates
warnings. This change removes those np specific built-in and updates
required numpy to this requirement.

Ref: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

Signed-off-by: Travis F. Collins <travis.collins@analog.com>