### PR TITLE
Fix typo: Missing comma skipping tests for 204b variant

### DIFF
--- a/test/test_map.py
+++ b/test/test_map.py
@@ -171,7 +171,7 @@ def get_test_map():
         "socfpga-arria10-socdk-ad9081-np12",
         "versal-vck190-reva-ad9081",
         "zynq-zc706-adv7511-ad9081",
-        "zynq-zc706-adv7511-ad9081-np12"
+        "zynq-zc706-adv7511-ad9081-np12",
         "zynqmp-zcu102-rev10-ad9081-204b-txmode9-rxmode4",
         "zynqmp-zcu102-rev10-ad9081-204c-txmode0-rxmode1",
         "zynqmp-zcu102-rev10-ad9081-m8-l4",


### PR DESCRIPTION
Fixes # (issue)
zcu102-ad9081-204b-txmode9-rxmode4 skips all tests because of the missing typo in test_map.py

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested using the same environment as test harness pipelines.