### PR TITLE
Add list of supported projects in test_map.py

### DIFF
--- a/test/test_map.py
+++ b/test/test_map.py
@@ -10,6 +10,7 @@ def get_test_map():
     # zynq-zc706-adv7511-fmcadc4
     # zynq-zc706-adv7511-fmcomms11
     # zynq-zc706-adv7511-ad9625-fmcadc2
+    # vc707_fmcadc2
     #
     #
     # zynq-zed-adv7511-ad9467-fmc-250ebz
@@ -27,6 +28,49 @@ def get_test_map():
     # zynq-zc706-adv7511-fmcjesdadc1
     # zynq-zed-adv7511-fmcmotcon2
     # zynq-zc706-adv7511
+    #
+    # socfpga_arria10_socdk_cn0506_mii
+    # zynq-zc706-adv7511-cn0506-mii
+    # zynq-zc706-adv7511-cn0506-rgmii
+    # zynq-zc706-adv7511-cn0506-rmii
+    # zynq-zed-adv7511-cn0506-mii
+    # zynq-zed-adv7511-cn0506-rgmii
+    # zynq-zed-adv7511-cn0506-rmii
+    # zynqmp-zcu102-rev10-cn0506-mii
+    # zynqmp-zcu102-rev10-cn0506-rgmii
+    # zynqmp-zcu102-rev10-cn0506-rmii
+    #
+    # socfpga_cyclone5_de10_nano_cn0540
+    # zynq-coraz7s-cn0540
+    #
+    # socfpga_cyclone5_sockit_arradio
+    #
+    # zynq-coraz7s-cn0501
+    #
+    # zynq-zc706-adv7511-ad6676-fmc
+    # vc707_ad6676evb
+    #
+    # zynq-zed-adv7511-cn0577
+    #
+    # zynqmp-zcu102-rev10-ad9082-m4-l8
+    #
+    # zynqmp-zcu102-rev10-ad9695
+    #
+    # zynqmp-zcu102-rev10-ad9783
+    #
+    # zynqmp-zcu102-rev10-stingray
+    # zynqmp-zcu102-rev10-stingray-direct-clk
+    # zynqmp-zcu102-rev10-stingray-vcxo100
+    # zynqmp-zcu102-rev10-stingray-vcxo100-direct-clk
+    #
+    # zynq-zed-adv7511-ad7768
+    #
+    # zynq-zed-adv7511-ad7768-1-evb
+    #
+    # vcu118_dual_ad9208
+    #
+    # zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-xmicrowave
+    # zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-fmcbridge
 
     test_map = {}
     test_map["daq3"] = ["zynqmp-zcu102-rev10-fmcdaq3"]

--- a/test/test_map.py
+++ b/test/test_map.py
@@ -73,21 +73,53 @@ def get_test_map():
     # zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-fmcbridge
 
     test_map = {}
-    test_map["daq3"] = ["zynqmp-zcu102-rev10-fmcdaq3"]
+    test_map["daq3"] = [
+        "zynq-zc706-adv7511-fmcdaq3-revC",
+        "zynqmp-zcu102-rev10-fmcdaq3",
+        "kcu105_fmcdaq3",
+        "vc707_fmcdaq3",
+        "vcu118_fmcdaq3",
+    ]
     test_map["ad9152"] = ["zynqmp-zcu102-rev10-fmcdaq3"]
