### PR TITLE
Tfcollins/core update

### DIFF
--- a/adi/ad936x.py
+++ b/adi/ad936x.py
@@ -32,26 +32,19 @@
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from adi.context_manager import context_manager
-from adi.rx_tx import rx_tx
+from adi.rx_tx import rx_tx_def
 
 
-class ad9364(rx_tx, context_manager):
-    """ AD9364 Transceiver """
+class ad9364(rx_tx_def, context_manager):
+    """AD9364 Transceiver"""
 
     _complex_data = True
     _rx_channel_names = ["voltage0", "voltage1"]
     _tx_channel_names = ["voltage0", "voltage1"]
+    _control_device_name = "ad9361-phy"
+    _rx_data_device_name = "cf-ad9361-lpc"
+    _tx_data_device_name = "cf-ad9361-dds-core-lpc"
     _device_name = ""
-
-    def __init__(self, uri=""):
-
-        context_manager.__init__(self, uri, self._device_name)
-
-        self._ctrl = self._ctx.find_device("ad9361-phy")
-        self._rxadc = self._ctx.find_device("cf-ad9361-lpc")
-        self._txdac = self._ctx.find_device("cf-ad9361-dds-core-lpc")
-
-        rx_tx.__init__(self)
 
     @property
     def filter(self):
@@ -241,7 +234,7 @@ class ad9364(rx_tx, context_manager):
 
 
 class ad9361(ad9364):
-    """ AD9361 Transceiver """
+    """AD9361 Transceiver"""
 
     _rx_channel_names = ["voltage0", "voltage1", "voltage2", "voltage3"]
     _tx_channel_names = ["voltage0", "voltage1", "voltage2", "voltage3"]
@@ -278,13 +271,13 @@ class ad9361(ad9364):
 
 
 class ad9363(ad9361):
-    """ AD9363 Transceiver """
+    """AD9363 Transceiver"""
 
     pass
 
 
 class Pluto(ad9364):
-    """ PlutoSDR Evaluation Platform """
+    """PlutoSDR Evaluation Platform"""
 
     _device_name = "PlutoSDR"
     _uri_auto = "ip:pluto.local"

--- a/test/test_generic_rxtx.py
+++ b/test/test_generic_rxtx.py
@@ -1,0 +1,105 @@
+import iio
+
+import adi
+import pytest
+
+hardware = ["pluto", "adrv9361", "fmcomms2"]
+classname = ""
+
+#########################################
+@pytest.mark.iio_hardware(hardware, True)
+def test_generic_rx(iio_uri):
+    class MyAD9361(adi.rx_tx.rx_tx_def):
+        _complex_data = True
+        _control_device_name = "ad9361-phy"
+        _rx_data_device_name = "cf-ad9361-lpc"
+        _tx_data_device_name = "cf-ad9361-dds-core-lpc"
+
+        def __post_init__(self):
+            pass
+
+    dev = MyAD9361(iio_uri)
+    dev.rx()
+    assert dev._rxadc
+    assert dev._txdac
+    assert dev._ctrl
+
+
+#########################################
+@pytest.mark.iio_hardware(hardware, True)
+def test_generic_rx_with_ctx(iio_uri):
+    class MyAD9361(adi.rx_tx.rx_tx_def):
+        _complex_data = True
+        _control_device_name = "ad9361-phy"
+        _rx_data_device_name = "cf-ad9361-lpc"
+        _tx_data_device_name = "cf-ad9361-dds-core-lpc"
+
+        def __post_init__(self):
+            pass
+
+    ctx = iio.Context(iio_uri)
+
+    dev = MyAD9361(ctx)
+    dev.rx()
+    assert dev._rxadc
+    assert dev._txdac
+    assert dev._ctrl
+
+
+#########################################
+@pytest.mark.iio_hardware(hardware, True)
+def test_generic_rx_pv_old(iio_uri):
+    class MyAD9361(adi.rx_tx.rx_tx_def):
+        _complex_data = True
+        _control_device_name = "ad9361-phy"
+        _rx_data_device_name = "cf-ad9361-lpc"
+        _tx_data_device_name = "cf-ad9361-dds-core-lpc"
+
+        def __post_init__(self):
+            pass
+
+    dev = MyAD9361(uri=iio_uri)
+    dev.rx()
+    assert dev._rxadc
+    assert dev._txdac
+    assert dev._ctrl
+
+
+#########################################
+@pytest.mark.iio_hardware(hardware, True)
+def test_generic_rx_pv(iio_uri):
+    class MyAD9361(adi.rx_tx.rx_tx_def):
+        _complex_data = True
+        _control_device_name = "ad9361-phy"
+        _rx_data_device_name = "cf-ad9361-lpc"
+        _tx_data_device_name = "cf-ad9361-dds-core-lpc"
+
+        def __post_init__(self):
+            pass
+
+    dev = MyAD9361(uri_ctx=iio_uri)
+    dev.rx()
+    assert dev._rxadc
+    assert dev._txdac
+    assert dev._ctrl
+
+
+#########################################
+@pytest.mark.iio_hardware(hardware, True)
+def test_generic_rx_with_ctx_pv(iio_uri):
+    class MyAD9361(adi.rx_tx.rx_tx_def):
+        _complex_data = True
+        _control_device_name = "ad9361-phy"
+        _rx_data_device_name = "cf-ad9361-lpc"
+        _tx_data_device_name = "cf-ad9361-dds-core-lpc"
+
+        def __post_init__(self):
+            pass
+
+    ctx = iio.Context(iio_uri)
+
+    dev = MyAD9361(uri_ctx=ctx)
+    dev.rx()
+    assert dev._rxadc
+    assert dev._txdac
+    assert dev._ctrl


### PR DESCRIPTION
# Description

This PR adds new core template cases that can drastically simplify __init__ implementations of device classes (See AD936x updates). This also adds support for iio.Context objects to be passed to device class constructors for better reuse of context reference without re-creating them.

The following constructor APIs are possible:
```python
import adi
dev = adi.Pluto() # Automatic
dev = adi.Pluto("ip:pluto.local") # Existing string URI
dev = adi.Pluto(uri="ip:pluto.local") # Existing string URI
dev = adi.Pluto(uri_ctx="ip:pluto.local") # New string URI

ctx = iio.Context("ip:pluto.local")
dev = adi.Pluto(ctx) # New context input
dev = adi.Pluto(uri_ctx=ctx) # New context input
```

New tests were added for all these permutations.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Testing has been added with **test_generic_rxtx**

**Test Configuration**:
* Hardware: PlutoSDR + Emulated Tests
* OS: Ubuntu 20.04

# Documentation

If this is a new feature or example please mention or link any documentation. All new hardware interface classes require documentation.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
