### PR TITLE
context_manager.py: Fix error handling for usb

### DIFF
--- a/adi/context_manager.py
+++ b/adi/context_manager.py
@@ -36,3 +36,16 @@ class context_manager(object):
                 self._ctx = iio.Context(self.uri)
         except BaseException:
             raise Exception("No device found")
+
+    def close(self):
+        """Close the IIO context"""
+        if self._ctx:
+            del self._ctx
+            self._ctx = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+        return False

--- a/test/common.py
+++ b/test/common.py
@@ -106,32 +106,30 @@ def pytest_generate_tests(metafunc):
 def dev_interface(
     uri, classname, val, attr, tol, sub_channel=None, sleep=0, readonly=False
 ):
-    sdr = eval(classname + "(uri='" + uri + "')")
-    # Check hardware
-    if not hasattr(sdr, attr):
-        raise AttributeError(attr + " not defined in " + classname)
+    with eval(classname + "(uri='" + uri + "')") as sdr:
+        # Check hardware
+        if not hasattr(sdr, attr):
+            raise AttributeError(attr + " not defined in " + classname)
 
-    rval = getattr(sdr, attr)
-    is_list = isinstance(rval, list)
-    if is_list:
-        l = len(rval)
-        val = [val] * l
+        rval = getattr(sdr, attr)
+        is_list = isinstance(rval, list)
+        if is_list:
+            l = len(rval)
+            val = [val] * l
 
-    setattr(sdr, attr, val)
-    if sleep > 0:
-        time.sleep(sleep)
-    rval = getattr(sdr, attr)
+        setattr(sdr, attr, val)
+        if sleep > 0:
+            time.sleep(sleep)
+        rval = getattr(sdr, attr)
 
-    if not isinstance(rval, str) and not is_list:
-        rval = float(rval)
-        for _ in range(5):
-            setattr(sdr, attr, val)
-            time.sleep(0.3)
-            rval = float(getattr(sdr, attr))
-            if rval == val:
-                break
-
-    del sdr
+        if not isinstance(rval, str) and not is_list:
+            rval = float(rval)
+            for _ in range(5):
+                setattr(sdr, attr, val)
+                time.sleep(0.3)
+                rval = float(getattr(sdr, attr))
+                if rval == val:
+                    break
 
     if is_list and isinstance(rval[0], str):
         return val == rval
@@ -154,26 +152,24 @@ def dev_interface(
 def dev_interface_sub_channel(
     uri, classname, sub_channel, val, attr, tol, readonly=False, sleep=0,
 ):
-    sdr = eval(classname + "(uri='" + uri + "')")
-    # Check hardware
-    if not hasattr(sdr, sub_channel):
-        raise AttributeError(sub_channel + " not defined in " + classname)
-    if not hasattr(getattr(sdr, sub_channel), attr):
-        raise AttributeError(attr + " not defined in " + classname)
+    with eval(classname + "(uri='" + uri + "')") as sdr:
+        # Check hardware
+        if not hasattr(sdr, sub_channel):
+            raise AttributeError(sub_channel + " not defined in " + classname)
+        if not hasattr(getattr(sdr, sub_channel), attr):
+            raise AttributeError(attr + " not defined in " + classname)
 
-    rval = getattr(getattr(sdr, sub_channel), attr)
-    is_list = isinstance(rval, list)
-    if is_list:
-        l = len(rval)
-        val = [val] * l
+        rval = getattr(getattr(sdr, sub_channel), attr)
+        is_list = isinstance(rval, list)
+        if is_list:
+            l = len(rval)
+            val = [val] * l
 
-    if readonly is False:
-        setattr(getattr(sdr, sub_channel), attr, val)
-        if sleep > 0:
-            time.sleep(sleep)
-    rval = getattr(getattr(sdr, sub_channel), attr)
-
-    del sdr
+        if readonly is False:
+            setattr(getattr(sdr, sub_channel), attr, val)
+            if sleep > 0:
+                time.sleep(sleep)
+        rval = getattr(getattr(sdr, sub_channel), attr)
 
     if not isinstance(rval, str) and not is_list:
         rval = float(rval)


### PR DESCRIPTION
# Description

In the case of usb connections, no two iio.Context objects can exist at the same time. When the `dev_interface` functions are called inside the test functions, the function may fail before the `del sdr` operation can be performed and the iio.Context object is not destroyed. The next test that calls the `dev_interface` function will therefore also fail (since it cannot create another iio.Context object).
By transforming the `context_manager` class into a Pythonic context manager, we make use of the `with` statement. The `with` block will act as a wrapper over the usage of iio.Context objects and it will ensure that when errors are thrown, they are logged and memory is properly freed.
`context_manager` objects can still be created without the `with` statement (introduced change doesn't affect pre-existing code).

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Tested by running all pluto tests with a usb connection. The attribute test for setting the sampling rate (`test_pluto_attr[attr=sample_rate-start=2084000-stop=61440000-step=1-tol=4-repeats=100-classname=adi.Pluto]`) fails randomly. Whichever test comes after it (in my case it was `test_pluto_rx_data`) would fail with `Exception: No device found` because pyadi couldn't create a new iio.Context object. After implementing this fix, exceptions are caught and printed correctly and the memory for the iio.Context object is freed.

**Test Configuration**:
* Hardware: pluto
* OS: ubuntu22.04

# Documentation

If this is a new feature or example please mention or link any documentation. All new hardware interface classes require documentation.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
