### PR TITLE
.github: Add destination depth to doc build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,6 +141,7 @@ jobs:
 
       - name: Build doc and release
         run: |
+          export ADOC_TARGET_DEPTH=1
           cd doc && make html
           cd ..
 
@@ -174,6 +175,7 @@ jobs:
         run: |
           export GIT_BRANCH=${{ github.head_ref }}
           export DEV_BUILD=1
+          export ADOC_TARGET_DEPTH=2
           cd doc && make html
           cd ..
 


### PR DESCRIPTION
This repo stores different versions of the doc into multiple directories of the gh-pages branch.
Due to this, links requiring to reach the website root (not the content root of the doc itself), are broken if the deploy directory is different than `./` (e.g. `./main`, `./prs/1234`)

To resolve this issue, the ADOC_TARGET_DEPTH  env variable was implemented https://github.com/analogdevicesinc/doctools/commit/1da4cf161e515f1bd17aa102dbc25e42089f654a to allow tuning the depth before the doc build. 

Example of ADOC_TARGET_DEPTH values:

* ./         : ../       (0 or unset)
* ./main/    : ../../    (1)
* ./prs/1234 : ../../../ (2)

On Doctools I also added [a snipped to generate a JSON with the tags/branches/prs of the build docs](https://github.com/analogdevicesinc/doctools/blob/main/.github/workflows/deploy.yml#L172-L178), but since this repo uses peaceiris/actions-gh-pages@v3 action to commit and push to gh-pages, I didn't implement it here.
However, this tags.json file would be nice to create a dropdown to switch between versions on the live doc.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

This feature was tested on the Doctools repo itself, with different builds linking properly:
https://analogdevicesinc.github.io/doctools/
https://analogdevicesinc.github.io/doctools/v0.3.38/

Then I tested different values of ADOC_TARGET_DEPTH  while building this repo doc locally.
# Documentation

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
