### PR TITLE
Fix tx_enabled_channel condition order

### DIFF
--- a/adi/rx_tx.py
+++ b/adi/rx_tx.py
@@ -381,15 +381,6 @@ class tx_core(dds, rx_tx_common, metaclass=ABCMeta):
             Data must be complex when using a complex data device.
         """
 
-        if not self._tx_data_type:
-            # Find channel data format
-            chan_name = self._tx_channel_names[self.tx_enabled_channels[0]]
-            chan = self._txdac.find_channel(chan_name, True)
-            df = chan.data_format
-            fmt = ("i" if df.is_signed is True else "u") + str(df.length // 8)
-            fmt = ">" + fmt if df.is_be else fmt
-            self._tx_data_type = np.dtype(fmt)
-
         if not self.__tx_enabled_channels and data_np:
             raise Exception(
                 "When tx_enabled_channels is None or empty,"
@@ -402,6 +393,15 @@ class tx_core(dds, rx_tx_common, metaclass=ABCMeta):
                     chan.attrs["raw"].value = "0"
                     return
             raise Exception("No DDS channels found for TX, TX zeroing does not apply")
+
+        if not self._tx_data_type:
+            # Find channel data format
+            chan_name = self._tx_channel_names[self.tx_enabled_channels[0]]
+            chan = self._txdac.find_channel(chan_name, True)
+            df = chan.data_format
+            fmt = ("i" if df.is_signed is True else "u") + str(df.length // 8)
+            fmt = ">" + fmt if df.is_be else fmt
+            self._tx_data_type = np.dtype(fmt)
 
         if self._txbuf and self.tx_cyclic_buffer:
             raise Exception(


### PR DESCRIPTION
# Description

This PR includes a change in rx_tx class in tx() method which interchanges if conditions for tx_enabled_channels and tx_data_type to check if there are tx_enabled_channels before accessing them. The fix was found due to a failed test in test_pluto_p.py, which is the test_loopback_zeros or dma_dac_zeros in dma_tests. The issue is caused by tx_enabled_channels being accessed in tx() method while it is set to None.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Hardware: ADALM-Pluto
* OS: Windows

# Documentation

If this is a new feature or example please mention or link any documentation. All new hardware interface classes require documentation.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
