### PR TITLE
ad7606 tweaks and updates

### DIFF
--- a/adi/ad7606.py
+++ b/adi/ad7606.py
@@ -71,16 +71,16 @@ class ad7606(rx, context_manager):
     @property
     def oversampling_ratio(self):
         """AD7606 oversampling_ratio"""
-        return self._get_iio_attr(self.name, "oversampling_ratio", False)
+        return self._get_iio_dev_attr("oversampling_ratio")
 
     @oversampling_ratio.setter
     def oversampling_ratio(self, value):
-        self._get_iio_attr(self.name, "oversampling_ratio", False, value)
+        self._set_iio_dev_attr("oversampling_ratio", value)
 
     @property
     def oversampling_ratio_available(self):
         """AD7606 channel oversampling_ratio_available"""
-        return self._get_iio_attr(self.name, "oversampling_ratio_available", False)
+        return self._get_iio_dev_attr("oversampling_ratio_available")
 
     class _channel(attribute):
         """AD7606 channel"""

--- a/adi/ad7606.py
+++ b/adi/ad7606.py
@@ -55,6 +55,8 @@ class ad7606(rx, context_manager):
         self.channel = []
         for ch in self._ctrl.channels:
             name = ch._id
+            if name == "timestamp":
+                continue
             self._rx_channel_names.append(name)
             self.channel.append(self._channel(self, name))
 

--- a/adi/ad7606.py
+++ b/adi/ad7606.py
@@ -64,11 +64,6 @@ class ad7606(rx, context_manager):
         return self._get_iio_attr(self.channel[0].name, "scale_available", False)
 
     @property
-    def range_available(self):
-        """Provides all available range settings for the AD7606 channels"""
-        return self._get_iio_attr(self.channel[0].name, "range_available", False)
-
-    @property
     def oversampling_ratio(self):
         """AD7606 oversampling_ratio"""
         return self._get_iio_dev_attr("oversampling_ratio")
@@ -102,15 +97,6 @@ class ad7606(rx, context_manager):
         @scale.setter
         def scale(self, value):
             self._set_iio_attr(self.name, "scale", False, str(Decimal(value).real))
-
-        @property
-        def range(self):
-            """AD7606 channel range"""
-            return self._get_iio_attr(self.name, "range", False)
-
-        @range.setter
-        def range(self, value):
-            self._set_iio_attr(self.name, "range", False, str(Decimal(value).real))
 
     def to_volts(self, index, val):
         """Converts raw value to SI"""

--- a/adi/ad7606.py
+++ b/adi/ad7606.py
@@ -130,6 +130,12 @@ class ad7606(rx, context_manager):
         """Converts raw value to SI"""
         _scale = self.channel[index].scale
 
+        if isinstance(val, int):
+            return val * _scale
+
+        if isinstance(val, list):
+            return [x * _scale for x in val]
+
         # ADC7606C-18 will return int32 samples from the driver
         if isinstance(val, np.int32):
             return val * _scale

--- a/adi/ad7606.py
+++ b/adi/ad7606.py
@@ -128,12 +128,12 @@ class ad7606(rx, context_manager):
         """Converts raw value to SI"""
         _scale = self.channel[index].scale
 
-        ret = None
+        # ADC7606C-18 will return int32 samples from the driver
+        if isinstance(val, np.int32):
+            return val * _scale
 
         if isinstance(val, np.int16):
-            ret = val * _scale
+            return val * _scale
 
         if isinstance(val, np.ndarray):
-            ret = [x * _scale for x in val]
-
-        return ret
+            return [x * _scale for x in val]

--- a/adi/ad7606.py
+++ b/adi/ad7606.py
@@ -21,6 +21,8 @@ class ad7606(rx, context_manager):
 
     def __init__(self, uri="", device_name=""):
 
+        self._device_name = device_name
+
         context_manager.__init__(self, uri, self._device_name)
 
         compatible_parts = [


### PR DESCRIPTION
# Description

This changeset mostly targets support for the AD7606C-18 and AD7606C-16 parts.

The upstream support for these parts is pending here:

https://lore.kernel.org/linux-iio/20240819064721.91494-1-aardelean@baylibre.com/T/#t

But there were a couple of fixes required for existing parts.

For one thing the oversampling attributes need to be made device-level attributes.

There are no 'range' attributes. These are scale attributes.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Tested with a ZedBoard and an AD7606C-18 FMC board.
The HDL is a simplified version that uses the Zynq PS SPI controller, which kind of like using the AD7606 part directly connected to a simple RPi board; no fancy communication.

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Hardware: ZedBoard + AD7606C-18
* OS: Kuiper Linux + upstream IIO kernel + AD7606C-18/16 changes

# Documentation

If this is a new feature or example please mention or link any documentation. All new hardware interface classes require documentation.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
