### PR TITLE
ad9081/_mc: fix type and first channel defaulting

### DIFF
--- a/adi/ad9081.py
+++ b/adi/ad9081.py
@@ -155,18 +155,26 @@ class ad9081(rx_tx, context_manager, sync_start):
 
     def _get_iio_attr_str_single(self, channel_name, attr, output):
         # This is overridden by subclasses
+        if isinstance(channel_name, list):
+            channel_name = channel_name[0]
         return self._get_iio_attr_str(channel_name, attr, output)
 
     def _set_iio_attr_str_single(self, channel_name, attr, output, value):
         # This is overridden by subclasses
+        if isinstance(channel_name, list):
+            channel_name = channel_name[0]
         return self._set_iio_attr(channel_name, attr, output, value)
 
     def _get_iio_attr_single(self, channel_name, attr, output, _ctrl=None):
         # This is overridden by subclasses
+        if isinstance(channel_name, list):
+            channel_name = channel_name[0]
         return self._get_iio_attr(channel_name, attr, output, _ctrl)
 
     def _set_iio_attr_single(self, channel_name, attr, output, value, _ctrl=None):
         # This is overridden by subclasses
+        if isinstance(channel_name, list):
+            channel_name = channel_name[0]
         return self._set_iio_attr(channel_name, attr, output, value, _ctrl)
 
     def _get_iio_dev_attr_single(self, attr):
@@ -260,13 +268,13 @@ class ad9081(rx_tx, context_manager, sync_start):
     def rx_test_mode(self):
         """rx_test_mode: NCO Test Mode"""
         return self._get_iio_attr_str_single(
-            self._rx_coarse_ddc_channel_names[0], "test_mode", False
+            self._rx_coarse_ddc_channel_names, "test_mode", False
         )
 
     @rx_test_mode.setter
     def rx_test_mode(self, value):
         self._set_iio_attr_single(
-            self._rx_coarse_ddc_channel_names[0], "test_mode", False, value,
+            self._rx_coarse_ddc_channel_names, "test_mode", False, value,
         )
 
     @property
@@ -643,31 +651,28 @@ class ad9081(rx_tx, context_manager, sync_start):
     def rx_sample_rate(self):
         """rx_sampling_frequency: Sample rate after decimation"""
         return self._get_iio_attr_single(
-            self._rx_coarse_ddc_channel_names[0], "sampling_frequency", False
+            self._rx_coarse_ddc_channel_names, "sampling_frequency", False
         )
 
     @property
     def adc_frequency(self):
         """adc_frequency: ADC frequency in Hz"""
         return self._get_iio_attr_single(
-            self._rx_coarse_ddc_channel_names[0], "adc_frequency", False
+            self._rx_coarse_ddc_channel_names, "adc_frequency", False
         )
 
     @property
     def tx_sample_rate(self):
         """tx_sampling_frequency: Sample rate before interpolation"""
         return self._get_iio_attr_single(
-            self._tx_coarse_duc_channel_names[0],
-            "sampling_frequency",
-            True,
-            self._txdac,
+            self._tx_coarse_duc_channel_names, "sampling_frequency", True,
         )
 
     @property
     def dac_frequency(self):
         """dac_frequency: DAC frequency in Hz"""
         return self._get_iio_attr_single(
-            self._tx_coarse_duc_channel_names[0], "dac_frequency", True
+            self._tx_coarse_duc_channel_names, "dac_frequency", True
         )
 
     @property

--- a/adi/ad9081_mc.py
+++ b/adi/ad9081_mc.py
@@ -89,10 +89,10 @@ class ad9081_mc(ad9081):
     _rx_channel_names: List[str] = []
     _tx_channel_names: List[str] = []
     _tx_control_channel_names: List[str] = []
