### PR TITLE
Add AD9081 projects to the test_map

### DIFF
--- a/test/test_ad9081.py
+++ b/test/test_ad9081.py
@@ -6,6 +6,7 @@ import pytest
 hardware = "ad9081_tdd"
 classname = "adi.ad9081"
 
+
 #########################################
 @pytest.mark.iio_hardware(hardware)
 @pytest.mark.parametrize("classname", [(classname)])

--- a/test/test_ad9081.py
+++ b/test/test_ad9081.py
@@ -3,7 +3,7 @@ from os.path import dirname, join, realpath
 
 import pytest
 
-hardware = "ad9081_tdd"
+hardware = ["ad9081", "ad9081_tdd"]
 classname = "adi.ad9081"
 
 

--- a/test/test_ad9081.py
+++ b/test/test_ad9081.py
@@ -3,7 +3,7 @@ from os.path import dirname, join, realpath
 
 import pytest
 
-hardware = "ad9081"
+hardware = "ad9081_tdd"
 classname = "adi.ad9081"
 
 #########################################

--- a/test/test_map.py
+++ b/test/test_map.py
@@ -63,7 +63,6 @@ def get_test_map():
         "zynq-adrv9361-z7035-bob",
         "zynq-adrv9361-z7035-bob-cmos",
     ]
-    #  + test_map["fmcomms5"]
     test_map["ad9364"] = [
         "socfpga_cyclone5_sockit_arradio",
         "zynq-zc702-adv7511-ad9364-fmcomms4",

--- a/test/test_map.py
+++ b/test/test_map.py
@@ -85,5 +85,16 @@ def get_test_map():
         "zynq-zc706-adv7511-ad9172-fmc-ebz",
         "zynqmp-zcu102-rev10-ad9172-fmc-ebz-mode4",
     ]
+    test_map["ad9081"] = [
+        "socfpga-arria10-socdk-ad9081",
+        "socfpga-arria10-socdk-ad9081-np12",
+        "versal-vck190-reva-ad9081",
+        "zynq-zc706-adv7511-ad9081",
+        "zynqmp-zcu102-rev10-ad9081-204b-txmode9-rxmode4",
+        "zynqmp-zcu102-rev10-ad9081-204c-txmode0-rxmode1",
+        "zynqmp-zcu102-rev10-ad9081-m8-l4",
+        "zynqmp-zcu102-rev10-ad9081-m8-l4-vcxo122p88",
+        "zynqmp-zcu102-rev10-ad9081-m4-l8",
+    ]
 
     return test_map


### PR DESCRIPTION
# Description

- 2915285 - Add AD9081 projects to the test_map for them to be tested on the Test Harness
- 9235963 - Omitted FMComms5's appended key to AD9361 even though it was commented (for code consistency)

Fixes [this issue in JSL PR.](https://github.com/sdgtt/jenkins-shared-library/pull/52)

# Test
[jenkins / HW_tests/HW_pyadi_test / HW_pyadi_test / #225](http://10.116.171.86/jenkins/blue/organizations/jenkins/HW_tests%2FHW_pyadi_test/detail/HW_pyadi_test/225/pipeline/1531/)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
