### PR TITLE
Ad9081 test fixes

### DIFF
--- a/adi/ad9081.py
+++ b/adi/ad9081.py
@@ -138,13 +138,13 @@ class ad9081(rx_tx, context_manager, sync_start):
         # This is overridden by subclasses
         return self._set_iio_attr(channel_name, attr, output, value)
 
-    def _get_iio_attr_single(self, channel_name, attr, output):
+    def _get_iio_attr_single(self, channel_name, attr, output, _ctrl=None):
         # This is overridden by subclasses
-        return self._get_iio_attr(channel_name, attr, output)
+        return self._get_iio_attr(channel_name, attr, output, _ctrl)
 
-    def _set_iio_attr_single(self, channel_name, attr, output, value):
+    def _set_iio_attr_single(self, channel_name, attr, output, value, _ctrl=None):
         # This is overridden by subclasses
-        return self._set_iio_attr(channel_name, attr, output, value)
+        return self._set_iio_attr(channel_name, attr, output, value, _ctrl)
 
     def _get_iio_dev_attr_single(self, attr):
         # This is overridden by subclasses
@@ -627,7 +627,9 @@ class ad9081(rx_tx, context_manager, sync_start):
     @property
     def tx_sample_rate(self):
         """tx_sampling_frequency: Sample rate before interpolation"""
-        return self._get_iio_attr_single("voltage0_i", "sampling_frequency", True)
+        return self._get_iio_attr_single(
+            "voltage0_i", "sampling_frequency", True, self._txdac
+        )
 
     @property
     def dac_frequency(self):

