### PR TITLE
Fix seg fault v2

### DIFF
--- a/adi/cn0511.py
+++ b/adi/cn0511.py
@@ -106,9 +106,7 @@ class cn0511(ad9166_adi):
         """calibrated_output: ["desired_output_amplitude_in_dbm", "desired_output_frequency_in_Hz"]]"""
         if libad9166:
             return [int(20 * np.log10(self.raw / (2 ** 15))), self.frequency]
-        else:
-            print("Warning: Missing libad9166, calibration failed.")
-            return [None, None]
+        print("Warning: Missing libad9166, calibration failed.")
 
     @calibrated_output.setter
     def calibrated_output(self, value):
@@ -120,3 +118,10 @@ class cn0511(ad9166_adi):
             )
         else:
             print("Warning: Missing libad9166, calibration failed.")
+
+    @property
+    def board_calibrated(self):
+        """ board_calibrated: 1 if board was calibrated in production, 0 if board was not calibrated in production"""
+        if libad9166:
+            return libad9166.device_is_calibrated(self.__calibration_data)
+        print("Warning: Missing libad9166, calibration failed.")

--- a/examples/cn0511_example.py
+++ b/examples/cn0511_example.py
@@ -87,3 +87,6 @@ rpi_sig_gen.amp_enable = False
 print("Amplifier enabled: ", rpi_sig_gen.amp_enable)
 rpi_sig_gen.tx_enable = False
 print("Output enabled: ", rpi_sig_gen.tx_enable)
+
+# Check if board was calibrated in production
+print("Board was calibrated in production: ", rpi_sig_gen.board_calibrated)


### PR DESCRIPTION
# Description

- added attribute for cn0511 to check if the board was calibrated or not (cn0511.py)
- added use of this attribute in cn0511_example.py
- depends on https://github.com/analogdevicesinc/libad9166-iio/pull/16

#Issue

- cn0511 was returning a segmentation error when used as normal (iio-oscilloscope or pyadi-iio example) if it was not calibrated in production.

## Type of change

-  New feature (non-breaking change which adds functionality)

# How has this been tested?

- Tested if this attribute affects cn0511 output with a spectrum analyzer on 2 boards, one calibrated and one uncalibrated.

OBS: the calibration here is referring to running the production test for cn0511 with success.

# Checklist:

-  My code follows the style guidelines of this project
-  I have performed a self-review of my own code
-  I have commented my code, particularly in hard-to-understand areas
-  I have signed off all commits and they contain "Signed-off by: <VBeleca>"
-  I have made corresponding changes to the documentation
-  My changes generate no new warnings
-  I have added tests that prove my fix is effective or that my feature works
-  New and existing unit tests pass locally with my changes
-  Any dependent changes have been merged and published in downstream modules
