### PR TITLE
Fix dynamic channel config classes

### DIFF
--- a/adi/ad4110.py
+++ b/adi/ad4110.py
@@ -45,6 +45,8 @@ class ad4110(rx, context_manager):
         if not self._rxadc:
             raise Exception("Error in selecting matching device")
 
+        self._rx_channel_names = []
+        self.channel = []
         for ch in self._ctrl.channels:
             name = ch._id
             self._rx_channel_names.append(name)

--- a/adi/ad4130.py
+++ b/adi/ad4130.py
@@ -40,6 +40,8 @@ class ad4130(rx, context_manager):
                 self._rxadc = device
                 break
 
+        self._rx_channel_names = []
+        self.channel = []
         for ch in self._ctrl.channels:
             name = ch._id
             self._rx_channel_names.append(name)

--- a/adi/ad469x.py
+++ b/adi/ad469x.py
@@ -51,6 +51,7 @@ class ad469x(rx, context_manager):
         if not self._rxadc:
             raise Exception("Error in selecting matching device")
 
+        self._rx_channel_names = []
         for ch in self._ctrl.channels:
             name = ch._id
             self._rx_channel_names.append(name)

--- a/adi/ad4858.py
+++ b/adi/ad4858.py
@@ -45,6 +45,8 @@ class ad4858(rx, context_manager):
         if not self._rxadc:
             raise Exception("Error in selecting matching device")
 
+        self._rx_channel_names = []
+        self.channel = []
         for ch in self._ctrl.channels:
             name = ch._id
             self._rx_channel_names.append(name)

--- a/adi/ad5686.py
+++ b/adi/ad5686.py
@@ -61,6 +61,7 @@ class ad5686(context_manager, attribute):
                 else:
                     index += 1
 
+        self.channel = []
         for ch in self._ctrl.channels:
             name = ch.id
             self.channel.append(self._channel(self._ctrl, name))

--- a/adi/ad5754r.py
+++ b/adi/ad5754r.py
@@ -47,6 +47,8 @@ class ad5754r(tx, context_manager):
             raise Exception("Error in selecting matching device")
 
         self.output_bits = []
+        self.channel = []
+        self._tx_channel_names = []
         for ch in self._ctrl.channels:
             name = ch.id
             self.output_bits.append(ch.data_format.bits)

--- a/adi/ad578x.py
+++ b/adi/ad578x.py
@@ -54,6 +54,8 @@ class ad578x(tx, context_manager):
             raise Exception("Error in selecting matching device")
 
         self.output_bits = []
+        self.channel = []
+        self._tx_channel_names = []
         for ch in self._ctrl.channels:
             name = ch.id
             self.output_bits.append(ch.data_format.bits)

--- a/adi/ad5940.py
+++ b/adi/ad5940.py
@@ -33,6 +33,7 @@ class ad5940(rx, context_manager):
                 break
         # dynamically get channels
         _channels = []
+        self._rx_channel_names = []
         for ch in self._ctrl.channels:
             self._rx_channel_names.append(ch.id)
             if ch.name == "bia":

--- a/adi/ad717x.py
+++ b/adi/ad717x.py
@@ -59,6 +59,8 @@ class ad717x(rx, context_manager):
         if not self._rxadc:
             raise Exception("Error in selecting matching device")
 
+        self._rx_channel_names = []
+        self.channel = []
         for ch in self._ctrl.channels:
             name = ch._id
             self._rx_channel_names.append(name)

--- a/adi/ad719x.py
+++ b/adi/ad719x.py
@@ -46,6 +46,8 @@ class ad719x(rx, context_manager):
         if not self._rxadc:
             raise Exception("Error in selecting matching device")
 
+        self._rx_channel_names = []
+        self.channel = []
         for ch in self._ctrl.channels:
             name = ch._id
             self._rx_channel_names.append(name)

--- a/adi/ad7606.py
+++ b/adi/ad7606.py
@@ -48,6 +48,8 @@ class ad7606(rx, context_manager):
                 self._rxadc = device
                 break
 
+        self._rx_channel_names = []
+        self.channel = []
         for ch in self._ctrl.channels:
             name = ch._id
             self._rx_channel_names.append(name)

--- a/adi/ad7689.py
+++ b/adi/ad7689.py
@@ -44,6 +44,8 @@ class ad7689(rx, context_manager):
                 self._rxadc = device
                 break
 
+        self._rx_channel_names = []
+        self.channel = []
         for ch in self._ctrl.channels:
             name = ch._id
             self._rx_channel_names.append(name)

--- a/adi/ad7746.py
+++ b/adi/ad7746.py
@@ -41,6 +41,7 @@ class ad7746(rx, context_manager):
                 break
         # dynamically get channels
         _channels = []
+        self._rx_channel_names = []
         for ch in self._ctrl.channels:
             self._rx_channel_names.append(ch.id)
             if "capacitance" in ch.id:

--- a/adi/ad7768.py
+++ b/adi/ad7768.py
@@ -35,6 +35,7 @@ class ad7768(rx, context_manager):
         if not self._rxadc:
             raise Exception("Error in selecting matching device")
 
+        self._rx_channel_names = []
         for ch in self._rxadc.channels:
             name = ch._id
             self._rx_channel_names.append(name)

--- a/adi/ad777x.py
+++ b/adi/ad777x.py
@@ -46,6 +46,8 @@ class ad777x(rx, context_manager):
         if not self._rxadc:
             raise Exception("Error in selecting matching device")
 