-    _rx_coarse_ddc_channel_names: List[str] = []
-    _tx_coarse_duc_channel_names: List[str] = []
-    _rx_fine_ddc_channel_names: List[str] = []
-    _tx_fine_duc_channel_names: List[str] = []
+    _rx_coarse_ddc_channel_names: Dict[str, str] = {}
+    _tx_coarse_duc_channel_names: Dict[str, str] = {}
+    _rx_fine_ddc_channel_names: Dict[str, str] = {}
+    _tx_fine_duc_channel_names: [str, str] = {}
     _dds_channel_names: List[str] = []
     _device_name = ""
 
@@ -104,10 +104,10 @@ class ad9081_mc(ad9081):
         self._rx_channel_names: List[str] = []
         self._tx_channel_names: List[str] = []
         self._tx_control_channel_names: List[str] = []
-        self._rx_coarse_ddc_channel_names: List[str] = []
-        self._tx_coarse_duc_channel_names: List[str] = []
-        self._rx_fine_ddc_channel_names: List[str] = []
-        self._tx_fine_duc_channel_names: List[str] = []
+        self._rx_coarse_ddc_channel_names: Dict[str, str] = {}
+        self._tx_coarse_duc_channel_names: Dict[str, str] = {}
+        self._rx_fine_ddc_channel_names: Dict[str, str] = {}
+        self._tx_fine_duc_channel_names: Dict[str, str] = {}
         self._dds_channel_names: List[str] = []
 
         context_manager.__init__(self, uri, self._device_name)
@@ -276,6 +276,9 @@ class ad9081_mc(ad9081):
     # Singleton function intercepts
     def _get_iio_attr_str_single(self, channel_name, attr, output):
         channel_names_dict = self._rx_coarse_ddc_channel_names
+        if isinstance(channel_name, dict):
+            _dev = next(iter(self._tx_coarse_duc_channel_names))
+            channel_name = channel_names_dict[_dev][0]
         return {
             dev: attribute._get_iio_attr_str(
                 self, channel_name, attr, output, self._ctx.find_device(dev)
@@ -283,8 +286,23 @@ class ad9081_mc(ad9081):
             for dev in channel_names_dict
         }
 
+    def _set_iio_attr_str_single(self, channel_name, attr, output, value):
+        channel_names_dict = self._rx_coarse_ddc_channel_names
+        if isinstance(channel_name, dict):
+            _dev = next(iter(self._tx_coarse_duc_channel_names))
+            channel_name = channel_names_dict[_dev][0]
+        return {
+            dev: attribute._set_iio_attr_str(
+                self, channel_name, attr, output, value, self._ctx.find_device(dev)
+            )
+            for dev in channel_names_dict
+        }
+
     def _get_iio_attr_single(self, channel_name, attr, output):
         channel_names_dict = self._rx_coarse_ddc_channel_names
+        if isinstance(channel_name, dict):
+            _dev = next(iter(self._tx_coarse_duc_channel_names))
+            channel_name = channel_names_dict[_dev][0]
         return {
             dev: attribute._get_iio_attr(
                 self, channel_name, attr, output, self._ctx.find_device(dev)
@@ -294,6 +312,9 @@ class ad9081_mc(ad9081):
 
     def _set_iio_attr_single(self, channel_name, attr, output, values):
         channel_names_dict = self._rx_coarse_ddc_channel_names
+        if isinstance(channel_name, dict):
+            _dev = next(iter(self._tx_coarse_duc_channel_names))
+            channel_name = channel_names_dict[_dev][0]
         values = self._map_inputs_to_dict_single(channel_names_dict, values)
         for dev in channel_names_dict:
             self._set_iio_attr(


### PR DESCRIPTION
# Description

Some attributes are fetched from the first channel, and if multichip, from the first device:

* ad9081: [...]
* ad9081_mc: {'dev1': [...], 'dev2': [...],}

Due to the type change, examples/QuadMxFE_dual_example.py was broken.
Use the method overwrite to fix the type and behavior.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] HW test DualQuadMXFE

**Test Configuration**:
* Hardware:
* OS:

# Documentation

If this is a new feature or example please mention or link any documentation. All new hardware interface classes require documentation.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
