### PR TITLE
requirements_prod_test: fix tkinter library

### DIFF
--- a/requirements_prod_test.txt
+++ b/requirements_prod_test.txt
@@ -13,4 +13,4 @@ bump2version
 pytest-html
 plotly-express
 pyvisa
-tkinter
+tk


### PR DESCRIPTION
# Description

When running "pip install -r requirements_prod_test.txt" an error pops
up:
"ERROR: Could not find a version that satisfies the requirement
tkinter".

Use proper name for the library so the requirements doc can be fully
used with pip.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

run command: `pip install -r requirements_prod_test.txt`

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>