### PR TITLE
test/attr_tests: fix tests with setattr

### DIFF
--- a/test/attr_tests.py
+++ b/test/attr_tests.py
@@ -83,6 +83,10 @@ def attribute_single_value_boolean(uri, classname, attr, value):
             Value to write and read back from attribute
     """
     bi = eval(classname + "(uri='" + uri + "')")
+
+    if not hasattr(bi, attr):
+        raise AttributeError(f"no attribute named: {attr}")
+
     setattr(bi, attr, value)
     rval = getattr(bi, attr)
     del bi
@@ -258,6 +262,10 @@ def attribute_write_only_str(uri, classname, attr, value):
             Value to write into attr property
     """
     sdr = eval(classname + "(uri='" + uri + "')")
+
+    if not hasattr(sdr, attr):
+        raise AttributeError(f"no attribute named: {attr}")
+
     try:
         setattr(sdr, attr, value)
         del sdr
@@ -284,6 +292,14 @@ def attribute_write_only_str_with_depends(uri, classname, attr, value, depends):
             are properties and values are values to be written
     """
     sdr = eval(classname + "(uri='" + uri + "')")
+
+    for p in depends:
+        if not hasattr(sdr, p):
+            raise AttributeError(f"no attribute named: {p}")
+
+    if not hasattr(sdr, attr):
+        raise AttributeError(f"no attribute named: {attr}")
+
     for p in depends:
         setattr(sdr, p, depends[p])
     try:


### PR DESCRIPTION
# Description

Since Python objects will dynamically add an attribute if one does not exist when calling `setattr()`, we need to check that the attribute actually exists before setting it. Otherwise, tests will pass even if the attribute is not defined in the object being tested.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

While developing #474, I noticed that tests were passing when I had an obvious mistake. Applying this fix caught the mistake.

# Documentation

If this is a new feature or example please mention or link any documentation. All new hardware interface classes require documentation.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
