### PR TITLE
Fix cn0579 test

### DIFF
--- a/test/test_cn0579.py
+++ b/test/test_cn0579.py
@@ -20,9 +20,6 @@ def test_cn0579_rx_data(test_dma_rx, iio_uri, classname, channel):
         (
             "sampling_frequency",
             [
-                1000,
-                2000,
-                4000,
                 8000,
                 16000,
                 32000,


### PR DESCRIPTION
# Description

This change modifies the available sampling frequency being set by removing some values that are not being displayed in cn0579 iio_info. The fix was done due to the ValueError caused by setting sampling frequencies which are not supported.  

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Hardware:
* OS:

# Documentation

If this is a new feature or example please mention or link any documentation. All new hardware interface classes require documentation.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
