### PR TITLE
Add libiio v1.X support

### DIFF
--- a/.github/scripts/install_libiio.sh
+++ b/.github/scripts/install_libiio.sh
@@ -1,9 +1,28 @@
 #!/bin/bash
+
+# Set LIBIIO_BRANCH if not set
+if [ -z "$LIBIIO_BRANCH" ]; then
+    LIBIIO_BRANCH="v0.25"
+fi
+
 sudo apt-get -qq update
-sudo apt-get install -y git cmake graphviz libavahi-common-dev libavahi-client-dev libaio-dev libusb-1.0-0-dev libxml2-dev rpm tar bzip2 gzip flex bison git
-git clone -b 'v0.25' --single-branch --depth 1 https://github.com/analogdevicesinc/libiio.git
+sudo apt-get install -y git cmake graphviz libavahi-common-dev libavahi-client-dev libaio-dev libusb-1.0-0-dev libxml2-dev rpm tar bzip2 gzip flex bison git libzstd-dev
+git clone -b $LIBIIO_BRANCH --single-branch --depth 1 https://github.com/analogdevicesinc/libiio.git
 cd libiio
 cmake . -DHAVE_DNS_SD=OFF
 make
 sudo make install
 cd ..
+rm -rf libiio
+
+# Python pieces
+sudo apt-get install -y python3-pip python3-setuptools
+git clone -b $LIBIIO_BRANCH --single-branch --depth 1 https://github.com/analogdevicesinc/libiio.git
+cd libiio
+cmake . -DHAVE_DNS_SD=OFF -DPYTHON_BINDINGS=ON
+make
+cd bindings/python
+pip install .
+cd ../..
+cd ..
+rm -rf libiio

--- a/.github/scripts/install_part_libs.sh
+++ b/.github/scripts/install_part_libs.sh
@@ -1,7 +1,23 @@
 #!/bin/bash
+
+# Set LIBIIO_BRANCH if not set
+if [ -z "$LIBIIO_BRANCH" ]; then
+    LIBIIO_BRANCH="v0.25"
+fi
+
+if [ "$LIBIIO_BRANCH" = "main" ]; then
+    exit 0
+fi
+
+
+
 git clone -b 'master' --single-branch --depth 1 https://github.com/analogdevicesinc/libad9361-iio.git
 cd libad9361-iio
-cmake -DPYTHON_BINDINGS=ON .
+if [ "$LIBIIO_BRANCH" = "main" ]; then
+    cmake -DPYTHON_BINDINGS=ON -DLIBIIO_INCLUDEDIR=/usr/include/iio .
+else
+    cmake -DPYTHON_BINDINGS=ON .
+fi
 make
 cd bindings/python
 pip install .
@@ -13,7 +29,11 @@ rm -rf libad9361-iio
 
 git clone -b 'master' --single-branch --depth 1 https://github.com/analogdevicesinc/libad9166-iio.git
 cd libad9166-iio
-cmake -DPYTHON_BINDINGS=ON .
+if [ "$LIBIIO_BRANCH" = "main" ]; then
+    cmake -DPYTHON_BINDINGS=ON -DLIBIIO_INCLUDEDIR=/usr/include/iio .
+else
+    cmake -DPYTHON_BINDINGS=ON .
+fi
 make
 cd bindings/python
 pip install .

--- a/.github/scripts/install_pydeps.sh
+++ b/.github/scripts/install_pydeps.sh
@@ -17,5 +17,5 @@ if [ "$LIBIIO_BRANCH" = "main" ]; then
     cd ..
     rm -rf libiio
 else
-    pip install "pytest-libiio>=0.0.14"
+    pip install "pytest-libiio>=0.0.18"
 fi

--- a/.github/scripts/install_pydeps.sh
+++ b/.github/scripts/install_pydeps.sh
@@ -2,4 +2,20 @@
 sudo apt-get install -y python3-pip python3-setuptools
 pip install -r requirements.txt
 pip install -r requirements_dev.txt
-pip install pylibiio
+
+if [ "$LIBIIO_BRANCH" = "main" ]; then
+    pip install --no-deps --force-reinstall pytest-libiio@git+https://github.com/tfcollins/pytest-libiio.git@master
+    pip install lxml pyyaml
+    # Update python bindings again
+    git clone -b $LIBIIO_BRANCH --single-branch --depth 1 https://github.com/analogdevicesinc/libiio.git
+    cd libiio
+    cmake . -DHAVE_DNS_SD=OFF -DPYTHON_BINDINGS=ON
+    make
+    cd bindings/python
+    pip install .
+    cd ../..
+    cd ..
+    rm -rf libiio
+else
+    pip install "pytest-libiio>=0.0.14"
+fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9, "3.10"]
+        libiio: ['main', 'v0.25']
 
     steps:
       - uses: actions/checkout@v2
