### PR TITLE
MAX31855: Fix the device's name

### DIFF
--- a/adi/max31855.py
+++ b/adi/max31855.py
@@ -47,7 +47,7 @@ class max31855(rx, context_manager, attribute):
 
     def __init__(self, uri=""):
         context_manager.__init__(self, uri, self._device_name)
-        self._ctrl = self._ctx.find_device("max31855")
+        self._ctrl = self._ctx.find_device("maxim_thermocouple")
 
         if self._ctrl is None:
             raise Exception("No device found")


### PR DESCRIPTION
The IIO device name for the MAX31855 is "maxim_thermocouple" in both Linux and no-OS.

# Description

The IIO device's name for the MAX31855 (in both no-OS(after a recent update) and Linux) is "maxim_thermocouple". This requires a rename here too.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**: MCU running the MAX31855 no-OS IIO example
* Hardware: MAX32655 + FTHR to PMOD adapter + MAX31855
* OS: Linux

# Documentation

If this is a new feature or example please mention or link any documentation. All new hardware interface classes require documentation.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
