### PR TITLE
Fix dma_rx test overflow issue.

### DIFF
--- a/test/dma_tests.py
+++ b/test/dma_tests.py
@@ -61,9 +61,9 @@ def dma_rx(
             else:
                 if isinstance(data, list):
                     for chan in data:
-                        assert np.sum(np.abs(chan)) > 0, "Buffer all zeros"
+                        assert np.max(np.abs(chan)) > 0, "Buffer all zeros"
                 else:
-                    assert np.sum(np.abs(data)) > 0, "Buffer all zeros"
+                    assert np.max(np.abs(data)) > 0, "Buffer all zeros"
     except Exception as e:
         del sdr
         raise Exception(e) from e


### PR DESCRIPTION
dma_rx passes as long as there's at least one nonzero data point. Using np.sum(np.max(data)) can overflow to a negative value, particularly with high-resolution ADCs and long buffers, failing the test. Replace with np.max(np.abs(data))

Signed-off-by: Mark Thoren <mark.thoren@analog.com>

# Description

Fix DMA test issue where large values can roll over to a negative sum, failing the test.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Test fails with an actual LTC2387-18 if you apply a large input signal +4.0V or -4.0V)
dma_test() exercised by intercepting data returned by rx_tx.py's rx() method, returning test vectors.
- [X] Setting all data to zero fails, setting a single data point to +1 or -1 passes,
- [X] Setting all data to -1 * (2**17 -1) passes (fails before the fix)
- [X] Setting all data to 2**17 -1 passes (fails before the fix)

**Test Configuration**:
* Hardware: CN0577 / LTC2387-18 board, with data intercepted in rx_tx.py
* OS: ADI Kuiper Linux on ZedBoard, tests running on Windows 10.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