+        self._rx_channel_names = []
+        self.channel = []
         for ch in self._ctrl.channels:
             name = ch._id
             self._rx_channel_names.append(name)

--- a/adi/ad7799.py
+++ b/adi/ad7799.py
@@ -21,6 +21,7 @@ class ad7799(rx, context_manager):
 
         self._rxadc = self._ctx.find_device("AD7799")
 
+        self.channel = []
         for name in self._rx_channel_names:
             self.channel.append(self._channel(self._rxadc, name))
 

--- a/adi/ad9083.py
+++ b/adi/ad9083.py
@@ -25,6 +25,7 @@ class ad9083(sync_start, rx, context_manager):
         if not self._rxadc:
             raise Exception("Cannot find device axi-ad9083-rx-hpc")
 
+        self._rx_channel_names = []
         for ch in self._rxadc.channels:
             if ch.scan_element and not ch.output:
                 self._rx_channel_names.append(ch._id)

--- a/adi/ad9172.py
+++ b/adi/ad9172.py
@@ -25,6 +25,7 @@ class ad9172(tx, context_manager, sync_start):
         if not self._txdac:
             raise RuntimeError("Could not find axi-ad9172-hpc")
 
+        self._tx_channel_names = []
         for chan in self._txdac.channels:
             if (
                 hasattr(chan, "scan_element")

--- a/adi/adaq8092.py
+++ b/adi/adaq8092.py
@@ -12,6 +12,8 @@ class adaq8092(rx, context_manager):
     """ADAQ8092 14-Bit, 105MSPS, Dual-Channel uModule Data Acquisition Solution"""
 
     _device_name = "adaq8092"
+    _rx_stack_interleaved = True
+    _rx_data_type = np.int16
 
     def __init__(
         self, uri="",
@@ -27,8 +29,7 @@ class adaq8092(rx, context_manager):
             self._rxadc = self._ctx.find_device("cf_axi_adc")
             self._device_name = "cf_axi_adc"
 
-        rx._rx_stack_interleaved = True
-        rx._rx_data_type = np.int16
+        self._rx_channel_names = []
         for ch in self._rxadc.channels:
             name = ch._id
             self._rx_channel_names.append(name)

--- a/adi/adpd1080.py
+++ b/adi/adpd1080.py
@@ -34,7 +34,8 @@ class adpd1080(rx, context_manager):
 
         # dynamically get channels and sorting them after the color
         # self._ctrl.channels.sort(key=lambda x: str(x.id[14:]))
-
+        self._rx_channel_names = []
+        self.channel = []
         for ch in self._ctrl._channels:
             name = ch._id
             self._rx_channel_names.append(name)

--- a/adi/adpd188.py
+++ b/adi/adpd188.py
@@ -35,7 +35,8 @@ class adpd188(rx, context_manager):
 
         # dynamically get channels and sorting them after the color
         # self._ctrl.channels.sort(key=lambda x: str(x.id[14:]))
-
+        self._rx_channel_names = []
+        self.channel = []
         for ch in self._ctrl._channels:
             name = ch._id
             self._rx_channel_names.append(name)

--- a/adi/adpd410x.py
+++ b/adi/adpd410x.py
@@ -30,6 +30,7 @@ class adpd410x(rx, context_manager):
 
         self._rxadc = self._ctx.find_device("adpd410x")
 
+        self.channel = []
         for name in self._rx_channel_names:
             self.channel.append(self._channel(self._rxadc, name))
 

--- a/adi/ltc2499.py
+++ b/adi/ltc2499.py
@@ -24,6 +24,7 @@ class ltc2499(rx, context_manager):
             raise Exception("No device found")
 
         _channels = []
+        self._rx_channel_names = []
         for ch in self._ctrl.channels:
             self._rx_channel_names.append(ch.id)
             _channels.append((ch.id, self._channel(self._ctrl, ch.id)))

--- a/adi/ltc2983.py
+++ b/adi/ltc2983.py
@@ -27,6 +27,7 @@ class ltc2983(rx, context_manager):
 
         # dynamically get channels
         _channels = []
+        self._rx_channel_names = []
         for ch in self._ctrl.channels:
             self._rx_channel_names.append(ch.id)
             _channels.append((ch.id, self._channel(self._ctrl, ch.id)))

--- a/adi/max11205.py
+++ b/adi/max11205.py
@@ -47,6 +47,8 @@ class max11205(rx, context_manager):
         if not self._rxadc:
             raise Exception("Error in selecting matching device")
 
+        self._rx_channel_names = []
+        self.channel = []
         for ch in self._ctrl.channels:
             name = ch._id
             self._rx_channel_names.append(name)

--- a/adi/max14001.py
+++ b/adi/max14001.py
@@ -47,6 +47,8 @@ class max14001(rx, context_manager):
         if not self._rxadc:
             raise Exception("Error in selecting matching device")
 
+        self._rx_channel_names = []
+        self.channel = []
         for ch in self._ctrl.channels:
             name = ch._id
             self._rx_channel_names.append(name)

--- a/adi/max9611.py
+++ b/adi/max9611.py
@@ -39,6 +39,7 @@ class max9611(rx, context_manager):
             raise Exception("Error in selecting matching device")
 
         # Dynamically get channels after the index
+        self._rx_channel_names = []
         for ch in self._ctrl.channels:
             name = ch._id
 


### PR DESCRIPTION
A large set of classes were not reseting their channel names during their init. This will create undesired behavior since _rx/tx_channel_names are class properties and shared across all instances
