### PR TITLE
test: fix spelling of multiple

### DIFF
--- a/test/attr_tests.py
+++ b/test/attr_tests.py
@@ -179,8 +179,8 @@ def attribute_single_value_pow2(uri, classname, attr, max_pow, tol, repeats=1):
         assert dev_interface(uri, classname, val, attr, tol)
 
 
-def attribute_multipe_values(uri, classname, attr, values, tol, repeats=1, sleep=0):
-    """attribute_multipe_values: Write and read back multiple class properties
+def attribute_multiple_values(uri, classname, attr, values, tol, repeats=1, sleep=0):
+    """attribute_multiple_values: Write and read back multiple class properties
     in a loop where all values are pre-defined. This is performed a defined
     number of times.
 
@@ -206,10 +206,10 @@ def attribute_multipe_values(uri, classname, attr, values, tol, repeats=1, sleep
                 assert dev_interface(uri, classname, val, attr, tol, sleep=sleep)
 
 
-def attribute_multipe_values_with_depends(
+def attribute_multiple_values_with_depends(
     uri, classname, attr, depends, values, tol, repeats=1
 ):
-    """attribute_multipe_values_with_depends: Write and read back multiple class
+    """attribute_multiple_values_with_depends: Write and read back multiple class
     properties in a loop where all values are pre-defined, where a set of
     dependent attributes are written first. This is performed a defined
     number of times.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -155,13 +155,13 @@ if not disable_prod_tests:
 
 
 @pytest.fixture()
-def test_attribute_multipe_values(request):
-    yield attribute_multipe_values
+def test_attribute_multiple_values(request):
+    yield attribute_multiple_values
 
 
 @pytest.fixture()
-def test_attribute_multipe_values_with_depends(request):
-    yield attribute_multipe_values_with_depends
+def test_attribute_multiple_values_with_depends(request):
+    yield attribute_multiple_values_with_depends
 
 
 @pytest.fixture()

--- a/test/test_ad4630.py
+++ b/test/test_ad4630.py
@@ -23,5 +23,5 @@ def test_ad4630_rx_data(test_dma_rx, iio_uri, classname, channel):
         ),
     ],
 )
-def test_ad4630_attr(test_attribute_multipe_values, iio_uri, classname, attr, val):
-    test_attribute_multipe_values(iio_uri, classname, attr, val, 0)
+def test_ad4630_attr(test_attribute_multiple_values, iio_uri, classname, attr, val):
+    test_attribute_multiple_values(iio_uri, classname, attr, val, 0)

--- a/test/test_ad5754r.py
+++ b/test/test_ad5754r.py
@@ -16,9 +16,9 @@ classname = "adi.ad5754r"
     ],
 )
 def test_ad5754r_global_attr(
-    test_attribute_multipe_values, iio_uri, classname, attr, val
+    test_attribute_multiple_values, iio_uri, classname, attr, val
 ):
-    test_attribute_multipe_values(iio_uri, classname, attr, val, 0)
+    test_attribute_multiple_values(iio_uri, classname, attr, val, 0)
 
 
 #########################################

--- a/test/test_ad7768.py
+++ b/test/test_ad7768.py
@@ -36,5 +36,5 @@ def test_ad7768_rx_data(test_dma_rx, iio_uri, classname, channel):
         ("power_mode", ["MEDIAN_MODE", "FAST_MODE"],),
     ],
 )
-def test_ad4630_attr(test_attribute_multipe_values, iio_uri, classname, attr, val):
-    test_attribute_multipe_values(iio_uri, classname, attr, val, 0)
+def test_ad4630_attr(test_attribute_multiple_values, iio_uri, classname, attr, val):
+    test_attribute_multiple_values(iio_uri, classname, attr, val, 0)

--- a/test/test_ad7768_4.py
+++ b/test/test_ad7768_4.py
@@ -37,5 +37,5 @@ def test_ad7768_4_rx_data(test_dma_rx, iio_uri, classname, channel):
         ("sync_start_enable", ["arm"],),
     ],
 )
-def test_ad7768_4_attr(test_attribute_multipe_values, iio_uri, classname, attr, val):
-    test_attribute_multipe_values(iio_uri, classname, attr, val, 0)
+def test_ad7768_4_attr(test_attribute_multiple_values, iio_uri, classname, attr, val):
+    test_attribute_multiple_values(iio_uri, classname, attr, val, 0)

--- a/test/test_ad9081.py
+++ b/test/test_ad9081.py
@@ -51,8 +51,8 @@ def scale_field(param_set, iio_uri):
         ),
     ],
 )
-def test_ad9081_str_attr(test_attribute_multipe_values, iio_uri, classname, attr, val):
-    test_attribute_multipe_values(iio_uri, classname, attr, val, 0)
+def test_ad9081_str_attr(test_attribute_multiple_values, iio_uri, classname, attr, val):
+    test_attribute_multiple_values(iio_uri, classname, attr, val, 0)
 
 
 #########################################