-    test_map["daq2"] = ["zynq-zc706-adv7511-fmcdaq2", "zynqmp-zcu102-rev10-fmcdaq2"]
+    test_map["daq2"] = [
+        "zynq-zc706-adv7511-fmcdaq2",
+        "zynqmp-zcu102-rev10-fmcdaq2",
+        "socfpga_arria10_socdk_daq2",
+        "kc705_fmcdaq2",
+        "kcu105_fmcdaq2",
+        "vc707_fmcdaq2",
+    ]
     test_map["ad9144"] = ["zynq-zc706-adv7511-fmcdaq2", "zynqmp-zcu102-rev10-fmcdaq2"]
     test_map["ad9680"] = ["zynq-zc706-adv7511-fmcdaq2", "zynqmp-zcu102-rev10-fmcdaq2"]
     test_map["adrv9371"] = [
         "zynqmp-zcu102-rev10-adrv9371",
         "zynq-zc706-adv7511-adrv9371",
         "socfpga_arria10_socdk_adrv9371",
+        "kcu105_adrv9371x",
+        "zynq-zc706-adv7511-adrv9375",
+        "zynqmp-zcu102-rev10-adrv9375",
     ]
     test_map["adrv9009"] = [
         "socfpga_arria10_socdk_adrv9009",
         "zynqmp-zcu102-rev10-adrv9008-1",
         "zynqmp-zcu102-rev10-adrv9008-2",
         "zynqmp-zcu102-rev10-adrv9009",
+        "zynq-zc706-adv7511-adrv9009",
+        "zynq-zc706-adv7511-adrv9008-1",
+        "zynq-zc706-adv7511-adrv9008-2",
+    ]
+    test_map["zu11eg"] = [
+        "zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb",
+        "zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-sync-multisom-primary",
+        "zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-sync-multisom-secondary",
+    ]
+    test_map["fmcomms8"] = [
+        "zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-sync-fmcomms8",
+        "zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-sync-fmcomms8-multisom-primary",
+        "zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-sync-fmcomms8-multisom-secondary",
+        "zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-sync-fmcomms8-using-clockdist",
+        "socfpga_arria10_socdk_fmcomms8",
+        "zynqmp-zcu102-rev10-adrv9009-fmcomms8",
     ]
     test_map["fmcomms5"] = [
         "zynqmp-zcu102-rev10-ad9361-fmcomms5",
@@ -106,6 +138,9 @@ def get_test_map():
         "zynq-adrv9361-z7035-box",
         "zynq-adrv9361-z7035-bob",
         "zynq-adrv9361-z7035-bob-cmos",
+        "kc705_fmcomms2-3",
+        "kcu105_fmcomms2-3",
+        "vc707_fmcomms2-3",
     ]
     test_map["ad9364"] = [
         "socfpga_cyclone5_sockit_arradio",
@@ -116,6 +151,9 @@ def get_test_map():
         "zynq-adrv9364-z7020-bob",
         "zynq-adrv9364-z7020-bob-cmos",
         "zynq-zed-adv7511-ad9364-fmcomms4",
+        "kc705_fmcomms4",
+        "kcu105_fmcomms4",
+        "vc707_fmcomms4",
     ]
     test_map["adrv9002"] = [
         "zynq-zc706-adv7511-adrv9002",
@@ -124,6 +162,8 @@ def get_test_map():
         "zynq-zed-adv7511-adrv9002-rx2tx2",
         "zynqmp-zcu102-rev10-adrv9002",
         "zynqmp-zcu102-rev10-adrv9002-rx2tx2",
+        "socfpga_arria10_socdk_adrv9002",
+        "socfpga_arria10_socdk_adrv9002_rx2tx2",
     ]
     test_map["ad9172"] = [
         "zynq-zc706-adv7511-ad9172-fmc-ebz",
@@ -134,12 +174,42 @@ def get_test_map():
         "socfpga-arria10-socdk-ad9081-np12",
         "versal-vck190-reva-ad9081",
         "zynq-zc706-adv7511-ad9081",
+        "zynq-zc706-adv7511-ad9081-np12"
         "zynqmp-zcu102-rev10-ad9081-204b-txmode9-rxmode4",
         "zynqmp-zcu102-rev10-ad9081-204c-txmode0-rxmode1",
         "zynqmp-zcu102-rev10-ad9081-m8-l4",
         "zynqmp-zcu102-rev10-ad9081-m8-l4-vcxo122p88",
         "zynqmp-zcu102-rev10-ad9081-m4-l8",
+        "vcu118_ad9081",
+        "vcu118_ad9081_m8_l4",
+        "vcu118_ad9081_fmca_ebz_vcu118_204c-txmode10-rxmode11",
+        "vcu118_ad9081_fmca_ebz_vcu118_204c-txmode23-rxmode25",
     ]
     test_map["fmcomms11"] = ["zynq-zc706-adv7511-fmcomms11"]
