### PR TITLE
ad7689: Corrected the 'channels' attribute name

### DIFF
--- a/adi/ad7689.py
+++ b/adi/ad7689.py
@@ -73,7 +73,7 @@ class ad7689(rx, context_manager):
                 self._rxadc = device
                 break
 
-        for ch in self._ctrl._channels:
+        for ch in self._ctrl.channels:
             name = ch._id
             self._rx_channel_names.append(name)
             self.channel.append(self._channel(self._ctrl, name))


### PR DESCRIPTION
Renamed '_channels' to 'channels' in ad7689.py file due to recent updates in the libiio

Signed-off-by: MPhalke <mahesh.phalke@analog.com>

# Description

Issue fixed in adi/ad7689.py file at line number 76.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran the customized python script based on pyadi-iio to read channel specific attributes.

**Test Configuration**:
* Hardware: SDP-K1, AD7689 EVB
* OS: Windows

# Documentation

If this is a new feature or example please mention or link any documentation. All new hardware interface classes require documentation.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
