### PR TITLE
Set _rx_data_type to 32-bits

### DIFF
--- a/adi/adxl355.py
+++ b/adi/adxl355.py
@@ -17,6 +17,7 @@ class adxl355(rx, context_manager, attribute):
     _device_name = "adxl355"
     _rx_unbuffered_data = True
     _rx_data_si_type = float
+    _rx_data_type = np.int32
 
     def __init__(self, uri=""):
 


### PR DESCRIPTION
# Description

Set rx_data_type to 32-bit integer. Not sure where the mismatch crept in, I suspect an earlier version of rx() either detected, or tolerated, the ADXL355's 20-bit data.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Verify adxl355_example.py runs (it exercises all data modes.)

**Test Configuration**:
* Hardware: EVAL-ADXL355-PMDZ on Raspberry Pi
* OS: Windows on remote host, Raspberry Pi on local

# Documentation

N/A

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