@@ -18,6 +19,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          export LIBIIO_BRANCH=${{ matrix.libiio }}
           bash ./.github/scripts/install_libiio.sh
           bash ./.github/scripts/install_pydeps.sh
           bash ./.github/scripts/install_part_libs.sh

--- a/adi/compat.py
+++ b/adi/compat.py
@@ -1,0 +1,192 @@
+# Copyright (C) 2023 Analog Devices, Inc.
+#
+# SPDX short identifier: ADIBSD
+"""Compatibility module for libiio v1.X."""
+
+from typing import List, Union
+
+import iio
+
+import numpy as np
+
+
+def _is_libiio_v1() -> bool:
+    """Check is we are using >= v1.X."""
+    v = iio.version
+    return v[0] >= 1
+
+
+class compat_libiio_v1_rx:
+    """Compatibility class for libiio v1.X RX."""
+
+    _rx_buffer_mask = None
+    _rx_stream = None
+    _rx_buffer_num_blocks = 4
+
+    def _rx_init_channels(self):
+        if not self._rx_buffer_mask:
+            self._rx_buffer_mask = iio.ChannelsMask(self._rxadc)
+
+        channels = []
+        if self._complex_data:
+            for m in self.rx_enabled_channels:
+                v = self._rxadc.find_channel(self._rx_channel_names[m * 2])
+                channels.append(v)
+                v = self._rxadc.find_channel(self._rx_channel_names[m * 2 + 1])
+                channels.append(v)
+        else:
+            for m in self.rx_enabled_channels:
+                v = self._rxadc.find_channel(self._rx_channel_names[m])
+                channels.append(v)
+
+        self._rx_buffer_mask.channels = channels
+
+        self._rxbuf = iio.Buffer(self._rxadc, self._rx_buffer_mask)
+        self._rx_stream = iio.Stream(
+            buffer=self._rxbuf,
+            nb_blocks=self._rx_buffer_num_blocks,
+            samples_count=self.rx_buffer_size,
+        )
+
+    def _rx_buffered_data(self):
+        if not self._rx_stream:
+            self._rx_init_channels()
+
+        block = next(self._rx_stream)
+
+        data_channel_interleaved = []
+        for chan in self._rx_buffer_mask.channels:
+            bytearray_data = chan.read(block)
+            # create format strings
+            df = chan.data_format
+            fmt = ("i" if df.is_signed is True else "u") + str(df.length // 8)
+            data_channel_interleaved.append(np.frombuffer(bytearray_data, dtype=fmt))
+
+        return data_channel_interleaved
+
+
+class compat_libiio_v1_tx:
+    """Compatibility class for libiio v1.X TX."""
+
+    _tx_buffer_mask = None
+    _tx_stream = None
+    _tx_buffer_num_blocks = 4
+    _tx_block = None
+
+    def _tx_init_channels(self):
+        if not self._tx_buffer_mask:
+            self._tx_buffer_mask = iio.ChannelsMask(self._txdac)
+
+        channels = []
+        if self._complex_data:
+            for m in self.tx_enabled_channels:
+                v = self._txdac.find_channel(self._tx_channel_names[m * 2], True)
+                channels.append(v)
+                v = self._txdac.find_channel(self._tx_channel_names[m * 2 + 1], True)
+                channels.append(v)
+        else:
+            for m in self.tx_enabled_channels:
+                v = self._txdac.find_channel(self._tx_channel_names[m], True)
+                channels.append(v)
+
+        self._tx_buffer_mask.channels = channels
+
+        self._txbuf = iio.Buffer(self._txdac, self._tx_buffer_mask)
+        if not self._tx_cyclic_buffer:
+            self._tx_stream = iio.Stream(
+                buffer=self._txbuf,
+                nb_blocks=self._tx_buffer_num_blocks,
+                samples_count=self._tx_buffer_size,
+            )
+        else:
+            self._tx_block = iio.Block(self._txbuf, self._tx_buffer_size)
+
+    def _tx_buffer_push(self, data):
+        """Push data to TX buffer.
+
+        data: bytearray
+        """
+        if self._tx_cyclic_buffer:
+            self._tx_block.write(data)
+            self._tx_block.enqueue(None, self._tx_cyclic_buffer)
+            self._txbuf.enabled = True
+        else:
+            block = next(self._tx_stream)
+            block.write(data)
+
+
+class compat_libiio_v0_rx:
+    """Compatibility class for libiio v0.X RX."""
+
+    def _rx_init_channels(self):
+        for m in self._rx_channel_names:
+            v = self._rxadc.find_channel(m)
+            if not v:
+                raise Exception(f"Channel {m} not found")
+            v.enabled = False
+
+        if self._complex_data:
+            for m in self.rx_enabled_channels:
+                v = self._rxadc.find_channel(self._rx_channel_names[m * 2])
+                v.enabled = True
+                v = self._rxadc.find_channel(self._rx_channel_names[m * 2 + 1])
+                v.enabled = True
+        else:
+            for m in self.rx_enabled_channels:
+                v = self._rxadc.find_channel(self._rx_channel_names[m])
+                v.enabled = True
+        self._rxbuf = iio.Buffer(self._rxadc, self._rx_buffer_size, False)
+
+    def _rx_buffered_data(self) -> Union[List[np.ndarray], np.ndarray]:
+        """_rx_buffered_data: Read data from RX buffer
+
+        Returns:
+            List of numpy arrays containing the data from the RX buffer that are
+            channel interleaved
+        """
+        if not self._rxbuf:
+            self._rx_init_channels()
+        self._rxbuf.refill()
+
+        data_channel_interleaved = []
+        ecn = []
+        if self._complex_data:
+            for m in self.rx_enabled_channels:
+                ecn.extend(
+                    (self._rx_channel_names[m * 2], self._rx_channel_names[m * 2 + 1])
+                )
+        else:
+            ecn = [self._rx_channel_names[m] for m in self.rx_enabled_channels]
+
+        for name in ecn:
+            chan = self._rxadc.find_channel(name)
+            bytearray_data = chan.read(self._rxbuf)  # Do local type conversion
+            # create format strings
+            df = chan.data_format
+            fmt = ("i" if df.is_signed is True else "u") + str(df.length // 8)
+            data_channel_interleaved.append(np.frombuffer(bytearray_data, dtype=fmt))
+
+        return data_channel_interleaved
+
+
+class compat_libiio_v0_tx:
+    """Compatibility class for libiio v0.X TX."""
+
+    def _tx_init_channels(self):
+        if self._complex_data:
+            for m in self.tx_enabled_channels:
+                v = self._txdac.find_channel(self._tx_channel_names[m * 2], True)
+                v.enabled = True
+                v = self._txdac.find_channel(self._tx_channel_names[m * 2 + 1], True)
+                v.enabled = True
+        else:
+            for m in self.tx_enabled_channels:
+                v = self._txdac.find_channel(self._tx_channel_names[m], True)
+                v.enabled = True
+        self._txbuf = iio.Buffer(
+            self._txdac, self._tx_buffer_size, self._tx_cyclic_buffer
+        )
+
+    def _tx_buffer_push(self, data):
+        self._txbuf.write(bytearray(data))
+        self._txbuf.push()

--- a/doc/source/libiio.md
+++ b/doc/source/libiio.md
@@ -115,3 +115,7 @@ Output:
 ```bash
 ID: 0xa
 ```
+
+## libiio v1.X support
+
+**pyadi-iio** supports **libiio** v1.X and v0.X. However, the **libiio** python bindings are not available on PyPI for v1.X and they are currently unstable. If you require stable operation, please use **libiio** v0.X. Its also possible that not all ecosystem features are available yet for v1.X. Please report any issues you find with v1.X.

--- a/doc/update_devs.py
+++ b/doc/update_devs.py
@@ -46,6 +46,7 @@ def update_devs():
         "jesd_internal",
         "sync_start",
         "dsp",
+        "compat",
     ]
     adi_rst_path = os.path.join(root, "source", "devices", "adi.rst")
     with open(adi_rst_path, "r") as f:

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,7 +10,7 @@ pytest-cov
 coveralls
 pytest-libiio==0.0.13
 bump2version
-pytest-html
+pytest-html==3.2.0
 plotly-express
 pyvisa
 matplotlib

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,7 +8,7 @@ scapy
 scipy
 pytest-cov
 coveralls
-pytest-libiio==0.0.13
+pytest-libiio>=0.0.18
 bump2version
 pytest-html==3.2.0
 plotly-express


### PR DESCRIPTION
This PR adds a compatibility layer to support libiio v0.X and v1.X. It includes:
- Attribute support
- Buffer support
- Basic CI infrastructure
- Doc notes

iio-emu support appears broken at this time so its not enabled in CI yet.