### PR TITLE
cn0532.py: clean up for flake8 whitespace check

### DIFF
--- a/adi/cn0532.py
+++ b/adi/cn0532.py
@@ -34,7 +34,7 @@ class cn0532(cn0540):
             if int(dac_voltage) > 2 ** 16 - 1:
                 print(
                     "Warning: DAC voltage at upper limit, "
-                    + f"calibration may not converge (Error: {e-(2**16-1)} codes).\n"
+                    + f"calibration may not converge (Error: {e - (2**16 - 1)} codes).\n"
                     + "Make sure sensor is connected."
                 )
                 dac_voltage = 2 ** 16 - 1


### PR DESCRIPTION
Add whitespace around arithmetic operators so that the cn0532 module doesn't trigger flake8 failures on other runs.

# Description

Tiny cleanup by adding whitespace around arithmetic operators in cn0532.py. The flake8 check in pre-commit was reporting an issue here while I was working on #524 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Re-ran `pre-commit run --all-files` after the change to make sure the test passed.

**Test Configuration**:

* OS: Fedora 39, Python 3.12, virtualenv with pyadi-iio requirements from requirements_prod_test.txt installed.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
