### PR TITLE
adi/rx_tx.py: fix return type of rx_enabled_channels

### DIFF
--- a/adi/rx_tx.py
+++ b/adi/rx_tx.py
@@ -91,7 +91,7 @@ class rx(rx_tx_common):
         self.__rx_buffer_size = value
 
     @property
-    def rx_enabled_channels(self) -> List[int]:
+    def rx_enabled_channels(self) -> Union[List[int], List[str]]:
         """rx_enabled_channels: List of enabled channels (channel 1 is 0)
 
         Either a list of channel numbers or channel names can be used to set


### PR DESCRIPTION

# Description
As mentioned in the doc string and in the setter type hints, `rx_enabled_channels` can be either a list of channel numbers (int) or names (str).

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Hardware:
* OS:

# Documentation

If this is a new feature or example please mention or link any documentation. All new hardware interface classes require documentation.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
