### PR TITLE
adi/ad908[1|4]_mc.py: Fix label parsing in _map_to_dict()

### DIFF
--- a/adi/ad9081_mc.py
+++ b/adi/ad9081_mc.py
@@ -13,7 +13,7 @@ from adi.sync_start import sync_start
 
 
 def _map_to_dict(paths, ch, dev_name):
-    if "label" in ch.attrs and "buffer_only" in ch.attrs["label"].value:
+    if "->" not in ch.attrs["label"].value:
         return paths, False
     fddc, cddc, adc = ch.attrs["label"].value.split("->")
     if dev_name not in paths.keys():

--- a/adi/ad9084_mc.py
+++ b/adi/ad9084_mc.py
@@ -14,7 +14,7 @@ from adi.sync_start import sync_start
 
 
 def _map_to_dict(paths, ch, dev_name):
-    if "label" in ch.attrs and "buffer_only" in ch.attrs["label"].value:
+    if "->" not in ch.attrs["label"].value:
         return paths, False
     side, fddc, cddc, adc = ch.attrs["label"].value.replace(":", "->").split("->")
     if dev_name not in paths.keys():


### PR DESCRIPTION


# Description

In recent kernels the IIO core adds labels for all channels with extended names. This now causes undesired behavior. Before splitting, check if the split string is part of the string. This will also catch the 'buffer_only' case.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

On HW using Linux 6.1

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Hardware:
* OS:

# Documentation

If this is a new feature or example please mention or link any documentation. All new hardware interface classes require documentation.


