### PR TITLE
AD7124 fix

### DIFF
--- a/adi/ad7124.py
+++ b/adi/ad7124.py
@@ -36,7 +36,7 @@ class ad7124(rx, context_manager):
                 else:
                     index += 1
 
-        self._rx_channel_names = [chan.name for chan in self._ctrl.channels]
+        self._rx_channel_names = [chan.id for chan in self._ctrl.channels]
         if "-" in self._rx_channel_names[0]:
             self._rx_channel_names.sort(key=lambda x: int(x[7:].split("-")[0]))
         else:

--- a/examples/ad7124.py
+++ b/examples/ad7124.py
@@ -2,25 +2,56 @@
 #
 # SPDX short identifier: ADIBSD
 
+import argparse
+
 import adi
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal
 
 # Set up AD7124
-ad7124 = adi.ad7124(uri="ip:10.48.65.138")
-ad_channel = 0
+# Optionally pass URI as command line argument with -u option,
+# else use default to "ip:analog.local"
+parser = argparse.ArgumentParser(description="AD7124 Example Script")
+parser.add_argument(
+    "-u",
+    default=["ip:analog.local"],
+    help="-u (arg) URI of target device's context, eg: 'ip:analog.local',\
+    'ip:192.168.2.1',\
+    'serial:COM4,115200,8n1n'",
+    action="store",
+    nargs="*",
+)
+args = parser.parse_args()
+my_uri = args.u[0]
+
+print("uri: " + str(my_uri))
+
+ad7124 = adi.ad7124(uri=my_uri)
+ad_channel0 = 0  # voltage0-voltage1 plug to CH1 on my m2k
+ad_channel1 = 1  # voltage2-voltage3 plug to CH2 on my m2k
 
 sc = ad7124.scale_available
 
-ad7124.channel[ad_channel].scale = sc[-1]  # get highest range
+ad7124.channel[ad_channel0].scale = sc[-1]  # get highest range
+ad7124.channel[ad_channel1].scale = sc[-1]  # get highest range
 ad7124.rx_output_type = "SI"
 # sets sample rate for all channels
 ad7124.sample_rate = 19200
-ad7124.rx_enabled_channels = [ad_channel]
+ad7124.rx_enabled_channels = [ad_channel0, ad_channel1]
 ad7124.rx_buffer_size = 100
+ad7124._ctx.set_timeout(100000)
 
-raw = ad7124.channel[0].raw
 data = ad7124.rx()
 
 print(data)
+
+plt.figure(1)
+plt.title(f"{ad7124._ctrl.name} @{ad7124.sample_rate}sps")
+plt.ylabel("Volts")
+plt.xlabel("Sample Number")
+plt.plot(data[0], label=ad7124.channel[ad_channel0].name, color="orange", linewidth=2)
+plt.plot(data[1], label=ad7124.channel[ad_channel1].name, color="blue", linewidth=2)
+plt.show()
+
+del ad7124


### PR DESCRIPTION
# Description

This PR includes fix of the ad7124 class. When using .name, it cannot list the channels thus changing to .id in getting the channels. Also updated the example.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested on actual hardware AD7124 on RPI4.

# Documentation

If this is a new feature or example please mention or link any documentation. All new hardware interface classes require documentation.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
