### PR TITLE
Modification to fix issue with MAX14906 current_limit setting functio…

### DIFF
--- a/adi/max14906.py
+++ b/adi/max14906.py
@@ -68,7 +68,7 @@ class max14906(rx, context_manager):
 		def current_limit(self, value):
 			if not self.output:
 				return 0
-			return self._get_iio_attr(self.name, "current_limit", self.output, value)
+			return self._set_iio_attr(self.name, "current_limit", self.output, value)
 
 		@property
 		def current_limit_available(self):


### PR DESCRIPTION
max14906.py

# Description

Fixing improper function call for setting the current limit on channels of the MAX14906.

Fixes # (654)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Used this function to successfully set current limits on the AD-SWIT1L-SL board between 160mA and 300mA in proprietary GUI interface.

**Test Configuration**:
* Hardware: AD-SWIOT1L-SL
* OS: Windows 11
* Python: 3.11.1

# Documentation

Simple bug fix - N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
