### PR TITLE
test: modiy daq2/3 assertions based on scale

### DIFF
--- a/test/dma_tests.py
+++ b/test/dma_tests.py
@@ -257,6 +257,7 @@ def dds_loopback(
     peak_min,
     use_obs=False,
     use_rx2=False,
+    useWindow=False,
 ):
     """dds_loopback: Test DDS loopback with connected loopback cables.
     This test requires a devices with TX and RX onboard where the transmit
@@ -321,7 +322,9 @@ def dds_loopback(
         del sdr
         raise Exception(e)
     del sdr
-    tone_peaks, tone_freqs = spec.spec_est(data, fs=RXFS, ref=2 ** 15, plot=False)
+    tone_peaks, tone_freqs = spec.spec_est(
+        data, fs=RXFS, ref=2 ** 15, plot=False, useWindow=useWindow
+    )
     indx = np.argmax(tone_peaks)
     diff = np.abs(tone_freqs[indx] - frequency)
     s = "Peak: " + str(tone_peaks[indx]) + "@" + str(tone_freqs[indx])

--- a/test/rf/spec.py
+++ b/test/rf/spec.py
@@ -18,13 +18,14 @@ from scipy import signal
 from scipy.signal import find_peaks
 
 
-def spec_est(x, fs, ref=2 ** 15, plot=False):
+def spec_est(x, fs, ref=2 ** 15, plot=False, useWindow=False):
 
     N = len(x)
 
     # Apply window
-    window = signal.windows.kaiser(N, beta=8.6)
-    # x = multiply(x, window)
+    if useWindow:
+        window = signal.kaiser(N, beta=8.6)
+        x = multiply(x, window)
 
     # Use FFT to get the amplitude of the spectrum
     ampl = 1 / N * absolute(fft(x))

--- a/test/test_daq2_p.py
+++ b/test/test_daq2_p.py
@@ -26,17 +26,16 @@ def test_daq2_rx_data(test_dma_rx, iio_uri, classname, channel):
 @pytest.mark.parametrize("channel", [0])
 @pytest.mark.parametrize("param_set", [dict()])
 @pytest.mark.parametrize(
-    "frequency, scale",
+    "frequency, scale, peak_min",
     [
-        (5000000, 0.12),
-        (10000000, 0.06),
-        (10000000, 0.12),
-        (15000000, 0.12),
-        (15000000, 0.5),
-        (200000000, 0.5),
+        (5000000, 0.12, -55),
+        (10000000, 0.06, -61),
+        (10000000, 0.12, -55),
+        (15000000, 0.12, -61),
+        (15000000, 0.5, -42),
+        (200000000, 0.5, -42),
     ],
 )
-@pytest.mark.parametrize("peak_min", [-45])
 def test_daq2_dds_loopback(
     test_dds_loopback,
     iio_uri,
@@ -48,7 +47,14 @@ def test_daq2_dds_loopback(
     peak_min,
 ):
     test_dds_loopback(
-        iio_uri, classname, param_set, channel, frequency, scale, peak_min
+        iio_uri,
+        classname,
+        param_set,
+        channel,
+        frequency,
+        scale,
+        peak_min,
+        useWindow=True,
     )
 
 

--- a/test/test_daq3_p.py
+++ b/test/test_daq3_p.py
@@ -26,17 +26,16 @@ def test_daq3_rx_data(test_dma_rx, iio_uri, classname, channel):
 @pytest.mark.parametrize("channel", [0, 1])
 @pytest.mark.parametrize("param_set", [dict()])
 @pytest.mark.parametrize(
-    "frequency, scale",
+    "frequency, scale, peak_min",
     [
-        (5000000, 0.12),
-        (10000000, 0.06),
-        (10000000, 0.12),
-        (15000000, 0.12),
-        (15000000, 0.5),
-        (200000000, 0.5),
+        (5000000, 0.12, -55),
+        (10000000, 0.06, -61),
+        (10000000, 0.12, -55),
+        (15000000, 0.12, -55),
+        (15000000, 0.5, -42),
+        (200000000, 0.5, -42),
     ],
 )
-@pytest.mark.parametrize("peak_min", [-50])
 def test_daq3_dds_loopback(
     test_dds_loopback,
     iio_uri,
@@ -48,7 +47,14 @@ def test_daq3_dds_loopback(
     peak_min,
 ):
     test_dds_loopback(
-        iio_uri, classname, param_set, channel, frequency, scale, peak_min
+        iio_uri,
+        classname,
+        param_set,
+        channel,
+        frequency,
+        scale,
+        peak_min,
+        useWindow=True,
     )
 
 


### PR DESCRIPTION
# Description

daq2/3 consistently fails on at the lowest scale param 0.06. The minimum peak values are empirically set using test harness hardware.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran on hardware

**Test Configuration**:
* Hardware: zcu102-fmcdaq3
* OS: Kuiper

# Documentation

If this is a new feature or example please mention or link any documentation. All new hardware interface classes require documentation.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