--- a/test/test_ad9084.py
+++ b/test/test_ad9084.py
@@ -47,8 +47,8 @@ def scale_field(param_set, iio_uri):
         ),
     ],
 )
-def test_ad9084_str_attr(test_attribute_multipe_values, iio_uri, classname, attr, val):
-    test_attribute_multipe_values(iio_uri, classname, attr, val, 0)
+def test_ad9084_str_attr(test_attribute_multiple_values, iio_uri, classname, attr, val):
+    test_attribute_multiple_values(iio_uri, classname, attr, val, 0)
 
 
 #########################################

--- a/test/test_adl5240.py
+++ b/test/test_adl5240.py
@@ -12,5 +12,5 @@ classname = "adi.adl5240"
 @pytest.mark.parametrize(
     "attr, val", [("hardwaregain", [0.06, 0.12, 0.25, 0.5, 0.9],),],
 )
-def test_adl5240_attr(test_attribute_multipe_values, iio_uri, classname, attr, val):
-    test_attribute_multipe_values(iio_uri, classname, attr, val, 0)
+def test_adl5240_attr(test_attribute_multiple_values, iio_uri, classname, attr, val):
+    test_attribute_multiple_values(iio_uri, classname, attr, val, 0)

--- a/test/test_adrv9002_p.py
+++ b/test/test_adrv9002_p.py
@@ -94,9 +94,9 @@ def test_adrv9002_float_attr(
     ],
 )
 def test_adrv9002_hardware_gain(
-    test_attribute_multipe_values_with_depends, iio_uri, classname, attr, depends, val
+    test_attribute_multiple_values_with_depends, iio_uri, classname, attr, depends, val
 ):
-    test_attribute_multipe_values_with_depends(
+    test_attribute_multiple_values_with_depends(
         iio_uri, classname, attr, depends, val, 0
     )
 
@@ -138,9 +138,9 @@ def test_adrv9002_hardware_gain(
     ],
 )
 def test_adrv9002_boolean_attr(
-    test_attribute_multipe_values, iio_uri, classname, attr, val
+    test_attribute_multiple_values, iio_uri, classname, attr, val
 ):
-    test_attribute_multipe_values(iio_uri, classname, attr, val, 0)
+    test_attribute_multiple_values(iio_uri, classname, attr, val, 0)
 
 
 #########################################
@@ -166,10 +166,10 @@ def test_adrv9002_boolean_attr(
     ],
 )
 def test_adrv9002_str_attr(
-    test_attribute_multipe_values, iio_uri, classname, attr, val
+    test_attribute_multiple_values, iio_uri, classname, attr, val
 ):
     sleep = 3 if "ensm_mode" in attr else 0
-    test_attribute_multipe_values(iio_uri, classname, attr, val, 0, sleep=sleep)
+    test_attribute_multiple_values(iio_uri, classname, attr, val, 0, sleep=sleep)
 
 
 #########################################
@@ -198,7 +198,7 @@ def test_adrv9002_str_attr(
     ],
 )
 def test_adrv9002_interface_gain_narrowband(
-    test_attribute_multipe_values_with_depends, iio_uri, classname, attr, depends, val
+    test_attribute_multiple_values_with_depends, iio_uri, classname, attr, depends, val
 ):
     from adi.adrv9002 import adrv9002
 
@@ -214,7 +214,7 @@ def test_adrv9002_interface_gain_narrowband(
                 "Baseband RX2 Sample Rate should be less than 1MHz to run this test."
             )
 
-    test_attribute_multipe_values_with_depends(
+    test_attribute_multiple_values_with_depends(
         iio_uri, classname, attr, depends, val, 0
     )
 

--- a/test/test_cn0575.py
+++ b/test/test_cn0575.py
@@ -36,5 +36,5 @@ def test_adt75_attr(
 @pytest.mark.parametrize(
     "attr, val", [("led", [1, 0],),],
 )
-def test_led_attr(test_attribute_multipe_values, iio_uri, classname, attr, val):
-    test_attribute_multipe_values(iio_uri, classname, attr, val, 0, repeats=10)
+def test_led_attr(test_attribute_multiple_values, iio_uri, classname, attr, val):
+    test_attribute_multiple_values(iio_uri, classname, attr, val, 0, repeats=10)

--- a/test/test_cn0579.py
+++ b/test/test_cn0579.py
@@ -38,9 +38,9 @@ def test_cn0579_rx_data(test_dma_rx, iio_uri, classname, channel):
     ],
 )
 def test_cn0579_attr_multiple(
-    test_attribute_multipe_values, iio_uri, classname, attr, val
+    test_attribute_multiple_values, iio_uri, classname, attr, val
 ):
-    test_attribute_multipe_values(iio_uri, classname, attr, val, 0)
+    test_attribute_multiple_values(iio_uri, classname, attr, val, 0)
 
 
 #########################################


### PR DESCRIPTION


# Description

This replaces the misspelled "multipe" with "multiple" in the tests.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

CI

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
