### PR TITLE
Added support for ad4130 device

### DIFF
--- a/adi/__init__.py
+++ b/adi/__init__.py
@@ -34,6 +34,7 @@
 from adi.ad717x import ad717x
 from adi.ad936x import Pluto, ad9361, ad9363, ad9364
 from adi.ad4110 import ad4110
+from adi.ad4130 import ad4130
 from adi.ad4630 import ad4630
 from adi.ad5686 import ad5686
 from adi.ad7124 import ad7124

--- a/adi/ad4130.py
+++ b/adi/ad4130.py
@@ -1,0 +1,122 @@
+# Copyright (C) 2022 Analog Devices, Inc.
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#     - Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     - Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#     - Neither the name of Analog Devices, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#     - The use of this software may or may not infringe the patent rights
+#       of one or more patent holders.  This license does not release you
+#       from the requirement that you obtain separate licenses from these
+#       patent holders to use this software.
+#     - Use of the software either in source or binary form, must be run
+#       on or directly connected to an Analog Devices Inc. component.
+#
+# THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED.
+#
+# IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, INTELLECTUAL PROPERTY
+# RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+from decimal import Decimal
+
+import numpy as np
+from adi.attribute import attribute
+from adi.context_manager import context_manager
+from adi.rx_tx import rx
+
+
+class ad4130(rx, context_manager):
+
+    """ AD4130 ADC """
+
+    _complex_data = False
+    channel = []  # type: ignore
+    _device_name = ""
+
+    def __init__(self, uri="", device_name=""):
+        """Constructor for AD4130 class."""
+        context_manager.__init__(self, uri, self._device_name)
+
+        compatible_parts = ["ad4130-8"]
+
+        self._ctrl = None
+
+        if not device_name:
+            device_name = compatible_parts[0]
+        else:
+            if device_name not in compatible_parts:
+                raise Exception("Not a compatible device: " + device_name)
+
+        # Select the device matching device_name as working device
+        for device in self._ctx.devices:
+            if device.name == device_name:
+                self._ctrl = device
+                self._rxadc = device
+                break
+
+        for ch in self._ctrl.channels:
+            name = ch._id
+            self._rx_channel_names.append(name)
+            self.channel.append(self._channel(self._ctrl, name))
+
+        rx.__init__(self)
+
+    class _channel(attribute):
+
+        """AD4130 channel"""
+
+        def __init__(self, ctrl, channel_name):
+            self.name = channel_name
+            self._ctrl = ctrl
+
+        @property
+        def raw(self):
+            """AD4130 channel raw value."""
+            return self._get_iio_attr(self.name, "raw", False)
+
+        @property
+        def offset(self):
+            """AD4130 channel offset."""
+            return float(self._get_iio_attr_str(self.name, "offset", False))
+
+        @offset.setter
+        def offset(self, value):
+            self._set_iio_attr(self.name, "offset", False, str(Decimal(value).real))
+
+        @property
+        def scale(self):
+            """AD4130 channel scale."""
+            return float(self._get_iio_attr_str(self.name, "scale", False))
+
+        @scale.setter
+        def scale(self, value):
+            self._set_iio_attr(self.name, "scale", False, str(Decimal(value).real))
+
+    def to_volts(self, index, val):
+        """Converts raw value to SI."""
+        _scale = self.channel[index].scale
+
+        ret = None
+
+        if isinstance(val, np.int16):
+            ret = val * _scale
+
+        if isinstance(val, np.ndarray):
+            ret = [x * _scale for x in val]
+
+        return ret

--- a/doc/source/devices/adi.ad4130.rst
+++ b/doc/source/devices/adi.ad4130.rst
@@ -1,0 +1,7 @@
+ad4130
+=================
+
+.. automodule:: adi.ad4130
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/source/devices/index.rst
+++ b/doc/source/devices/index.rst
@@ -8,6 +8,7 @@ Supported Devices
    :maxdepth: 4
 
    adi.QuadMxFE_multi
+   adi.ad4130
    adi.ad4110
    adi.ad4630
    adi.ad5627

--- a/examples/ad4130_example.py
+++ b/examples/ad4130_example.py
@@ -1,0 +1,47 @@
+# Copyright (C) 2022 Analog Devices, Inc.
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#     - Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     - Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#     - Neither the name of Analog Devices, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#     - The use of this software may or may not infringe the patent rights
+#       of one or more patent holders.  This license does not release you
+#       from the requirement that you obtain separate licenses from these
+#       patent holders to use this software.
+#     - Use of the software either in source or binary form, must be run
+#       on or directly connected to an Analog Devices Inc. component.
+#
+# THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED.
+#
+# IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, INTELLECTUAL PROPERTY
+# RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import adi
+import numpy as np
+
+ad4130_dev = adi.ad4130("ip:analog")
+
+chn = 0
+ad4130_dev._rx_data_type = np.int32
+ad4130_dev.rx_output_type = "SI"
+ad4130_dev.rx_enabled_channels = [chn]
+ad4130_dev.rx_buffer_size = 100
+
+data = ad4130_dev.rx()
+
+print(data)

--- a/supported_parts.md
+++ b/supported_parts.md
@@ -10,6 +10,7 @@
 [[Wiki](https://wiki.analog.com/resources/tools-software/linux-software/pyadi-iio)]
 
 ### Currently supported hardware
+- AD4130
 - AD4110
 - AD4111
 - AD4112

--- a/test/test_ad4130.py
+++ b/test/test_ad4130.py
@@ -1,0 +1,10 @@
+import pytest
+
+hardware = "ad4130-8"
+classname = "adi.ad4130"
+
+#########################################
+@pytest.mark.iio_hardware(hardware)
+@pytest.mark.parametrize("classname", [(classname)])
+def test_ad4130_rx_data(test_dma_rx, iio_uri, classname, channel):
+    test_dma_rx(iio_uri, classname, channel)


### PR DESCRIPTION
1. Added ad4130.py class file, which includes supported devices list (ad4130-8) and basic attributes (raw, offset, scale).
2. Added ad4130 example script.
3. Added other supporting files.

Signed-off-by: MPhalke <mahesh.phalke@analog.com>

# Description

Added support for ad4130 device

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Tested through customized python script based on pyadi-iio library on the ad4130 EVB

**Test Configuration**:
* Hardware: SDP-K1, AD4130 EVB
* OS: Windows

# Documentation

If this is a new feature or example please mention or link any documentation. All new hardware interface classes require documentation.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
