### PR TITLE
test: ad9081: Scale channel param

### DIFF
--- a/test/test_ad9081.py
+++ b/test/test_ad9081.py
@@ -7,6 +7,16 @@ hardware = ["ad9081", "ad9081_tdd"]
 classname = "adi.ad9081"
 
 
+def is_channel(channel, iio_uri):
+    import adi
+
+    dev = adi.ad9081(uri=iio_uri)
+    channels = list(
+        set([int("".join(filter(str.isdigit, s))) for s in dev._tx_channel_names])
+    )
+    return channel in channels
+
+
 def scale_field(param_set, iio_uri):
     # Scale fields to match number of channels
     import adi
@@ -97,6 +107,8 @@ def test_ad9081_attr(
 @pytest.mark.parametrize("classname", [(classname)])
 @pytest.mark.parametrize("channel", [0, 1, 2, 3])
 def test_ad9081_rx_data(test_dma_rx, iio_uri, classname, channel):
+    if not is_channel(channel, iio_uri):
+        pytest.skip("Skipping test: Channel " + str(channel) + "not available.")
     test_dma_rx(iio_uri, classname, channel)
 
 
@@ -105,6 +117,8 @@ def test_ad9081_rx_data(test_dma_rx, iio_uri, classname, channel):
 @pytest.mark.parametrize("classname", [(classname)])
 @pytest.mark.parametrize("channel", [0, 1, 2, 3])
 def test_ad9081_tx_data(test_dma_tx, iio_uri, classname, channel):
+    if not is_channel(channel, iio_uri):
+        pytest.skip("Skipping test: Channel " + str(channel) + "not available.")
     test_dma_tx(iio_uri, classname, channel)
 
 
@@ -135,6 +149,8 @@ def test_ad9081_tx_data(test_dma_tx, iio_uri, classname, channel):
 def test_ad9081_cyclic_buffers(
     test_cyclic_buffer, iio_uri, classname, channel, param_set
 ):
+    if not is_channel(channel, iio_uri):
+        pytest.skip("Skipping test: Channel " + str(channel) + "not available.")
     param_set = scale_field(param_set, iio_uri)
     test_cyclic_buffer(iio_uri, classname, channel, param_set)
 
@@ -164,6 +180,8 @@ def test_ad9081_cyclic_buffers(
 def test_ad9081_cyclic_buffers_exception(
     test_cyclic_buffer_exception, iio_uri, classname, channel, param_set
 ):
+    if not is_channel(channel, iio_uri):
+        pytest.skip("Skipping test: Channel " + str(channel) + "not available.")
     param_set = scale_field(param_set, iio_uri)
     test_cyclic_buffer_exception(iio_uri, classname, channel, param_set)
 


### PR DESCRIPTION
# Description

AD9081 tests started to fail recently across all variants on zcu102. They channel parameter does not get scaled according to the available channels. The issue was handled by checking for tx channel names and getting the channel index from the list, even if the test should check for rx channels.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?
**Test Configuration**:
* Hardware: zcu102-ad9081, all variants
* OS: Tests were run on Windows