### PR TITLE
ad7124: Fix channel initialization

### DIFF
--- a/adi/ad7124.py
+++ b/adi/ad7124.py
@@ -15,7 +15,6 @@ class ad7124(rx, context_manager):
     """ AD7124 ADC """
 
     _complex_data = False
-    channel = []  # type: ignore
     _device_name = ""
 
     def __init__(self, uri="", device_index=0):
@@ -38,6 +37,7 @@ class ad7124(rx, context_manager):
                     index += 1
 
         self._rx_channel_names = [chan.id for chan in self._ctrl.channels]
+        self.channel = []
         if "-" in self._rx_channel_names[0]:
             self._rx_channel_names.sort(key=lambda x: int(x[7:].split("-")[0]))
         else:


### PR DESCRIPTION
1. Fix channel list initialization to remove stale references when the device context is deleted

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Hardware:
* OS:

# Documentation

If this is a new feature or example please mention or link any documentation. All new hardware interface classes require documentation.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X ] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
