### PR TITLE
fix: random_values_in_range in test_adrv9002

### DIFF
--- a/test/test_adrv9002_p.py
+++ b/test/test_adrv9002_p.py
@@ -42,7 +42,7 @@ def random_values_in_range(start, stop, step, to_generate=1):
         ind = randint(0, numints)
         val = start + step * ind
         if isinstance(val, float):
-            val = floor(val / step) * step
+            val = round(floor(val / step) * step, 2)
         values.append(val)
     return values
 


### PR DESCRIPTION
# Description

This PR includes a fix to an existing failing test in adrv9002.

>FAILED test/test_adrv9002_p.py::test_adrv9002_hardware_gain
  >  Failed to set: tx_hardwaregain_chan0
  > Set: -22.700000000000003
  > Got: -22.7


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested on actual board setup.

# Documentation

If this is a new feature or example please mention or link any documentation. All new hardware interface classes require documentation.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
