### PR TITLE
Update ad7768/ad7768-4 tests

### DIFF
--- a/test/dma_tests.py
+++ b/test/dma_tests.py
@@ -17,7 +17,13 @@ except:
 
 
 def dma_rx(
-    uri, classname, channel, use_rx2=False, buffer_size=2 ** 15, annotated=False, param_set=None
+    uri,
+    classname,
+    channel,
+    use_rx2=False,
+    buffer_size=2 ** 15,
+    annotated=False,
+    param_set=None,
 ):
     """dma_rx: Construct RX buffers and verify data is non-zero when pulled.
     Collected buffer is of size 2**15 and 10 buffers are checked

--- a/test/dma_tests.py
+++ b/test/dma_tests.py
@@ -17,7 +17,7 @@ except:
 
 
 def dma_rx(
-    uri, classname, channel, use_rx2=False, buffer_size=2 ** 15, annotated=False
+    uri, classname, channel, use_rx2=False, buffer_size=2 ** 15, annotated=False, param_set=None
 ):
     """dma_rx: Construct RX buffers and verify data is non-zero when pulled.
     Collected buffer is of size 2**15 and 10 buffers are checked
@@ -36,8 +36,15 @@ def dma_rx(
             Size of RX buffer in samples. Defaults to 2**15
         annotated: type=bool
             If True, annotated output is provided (dict)
+        param_set: type=dict
+            Dictionary of attribute and values to be set before tone is
+            received
     """
     sdr = eval(classname + "(uri='" + uri + "')")
+    # Set custom device parameters
+    if param_set:
+        for p in param_set.keys():
+            setattr(sdr, p, param_set[p])
     N = buffer_size
 
     if use_rx2:

--- a/test/test_ad7768.py
+++ b/test/test_ad7768.py
@@ -4,14 +4,6 @@ hardware = ["ad7768"]
 classname = "adi.ad7768"
 
 #########################################
-@pytest.mark.iio_hardware(hardware, True)
-@pytest.mark.parametrize("classname", [(classname)])
-@pytest.mark.parametrize("channel", [0, 1, 2, 3, 4, 5, 6, 7])
-def test_ad7768_rx_data(test_dma_rx, iio_uri, classname, channel):
-    test_dma_rx(iio_uri, classname, channel)
-
-
-#########################################
 @pytest.mark.iio_hardware(hardware)
 @pytest.mark.parametrize("classname", [(classname)])
 @pytest.mark.parametrize(
@@ -20,9 +12,6 @@ def test_ad7768_rx_data(test_dma_rx, iio_uri, classname, channel):
         (
             "sampling_frequency",
             [
-                1000,
-                2000,
-                4000,
                 8000,
                 16000,
                 32000,
@@ -33,8 +22,19 @@ def test_ad7768_rx_data(test_dma_rx, iio_uri, classname, channel):
             ],  # End on a rate compatible with all power modes
         ),
         ("filter_type", ["WIDEBAND", "SINC5"],),
-        ("power_mode", ["MEDIAN_MODE", "FAST_MODE"],),
+        ("power_mode", ["LOW_POWER_MODE", "MEDIAN_MODE", "FAST_MODE"],),
     ],
 )
-def test_ad4630_attr(test_attribute_multiple_values, iio_uri, classname, attr, val):
+def test_ad7768_attr(test_attribute_multiple_values, iio_uri, classname, attr, val):
     test_attribute_multiple_values(iio_uri, classname, attr, val, 0)
+
+
+#########################################
+@pytest.mark.iio_hardware(hardware, True)
+@pytest.mark.parametrize("classname", [(classname)])
+@pytest.mark.parametrize("channel", [0, 1, 2, 3, 4, 5, 6, 7])
+@pytest.mark.parametrize(
+    "param_set", [dict(filter_type="SINC5"), dict(filter_type="WIDEBAND")]
+)
+def test_ad7768_rx_data(test_dma_rx, iio_uri, classname, channel, param_set):
+    test_dma_rx(iio_uri, classname, channel, param_set=param_set)

--- a/test/test_ad7768_4.py
+++ b/test/test_ad7768_4.py
@@ -4,14 +4,6 @@ hardware = ["ad7768-4"]
 classname = "adi.ad7768_4"
 
 #########################################
-@pytest.mark.iio_hardware(hardware, True)
-@pytest.mark.parametrize("classname", [(classname)])
-@pytest.mark.parametrize("channel", [0, 1, 2, 3])
-def test_ad7768_4_rx_data(test_dma_rx, iio_uri, classname, channel):
-    test_dma_rx(iio_uri, classname, channel)
-
-
-#########################################
 @pytest.mark.iio_hardware(hardware)
 @pytest.mark.parametrize("classname", [(classname)])
 @pytest.mark.parametrize(
@@ -20,9 +12,6 @@ def test_ad7768_4_rx_data(test_dma_rx, iio_uri, classname, channel):
         (
             "sampling_frequency",
             [
-                1000,
-                2000,
-                4000,
                 8000,
                 16000,
                 32000,
@@ -33,9 +22,20 @@ def test_ad7768_4_rx_data(test_dma_rx, iio_uri, classname, channel):
             ],  # End on a rate compatible with all power modes
         ),
         ("filter_type", ["WIDEBAND", "SINC5"],),
-        ("power_mode", ["MEDIAN_MODE", "FAST_MODE"],),
+        ("power_mode", ["LOW_POWER_MODE", "MEDIAN_MODE", "FAST_MODE"],),
         ("sync_start_enable", ["arm"],),
     ],
 )
 def test_ad7768_4_attr(test_attribute_multiple_values, iio_uri, classname, attr, val):
     test_attribute_multiple_values(iio_uri, classname, attr, val, 0)
+
+
+#########################################
+@pytest.mark.iio_hardware(hardware, True)
+@pytest.mark.parametrize("classname", [(classname)])
+@pytest.mark.parametrize("channel", [0, 1, 2, 3])
+@pytest.mark.parametrize(
+    "param_set", [dict(filter_type="SINC5"), dict(filter_type="WIDEBAND")]
+)
+def test_ad7768_4_rx_data(test_dma_rx, iio_uri, classname, channel, param_set):
+    test_dma_rx(iio_uri, classname, channel, param_set=param_set)


### PR DESCRIPTION
# Description

This PR includes changes on ad7768 and ad7768-4 tests which enables setting the filter_type first before testing the rx buffer. With that, a change in dma_rx test was introduced, adding param_set to enable setting of attributes firsts before getting data from buffer. If param_set is not passed, it will still work the usual.
For ad7768/ad7768-4, this test ensures that for both filter types the buffer is still working.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested on zed-ad7768
- [x] Tested on zed-ad7768-4

# Documentation

If this is a new feature or example please mention or link any documentation. All new hardware interface classes require documentation.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
