### PR TITLE
tfcollins/switch buffer call

### DIFF
--- a/adi/rx_tx.py
+++ b/adi/rx_tx.py
@@ -251,7 +251,11 @@ class rx(rx_tx_common):
         if not self.__rxbuf:
             self._rx_init_channels()
         self.__rxbuf.refill()
-        data = self.__rxbuf.read()
+        chan = self._rxadc.find_channel(
+            self._rx_channel_names[self.rx_enabled_channels[0]]
+        )
+        data = chan.read(self.__rxbuf)
+
         x = np.frombuffer(data, dtype=self._rx_data_type)
         indx = 0
         sig = []
@@ -288,7 +292,10 @@ class rx(rx_tx_common):
         if not self.__rxbuf:
             self._rx_init_channels()
         self.__rxbuf.refill()
-        data = self.__rxbuf.read()
+        chan = self._rxadc.find_channel(
+            self._rx_channel_names[self.rx_enabled_channels[0]]
+        )
+        data = chan.read(self.__rxbuf)
 
         if isinstance(self._rx_data_type, list):
             return self.__multi_type_rx(data)
@@ -653,7 +660,6 @@ class shared_def(context_manager, metaclass=ABCMeta):
             for c in contexts:
                 ctx = iio.Context(c)
                 devs = [dev.name for dev in ctx.devices]
-                print(devs)
                 if all(dev in devs for dev in required_devices):
                     self._ctx = iio.Context(c)
                     break

--- a/tasks.py
+++ b/tasks.py
@@ -168,6 +168,7 @@ def checkparts(c):
         "adrv9009_zu11eg_fmcomms8",
         "adar1000_array",
         "ad9081_mc",
+        "ad717x",
     ]
     for c in dir(mod):
         if (

--- a/test/dma_tests.py
+++ b/test/dma_tests.py
@@ -61,12 +61,12 @@ def dma_rx(
             else:
                 if isinstance(data, list):
                     for chan in data:
-                        assert np.sum(np.abs(chan)) > 0
+                        assert np.sum(np.abs(chan)) > 0, "Buffer all zeros"
                 else:
-                    assert np.sum(np.abs(data)) > 0
+                    assert np.sum(np.abs(data)) > 0, "Buffer all zeros"
     except Exception as e:
         del sdr
-        raise Exception(e)
+        raise Exception(e) from e
 
     del sdr
 

--- a/test/test_adrv9002_p.py
+++ b/test/test_adrv9002_p.py
@@ -278,7 +278,7 @@ def test_adrv9002_tx_data(test_dma_tx, iio_uri, classname, channel, use_tx2):
 
 
 #########################################
-@pytest.mark.iio_hardware(hardware)
+@pytest.mark.iio_hardware(hardware, True)
 @pytest.mark.parametrize("classname", [(classname)])
 @pytest.mark.parametrize("channel", [0, 1])
 @pytest.mark.parametrize("use_rx2", [False, True])


### PR DESCRIPTION
Switch buffer reads to use chan.read instead of buffer.read which does type conversion
    
Signed-off-by: Travis F. Collins <travis.collins@analog.com>