### PR TITLE
adi: ad719x: add missing whitespace in array

### DIFF
--- a/adi/ad719x.py
+++ b/adi/ad719x.py
@@ -24,7 +24,7 @@ class ad719x(rx, context_manager):
         """Constructor for AD719x class."""
         context_manager.__init__(self, uri, self._device_name)
 
-        compatible_parts = ["ad7190", "ad7191","ad7192", "ad7193", "ad7194", "ad7195"]
+        compatible_parts = ["ad7190", "ad7191", "ad7192", "ad7193", "ad7194", "ad7195"]
 
         self._ctrl = None
 


### PR DESCRIPTION
# Description

Fix the lint build by adding the missing whitespace after ','.

Fixes: https://github.com/analogdevicesinc/pyadi-iio/commit/33aeb03c3f0e13693ee24ede2d78079a2adcce61 ("projects:ad7191_iio:Added the python support for ad7191")

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
