### PR TITLE
URL fix in pyproject.toml metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ jesd = [
 [project.urls]
 homepage = "https://analogdevicesinc.github.io/pyadi-iio/"
 documentation = "https://analogdevicesinc.github.io/pyadi-iio/"
-repository = "https://github/analogdevicesinc/pyadi-iio"
+repository = "https://github.com/analogdevicesinc/pyadi-iio"
 
 [tool.isort]
 multi_line_output=3


### PR DESCRIPTION
# Description

Fixed typo in GitHub URL which causes broken links on PyPI, etc.

## Type of change

- [ Y ] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

URL now takes you to this repo.

# Documentation

Not applicable.

# Checklist:

- [ NA ] My code follows the style guidelines of this project
- [ NA ] I have performed a self-review of my own code
- [ NA ] I have commented my code, particularly in hard-to-understand areas
- [ Y ] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ NA ] I have made corresponding changes to the documentation
- [ NA ] My changes generate no new warnings
- [ NA ] I have added tests that prove my fix is effective or that my feature works
- [ NA ] New and existing unit tests pass locally with my changes
- [ NA ] Any dependent changes have been merged and published in downstream modules
