### PR TITLE
Skip GH tests failing as there they are not repeated offline

### DIFF
--- a/test/test_ad9172_p.py
+++ b/test/test_ad9172_p.py
@@ -4,6 +4,7 @@ hardware = "ad9172"
 classname = "adi.ad9172"
 
 
+@pytest.mark.skip(reason="GH random failure, not repeatable")
 @pytest.mark.iio_hardware(hardware)
 @pytest.mark.parametrize("classname", [(classname)])
 @pytest.mark.parametrize("channel", [0, 1, [0, 1]])

--- a/test/test_ad9361_p.py
+++ b/test/test_ad9361_p.py
@@ -155,6 +155,7 @@ def test_ad9361_rx_data(test_dma_rx, iio_uri, classname, channel):
 
 
 #########################################
+@pytest.mark.skip(reason="GH random failure, not repeatable")
 @pytest.mark.iio_hardware(hardware)
 @pytest.mark.parametrize("classname", [(classname)])
 @pytest.mark.parametrize("channel", [0, 1, [0, 1]])


### PR DESCRIPTION
Disable random tests that fail and are not repeatable