### PR TITLE
Add support for AD9172

### DIFF
--- a/examples/ad9172.py
+++ b/examples/ad9172.py
@@ -1,0 +1,74 @@
+# Copyright (C) 2022 Analog Devices, Inc.
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#     - Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     - Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#     - Neither the name of Analog Devices, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#     - The use of this software may or may not infringe the patent rights
+#       of one or more patent holders.  This license does not release you
+#       from the requirement that you obtain separate licenses from these
+#       patent holders to use this software.
+#     - Use of the software either in source or binary form, must be run
+#       on or directly connected to an Analog Devices Inc. component.
+#
+# THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED.
+#
+# IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, INTELLECTUAL PROPERTY
+# RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import time
+
+import adi
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy import signal
+
+# Create radio
+tx = adi.ad9172(uri="ip:localhost")
+rx = adi.Pluto()
+
+# Configure tx properties
+tx.sample_rate = 5000000000
+
+# Create a sinewave waveform
+fs = int(tx.sample_rate)
+N = 1024
+fc = int(3000000 / (fs / N)) * (fs / N)
+ts = 1 / float(fs)
+t = np.arange(0, N * ts, ts)
+i = np.cos(2 * np.pi * t * fc) * 2 ** 14
+q = np.sin(2 * np.pi * t * fc) * 2 ** 14
+iq = i + 1j * q
+
+# Send data
+tx.tx(iq)
+
+# Collect data
+for r in range(20):
+    x = rx.rx()
+    f, Pxx_den = signal.periodogram(x, fs)
+    plt.clf()
+    plt.semilogy(f, Pxx_den)
+    plt.ylim([1e-7, 1e2])
+    plt.xlabel("frequency [Hz]")
+    plt.ylabel("PSD [V**2/Hz]")
+    plt.draw()
+    plt.pause(0.05)
+    time.sleep(0.1)
+
+plt.show()

--- a/test/test_map.py
+++ b/test/test_map.py
@@ -82,5 +82,9 @@ def get_test_map():
         "zynqmp-zcu102-rev10-adrv9002",
         "zynqmp-zcu102-rev10-adrv9002-rx2tx2",
     ]
+    test_map["ad9172"] = [
+        "zynq-zc706-adv7511-ad9172-fmc-ebz",
+        "zynqmp-zcu102-rev10-ad9172-fmc-ebz-mode4",
+    ]
 
     return test_map


### PR DESCRIPTION
Signed-off-by: Hannah Rosete <Hannah.Rosete@analog.com>

# Description

This commit is originally from PR #333. This is to add the support for AD9172 and separate it from the PR that contains support for FMCOMMS11. This will add an example for AD9172 and add its project on the test_map.py


# How has this been tested?

Tested on the <project_name> installed on the Test Hatrness:

- [Hardware Tests/HW_pyadi_test/215](http://10.116.171.86/jenkins/blue/organizations/jenkins/HW_tests%2FHW_pyadi_test/detail/HW_pyadi_test/215/pipeline)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
