### PR TITLE
Add data alignment checks for RX and TX

### DIFF
--- a/adi/rx_tx.py
+++ b/adi/rx_tx.py
@@ -223,6 +223,29 @@ class rx(rx_tx_common):
             for m in self.rx_enabled_channels:
                 v = self._rxadc.find_channel(self._rx_channel_names[m])
                 v.enabled = True
+
+        # Make sure data fits into alignment requirement
+        if "length_align_bytes" in self._rxadc.buffer_attrs:
+            lab = int(self._rxadc.buffer_attrs["length_align_bytes"].value)
+            cbits = [
+                chan.data_format.length for chan in self._rxadc.channels if chan.enabled
+            ]
+            bytes_per_sample = (
+                max(cbits) // 8
+            )  # Assume all channels have the same sample size
+            rx_data_size = (
+                self.__rx_buffer_size * self._num_rx_channels_enabled * bytes_per_sample
+            )
+            if rx_data_size % lab != 0:
+                print("Warning: RX buffer size does not fit into alignment requirement")
+                samples = lab / bytes_per_sample
+                if self._complex_data:
+                    samples = samples / 2
+                print(
+                    f"rx_buffer_size must be a multiple of {samples} samples "
+                    "for optimal performance"
+                )
+
         self.__rxbuf = iio.Buffer(self._rxadc, self.__rx_buffer_size, False)
 
     def __rx_unbuffered_data(self):
@@ -451,6 +474,24 @@ class tx(dds, rx_tx_common):
             self._txdac, self._tx_buffer_size, self.__tx_cyclic_buffer
         )
 
+    def _check_alignment(self, data):
+        lab = int(self._txdac.buffer_attrs["length_align_bytes"].value)
+        cbits = [
+            chan.data_format.length for chan in self._txdac.channels if chan.enabled
+        ]
+        bytes_per_sample = (
+            max(cbits) // 8
+        )  # Assume all channels have the same sample size
+        if len(bytearray(data)) % lab != 0:
+            print("Warning: Data length does not fit into alignment requirement")
+            samples = lab / bytes_per_sample
+            if self._complex_data:
+                samples = samples / 2
+            print(
+                f"Data must be a multiple of {samples} samples "
+                "for optimal performance"
+            )
+
     def tx(self, data_np=None):
         """Transmit data to hardware buffers for each channel index in
         tx_enabled_channels.
@@ -513,6 +554,10 @@ class tx(dds, rx_tx_common):
             self.disable_dds()
             self._tx_buffer_size = len(data) // stride
             self._tx_init_channels()
+
+            # Make sure data fits into alignment requirement
+            if "length_align_bytes" in self._txdac.buffer_attrs:
+                self._check_alignment(data)
 
         if len(data) // stride != self._tx_buffer_size:
             raise Exception(


### PR DESCRIPTION
# Description

PR adds data alignment checks if buffers on RX and TX side to not meet the byte alignment within the IIO buffers. These will generate just warnings and not error.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] ADRV9361 + Example
- [ ] ADRV9371 + Example

**Test Configuration**:
* Hardware: ADRV9361, ADRV9371
* OS: Ubuntu 22.04

# Documentation

If this is a new feature or example please mention or link any documentation. All new hardware interface classes require documentation.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
