### PR TITLE
adt7420: Adding Linux support

### DIFF
--- a/adi/adt7420.py
+++ b/adi/adt7420.py
@@ -18,57 +18,108 @@ class adt7420(attribute, context_manager):
 
         if not self._ctrl:
             raise Exception("ADT7420 device not found")
+    # STARTS HERE   
+        self.channel = []
+        self._rx_channel_names = []
 
-        self.temp = self._channel(self._ctrl, "temp")
+        for ch in self._ctrl.channels:
+            name = ch._id  # or ch._id depending on backend, usually it's just .id
 
-    class _channel(attribute):
-        """ADT7420 Channel"""
+            self._rx_channel_names.append(name)
+            self.channel.append(name)
+
+            if name == "temp":
+                # no-OS driver
+                setattr(self, name, self.channel_temp_noos(self._ctrl, name))
+            elif name == "temp1":
+                # Linux driver
+                setattr(self, name, self.channel_temp_linux(self._ctrl, name))
+            else:
+                raise Exception(f"Unsupported: {name}")
+
+    class channel_temp_noos(attribute):
+        """Channel for no-OS driver"""
 
         def __init__(self, ctrl, channel_name):
             self._ctrl = ctrl
             self.name = channel_name
 
         @property
-        def temp_val(self):
-            """ ADT7420 Channel Temperature Value """
+        def temp(self):
+            """ Read temperature value """
             return self._get_iio_attr(self.name, "temp", False)
 
         @property
         def temp_max(self):
-            """ ADT7420 Channel Max Temperature """
             return self._get_iio_attr(self.name, "temp_max", False)
 
         @temp_max.setter
         def temp_max(self, value):
-            """ ADT7420 Channel Max Temperature """
             return self._set_iio_attr(self.name, "temp_max", False, value)
 
         @property
         def temp_min(self):
-            """ ADT7420 Channel Min Temperature """
             return self._get_iio_attr(self.name, "temp_min", False)
 
         @temp_min.setter
         def temp_min(self, value):
-            """ ADT7420 Channel Min Temperature """
             return self._set_iio_attr(self.name, "temp_min", False, value)
 
         @property
         def temp_crit(self):
-            """ ADT7420 Channel Critical Temperature """
             return self._get_iio_attr(self.name, "temp_crit", False)
 
         @temp_crit.setter
         def temp_crit(self, value):
-            """ ADT7420 Channel Critical Temperature """
             return self._set_iio_attr(self.name, "temp_crit", False, value)
 
         @property
         def temp_hyst(self):
-            """ ADT7420 Channel Hysteresis Temperature """
             return self._get_iio_attr(self.name, "temp_hyst", False)
 
         @temp_hyst.setter
         def temp_hyst(self, value):
-            """ ADT7420 Channel Hysteresis Temperature """
             return self._set_iio_attr(self.name, "temp_hyst", False, value)
+
+    class channel_temp_linux(attribute):
+        """Channel for Linux driver"""
+
+        def __init__(self, ctrl, channel_name):
+            self._ctrl = ctrl
+            self.name = channel_name
+
+        @property
+        def temp(self):
+            return self._get_iio_attr(self.name, "input", False)
+
+        @property
+        def temp_max(self):
+            return self._get_iio_attr(self.name, "max", False)
+
+        @temp_max.setter
+        def temp_max(self, value):
+            return self._set_iio_attr(self.name, "max", False, value)
+
+        @property
+        def temp_min(self):
+            return self._get_iio_attr(self.name, "min", False)
+
+        @temp_min.setter
+        def temp_min(self, value):
+            return self._set_iio_attr(self.name, "min", False, value)
+
+        @property
+        def temp_crit(self):
+            return self._get_iio_attr(self.name, "crit", False)
+
+        @temp_crit.setter
+        def temp_crit(self, value):
+            return self._set_iio_attr(self.name, "crit", False, value)
+
+        @property
+        def temp_hyst(self):
+            return self._get_iio_attr(self.name, "crit_hyst", False)
+
+        @temp_hyst.setter
+        def temp_hyst(self, value):
+            return self._set_iio_attr(self.name, "crit_hyst", False, value)

--- a/adi/adt7420.py
+++ b/adi/adt7420.py
@@ -17,109 +17,128 @@ class adt7420(attribute, context_manager):
         self._ctrl = self._ctx.find_device(self._device_name)
 
         if not self._ctrl:
-            raise Exception("ADT7420 device not found")
-    # STARTS HERE   
+            raise Exception("ADT7420 device not found")  
+      
         self.channel = []
         self._rx_channel_names = []
 
         for ch in self._ctrl.channels:
-            name = ch._id  # or ch._id depending on backend, usually it's just .id
+            name = ch._id
 
             self._rx_channel_names.append(name)
             self.channel.append(name)
 
             if name == "temp":
-                # no-OS driver
-                setattr(self, name, self.channel_temp_noos(self._ctrl, name))
+                # no-OS
+                setattr(self, name, self.channel_temp(self._ctrl, name))
+                self.temp = self.channel_temp(self._ctrl, "temp")
             elif name == "temp1":
-                # Linux driver
-                setattr(self, name, self.channel_temp_linux(self._ctrl, name))
+                # Linux
+                setattr(self, name, self.channel_temp1(self._ctrl, name))
+                self.temp = self.channel_temp1(self._ctrl, "temp1")
             else:
                 raise Exception(f"Unsupported: {name}")
 
-    class channel_temp_noos(attribute):
-        """Channel for no-OS driver"""
+    class channel_temp(attribute):
+        """ADT7420 Channel for no-OS"""
 
         def __init__(self, ctrl, channel_name):
             self._ctrl = ctrl
             self.name = channel_name
 
         @property
