### PR TITLE
[FIX] Update favicon usage in doc with package update in 1.0

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -66,7 +66,7 @@ extensions = [
     "sphinx.ext.githubpages",
     "sphinx_rtd_theme",
     "myst_parser",
-    "sphinx-favicon",
+    "sphinx_favicon",
     "sphinxcontrib.mermaid",
 ]
 


### PR DESCRIPTION
Fix sphinx-favicon package which has a name change in 1.0: https://github.com/tcmetzger/sphinx-favicon/blob/v1.0/README.md 