### PR TITLE
remove one underscore to match current bindings

### DIFF
--- a/adi/ad7124.py
+++ b/adi/ad7124.py
@@ -71,7 +71,7 @@ class ad7124(rx, context_manager):
         # dynamically get channels and sorting them after the index of the first voltage channel
         self._ctrl.channels.sort(key=lambda x: int(x.id[7 : x.id.find("-")]))
 
-        for ch in self._ctrl._channels:
+        for ch in self._ctrl.channels:
             name = ch._id
             self._rx_channel_names.append(name)
             self.channel.append(self._channel(self._ctrl, name))


### PR DESCRIPTION
# Description

I found that this change allowed the code to work. The example test code ad7124_setup_example.py as described in https://wiki.analog.com/university/labs/software/precision_adc_toolbox did not work before I made this change.

Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

ad7124_setup_example.py now runs correctly both locally on Raspberry Pi 3B with AD7124 on the local SPI pins, and also over the LAN from a remote host.

**Test Configuration**:
* Raspberry Pi 3B
* OS: ADI Kuiper Linux

# Documentation

No change to documentation. Now the published example works, and before it didn't.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [X ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
