### PR TITLE
Class fixes after rc testing

### DIFF
--- a/adi/ad9083.py
+++ b/adi/ad9083.py
@@ -31,7 +31,7 @@ class ad9083(sync_start, rx, context_manager):
                 self._rx_channel_names.append(ch._id)
 
         for name in self._rx_channel_names:
-            if "_i" or "_q" in name:
+            if any(ext in name for ext in ["_i", "_q"]):
                 self._complex_data = True
 
         rx.__init__(self)

--- a/adi/ad9467.py
+++ b/adi/ad9467.py
@@ -11,7 +11,7 @@ class ad9467(rx, context_manager):
     """ AD9467 High-Speed ADC """
 
     _complex_data = False
-    _rx_channel_names = ["voltage0", "voltage1"]
+    _rx_channel_names = ["voltage0"]
     _device_name = ""
 
     def __init__(self, uri=""):


### PR DESCRIPTION
AD9083 tests because of index error. AD9467 only has one channel.