-        def temp(self):
-            """ Read temperature value """
+        def temp_val(self):
+            """ ADT7420 Channel Temperature Value """
             return self._get_iio_attr(self.name, "temp", False)
 
         @property
         def temp_max(self):
+            """ ADT7420 Channel Max Temperature """
             return self._get_iio_attr(self.name, "temp_max", False)
 
         @temp_max.setter
         def temp_max(self, value):
+            """ ADT7420 Channel Max Temperature """
             return self._set_iio_attr(self.name, "temp_max", False, value)
 
         @property
         def temp_min(self):
+            """ ADT7420 Channel Min Temperature """
             return self._get_iio_attr(self.name, "temp_min", False)
 
         @temp_min.setter
         def temp_min(self, value):
+            """ ADT7420 Channel Min Temperature """
             return self._set_iio_attr(self.name, "temp_min", False, value)
 
         @property
         def temp_crit(self):
+            """ ADT7420 Channel Critical Temperature """
             return self._get_iio_attr(self.name, "temp_crit", False)
 
         @temp_crit.setter
         def temp_crit(self, value):
+            """ ADT7420 Channel Critical Temperature """
             return self._set_iio_attr(self.name, "temp_crit", False, value)
 
         @property
         def temp_hyst(self):
+            """ ADT7420 Channel Hysteresis Temperature """
             return self._get_iio_attr(self.name, "temp_hyst", False)
 
         @temp_hyst.setter
         def temp_hyst(self, value):
+            """ ADT7420 Channel Hysteresis Temperature """
             return self._set_iio_attr(self.name, "temp_hyst", False, value)
 
-    class channel_temp_linux(attribute):
-        """Channel for Linux driver"""
+    class channel_temp1(attribute):
+        """ADT7420 Channel for Linux"""
 
         def __init__(self, ctrl, channel_name):
             self._ctrl = ctrl
             self.name = channel_name
 
         @property
-        def temp(self):
+        def temp_val(self):
+            """ ADT7420 Channel Temperature Value """
             return self._get_iio_attr(self.name, "input", False)
 
         @property
         def temp_max(self):
+            """ ADT7420 Channel Max Temperature """
             return self._get_iio_attr(self.name, "max", False)
 
         @temp_max.setter
         def temp_max(self, value):
+            """ ADT7420 Channel Max Temperature """
             return self._set_iio_attr(self.name, "max", False, value)
 
         @property
         def temp_min(self):
+            """ ADT7420 Channel Min Temperature """
             return self._get_iio_attr(self.name, "min", False)
 
         @temp_min.setter
         def temp_min(self, value):
+            """ ADT7420 Channel Min Temperature """
             return self._set_iio_attr(self.name, "min", False, value)
 
         @property
         def temp_crit(self):
+            """ ADT7420 Channel Critical Temperature """
             return self._get_iio_attr(self.name, "crit", False)
 
         @temp_crit.setter
         def temp_crit(self, value):
+            """ ADT7420 Channel Critical Temperature """
             return self._set_iio_attr(self.name, "crit", False, value)
 
         @property
         def temp_hyst(self):
-            return self._get_iio_attr(self.name, "crit_hyst", False)
+            """ ADT7420 Channel Hysteresis Temperature """
+            return self._get_iio_attr(self.name, "max_hyst", False)
 
         @temp_hyst.setter
         def temp_hyst(self, value):
-            return self._set_iio_attr(self.name, "crit_hyst", False, value)
+            """ ADT7420 Channel Hysteresis Temperature """
+            return self._set_iio_attr(self.name, "max_hyst", False, value)

--- a/adi/adt7420.py
+++ b/adi/adt7420.py
@@ -17,8 +17,8 @@ class adt7420(attribute, context_manager):
         self._ctrl = self._ctx.find_device(self._device_name)
 
         if not self._ctrl:
-            raise Exception("ADT7420 device not found")  
-      
+            raise Exception("ADT7420 device not found")
+
         self.channel = []
         self._rx_channel_names = []
 

--- a/test/test_adt7420.py
+++ b/test/test_adt7420.py
@@ -10,10 +10,10 @@ classname = "adi.adt7420"
 @pytest.mark.parametrize(
     "attr, start, stop, step, tol, repeats, sub_channel",
     [
-        ("temp_max", 5, 50, 5, 1, 2, "_channel"),
-        ("temp_min", 0, 40, 5, 1, 1, "_channel"),
-        ("temp_crit", 80, 150, 5, 10, 1, "_channel"),
-        ("temp_hyst", 5, 20, 1, 1, 1, "_channel"),
+        ("temp_max", 5, 50, 5, 5, 1, "temp"),
+        ("temp_min", 0, 40, 5, 5, 1, "temp"),
+        ("temp_crit", 80, 150, 5, 10, 1, "temp"),
+        ("temp_hyst", 20, 40, 5, 20, 1, "temp"),
     ],
 )
 def test_adt7420_attrs(


### PR DESCRIPTION
# Description

Added Linux support for ADT7420 by handling Linux-specific IIO attributes (input, max, min, crit, max_hyst). It can now auto-detect whether the platform is no-OS or Linux based on the channel name (temp for no-OS, temp1 for Linux).

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [/] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Tested on actual hardware using the board example from pyadi-iio. The driver successfully reads and sets attribute values, confirming functionality on both no-OS and Linux setups.

# Documentation

If this is a new feature or example please mention or link any documentation. All new hardware interface classes require documentation.

# Checklist:

- [/] My code follows the style guidelines of this project
- [/] I have performed a self-review of my own code
- [/] I have commented my code, particularly in hard-to-understand areas
- [/] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [/] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