+    test_map["ad9083"] = [
+        "socfpga_arria10_socdk_ad9083_fmc_ebz",
+        "zynqmp-zcu102-rev10-ad9083-fmc-ebz",
+    ]
+    test_map["ad9136"] = ["socfpga_arria10_socdk_ad9136_fmc_ebz"]
+    test_map["ad9265"] = ["zynq-zc706-adv7511-ad9265-fmc-125ebz"]
+    test_map["ad9434"] = ["zynq-zc706-adv7511-ad9434-fmc-500ebz"]
+    test_map["ad9739a"] = ["zynq-zc706-adv7511-ad9739a-fmc"]
+    test_map["fmcjesdadc1"] = [
+        "zynq-zc706-adv7511-fmcjesdadc1",
+        "kc705_fmcjesdadc1",
+        "vc707_fmcjesdadc1",
+    ]
+    test_map["ad4020"] = ["zynq-zed-adv7511-ad4020"]
+    test_map["ad4630"] = ["zynq-zed-adv7511-ad4630-24"]
+    test_map["ad9467"] = [
+        "zynq-zed-adv7511-ad9467-fmc-250ebz",
+        "kc705_ad9467_fmc",
+    ]
+    test_map["adaq8092"] = ["zynq-zed-adv7511-adaq8092"]
+    test_map["ad9625"] = [
+        "zynq-zc706-adv7511-ad9625-fmcadc2",
+        "zynq-zc706-adv7511-ad9625-fmcadc3",
+        "zynq-zc706-adv7511-fmcomms11",
+    ]
 
     return test_map

--- a/test/test_map.py
+++ b/test/test_map.py
@@ -8,24 +8,16 @@ def get_test_map():
     # NO TESTS YET
     # zynq-zc702-adv7511
     # zynq-zc706-adv7511-fmcadc4
-    # zynq-zc706-adv7511-fmcomms11
     # zynq-zc706-adv7511-ad9625-fmcadc2
     # vc707_fmcadc2
     #
-    #
-    # zynq-zed-adv7511-ad9467-fmc-250ebz
     # zynq-zc706-adv7511-ad9625-fmcadc3
     #
     # zynq-zed-adv7511-cn0363
     # zynq-zc706-adv7511-ad6676-fmc
     #
-    # zynq-zc706-adv7511-ad9265-fmc-125ebz
-    # zynq-zc706-adv7511-ad9434-fmc-500ebz
     # zynq-zed-adv7511
-    # zynq-zc706-adv7511-ad9739a-fmc
     # zynq-zed-imageon
-    # zynq-zc706-adv7511-fmcdaq3-revC
-    # zynq-zc706-adv7511-fmcjesdadc1
     # zynq-zed-adv7511-fmcmotcon2
     # zynq-zc706-adv7511
     #


### PR DESCRIPTION
# Description

This PR adds the following supported projects, as of now, in PyADI-IIO:
- DAQ3
- DAQ2
- ADRV9371
- ADRV9375
- ADRV9009
- ADRV9009-ZU11EG
- FMCOMMS8
- ADRV9002
- AD9081
- AD9083
- AD9136
- AD9265
- AD9434
- AD9739A
- FMCJESDADC1
- AD4020
- AD4630
- AD9467
- ADAQ8092
- AD9361
- AD9364
- AD9625

Microblaze and no-OS projects were also added to the roster to be able to cater to the ongoing Jenkins pipeline support for the two.

This also futureproofs the tests of the projects that are yet to be added to the Test Harness.

AI: Add these projects' list of IIO devices in pytest-libiio, specifically in the [adi_hardware_map.py](https://github.com/tfcollins/pytest-libiio/blob/master/pytest_libiio/resources/adi_hardware_map.yml)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

@tfcollins 