### PR TITLE
ad469x: make compatible with latest driver

### DIFF
--- a/test/test_ad469x.py
+++ b/test/test_ad469x.py
@@ -5,7 +5,8 @@ classname = "adi.ad469x"
 
 
 #########################################
-@pytest.mark.iio_hardware(hardware)
+@pytest.mark.iio_hardware(hardware, True)
 @pytest.mark.parametrize("classname", [(classname)])
+@pytest.mark.parametrize("channel", [["voltage0", "voltage1"]])
 def test_ad469x_rx_data(test_dma_rx, iio_uri, classname, channel):
-    test_dma_rx(iio_uri, classname, channel)
+    test_dma_rx(iio_uri, classname, channel, buffer_size=2 ** 4)


### PR DESCRIPTION
adi/ad469x.py:
- make device setup logic in more similar to other recent part submissions (e.g. ad7944)
- add exception check for self._ctrl
- add sampling frequency, sampling_frequency available properties to channel (assumes ad4695 driver using SPI offload for performance)
- Update docstrings

test/test_ad469x.py:
- update to target channels voltage0 and voltage1, specify buffer size

general:
- run pre-commit for formatting and layout checks

# Description

Update the existing ad469x logic to support the latest upstream driver, now that it has been reworked and will incorporate SPI offload functionality for performance purposes.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Ran the test script against the configuration below.

**Test Configuration**:
* Hardware: Zedboard with EVAL-AD4696FMCZ board
* OS: Kuiper Linux with custom kernel featuring ad4695 driver and SPI offload functionality

# Documentation

No new docs added, but strings in class were updated a bit

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
