### PR TITLE
Remove scanning from emu tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Test without optional dependencies
         run: |
                 pip uninstall -y paramiko
-                pytest -vs --cov=adi --scan-verbose --emu --junitxml="results.xml" -k 'not prod'
+                pytest -vs --cov=adi --emu --junitxml="results.xml" -k 'not prod' --skip-scan
 
       - name: Report coverage
         if: (github.event_name != 'pull_request') && (matrix.python-version == 3.8)


### PR DESCRIPTION
Azure VM seem to have IIO running in their kernel now which breaks how our emulation tests work. Disable scanning fixes this issue