### PR TITLE
test: update adrv9002 profile test

### DIFF
--- a/test/test_adrv9002_p.py
+++ b/test/test_adrv9002_p.py
@@ -223,7 +223,7 @@ def test_adrv9002_interface_gain_narrowband(
 @pytest.mark.lvds_test
 @pytest.mark.iio_hardware(hardware)
 @pytest.mark.parametrize("classname", [(classname)])
-@pytest.mark.parametrize("attr", ["profile"])
+@pytest.mark.parametrize("attr", ["write_profile"])
 @pytest.mark.parametrize(
     "profile_file, depends",
     [
@@ -248,7 +248,7 @@ def test_adrv9002_profile_write(
 @pytest.mark.lvds_test
 @pytest.mark.iio_hardware(hardware)
 @pytest.mark.parametrize("classname", [(classname)])
-@pytest.mark.parametrize("attr", ["profile"])
+@pytest.mark.parametrize("attr", ["write_profile"])
 @pytest.mark.parametrize(
     "profile_file, depends", [(nco_test_profile, {"write_stream": nco_test_stream})]
 )
@@ -269,7 +269,7 @@ def test_adrv9002_nco_write_profile(
 @pytest.mark.cmos_test
 @pytest.mark.iio_hardware(hardware)
 @pytest.mark.parametrize("classname", [(classname)])
-@pytest.mark.parametrize("attr", ["profile"])
+@pytest.mark.parametrize("attr", ["write_profile"])
 @pytest.mark.parametrize(
     "profile_file, depends", [(lte_5_cmos_profile, {"write_stream": lte_5_cmos_stream})]
 )


### PR DESCRIPTION
# Description

This PR includes small change on the profile test of adrv9002. The 'profile' property will fail in hasattr() check since it has no getter. In the test, changed 'profile' to 'write_profile', directly using the write_profile attribute. All profile test passed.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Run the tests on both zed-adrv9002 and zcu102-adrv9002 on all variants.

**Test Configuration**:
* Hardware:
* OS:
* 

# Documentation

If this is a new feature or example please mention or link any documentation. All new hardware interface classes require documentation.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