--- a/test/attr_tests.py
+++ b/test/attr_tests.py
@@ -221,6 +221,44 @@ def attribute_multiple_values(
                 assert dev_interface(uri, classname, val, attr, tol, sleep=sleep)
 
 
+def attribute_multiple_values_error(
+    uri, classname, attr, values, tol, repeats=1, sleep=0, sub_channel=None
+):
+    """attribute_multiple_values_error: Write multiple class properties
+    in a loop where all values are pre-defined and expected to raise an error.
+    This is performed a defined number of times.
+
+    parameters:
+        uri: type=string
+            URI of IIO context of target board/system
+        classname: type=string
+            Name of pyadi interface class which contain attribute
+        attr: type=string
+            Attribute name to be written. Must be property of classname
+        values: type=list
+            A list of values to write and check as attributes
+        tol: type=integer
+            Allowable error of written value compared to read back value
+        repeats: type=integer
+            Number of times to repeatedly write values
+        sleep: type=integer
+            Seconds to sleep between writing to attribute and reading it back
+        sub_channel: type=string
+            Name of sub channel (nested class) to be tested
+    """
+    with pytest.raises(Exception) as e_info:
+        for _ in range(repeats):
+            for val in values:
+                if isinstance(val, str):
+                    tol = 0
+                if sub_channel:
+                    assert dev_interface_sub_channel(
+                        uri, classname, sub_channel, val, attr, tol, sleep=sleep
+                    )
+                else:
+                    assert dev_interface(uri, classname, val, attr, tol, sleep=sleep)
+
+
 def attribute_multiple_values_with_depends(
     uri, classname, attr, depends, values, tol, repeats=1
 ):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -160,6 +160,11 @@ def test_attribute_multiple_values(request):
 
 
 @pytest.fixture()
+def test_attribute_multiple_values_error(request):
+    yield attribute_multiple_values_error
+
+
+@pytest.fixture()
 def test_attribute_multiple_values_with_depends(request):
     yield attribute_multiple_values_with_depends
 

--- a/test/dma_tests.py
+++ b/test/dma_tests.py
@@ -595,10 +595,14 @@ def cw_loopback(uri, classname, channel, param_set, use_tx2=False, use_rx2=False
         RXFS = int(getattr(sdr, attr))
 
     A = 2 ** 15
-    fc = RXFS * 0.1
-    fc = int(fc / (RXFS / N)) * (RXFS / N)
+    if hasattr(sdr, "tx_sample_rate"):
+        FS = int(sdr.tx_sample_rate)
+    else:
+        FS = RXFS
+    fc = FS * 0.1
+    fc = int(fc / (FS / N)) * (FS / N)
 
-    ts = 1 / float(RXFS)
+    ts = 1 / float(FS)
     t = np.arange(0, N * ts, ts)
     if sdr._complex_data:
         i = np.cos(2 * np.pi * t * fc) * A * 0.5
@@ -692,10 +696,14 @@ def t_sfdr(uri, classname, channel, param_set, sfdr_min, use_obs=False, full_sca
     else:
         RXFS = int(sdr.rx_sample_rate)
 
-    fc = RXFS * 0.1
-    fc = int(fc / (RXFS / N)) * (RXFS / N)
+    if hasattr(sdr, "tx_sample_rate"):
+        FS = int(sdr.tx_sample_rate)
+    else:
+        FS = RXFS
 
-    ts = 1 / float(RXFS)
+    fc = FS * 0.1
+    fc = int(fc / (FS / N)) * (FS / N)
+    ts = 1 / float(FS)
     t = np.arange(0, N * ts, ts)
     i = np.cos(2 * np.pi * t * fc) * 2 ** 15 * full_scale
     q = np.sin(2 * np.pi * t * fc) * 2 ** 15 * full_scale
@@ -710,7 +718,7 @@ def t_sfdr(uri, classname, channel, param_set, sfdr_min, use_obs=False, full_sca
         del sdr
         raise Exception(e)
     del sdr
-    val, amp, freqs = spec.sfdr(data, plot=False)
+    val, amp, freqs = spec.sfdr(data, fs=RXFS, plot=False)
     if do_html_log:
         pytest.data_log = {
             "html": gen_line_plot_html(

--- a/test/rf/spec.py
+++ b/test/rf/spec.py
@@ -23,7 +23,7 @@ def spec_est(x, fs, ref=2 ** 15, plot=False):
     N = len(x)
 
     # Apply window
-    window = signal.kaiser(N, beta=38)
+    window = signal.windows.kaiser(N, beta=8.6)
     # x = multiply(x, window)
 
     # Use FFT to get the amplitude of the spectrum
@@ -147,10 +147,6 @@ def sfdr(x, fs=1, ref=2 ** 15, plot=False):
     main = peak_vals[0]
     next = peak_vals[1]
     sfdr = absolute(main - next)
-
-    print(main)
-    print(next)
-    print(sfdr)
 
     if plot:
         import matplotlib.pyplot as plt

--- a/test/rf/spec.py
+++ b/test/rf/spec.py
@@ -148,6 +148,10 @@ def sfdr(x, fs=1, ref=2 ** 15, plot=False):
     next = peak_vals[1]
     sfdr = absolute(main - next)
 
+    print(main)
+    print(next)
+    print(sfdr)
+
     if plot:
         import matplotlib.pyplot as plt
 

--- a/test/test_ad9081.py
+++ b/test/test_ad9081.py
@@ -36,7 +36,7 @@ def scale_field(param_set, iio_uri):
     "attr, val",
     [
         ("rx_nyquist_zone", ["even", "odd"]),
-        ("loopback_mode", [2, 1, 0]),
+        ("loopback_mode", [0]),
         (
             "rx_test_mode",
             [
@@ -63,6 +63,16 @@ def scale_field(param_set, iio_uri):
 )
 def test_ad9081_str_attr(test_attribute_multiple_values, iio_uri, classname, attr, val):
     test_attribute_multiple_values(iio_uri, classname, attr, val, 0)
+
+
+#########################################
+@pytest.mark.iio_hardware(hardware, True)
+@pytest.mark.parametrize("classname", [(classname)])
+@pytest.mark.parametrize("attr, val", [("loopback_mode", [2, 1])])
+def test_ad9081_str_attr_err(
+    test_attribute_multiple_values_error, iio_uri, classname, attr, val
+):
+    test_attribute_multiple_values_error(iio_uri, classname, attr, val, 0)
 
 
 #########################################


### PR DESCRIPTION
Fixes

test/test_ad9081.py::test_ad9081_iq_loopback fails for variants with different sampling_frequency between rx and tx device. With these modifications, the estimated frequency at rx is within tolerance, although some tests still fail because of peak value assertions.

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Ran tests on all variants on zcu102

**Test Configuration**:
* Hardware:
* OS:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
