### PR TITLE
ad9740: Add pyadi-iio support

### DIFF
--- a/adi/__init__.py
+++ b/adi/__init__.py
@@ -39,6 +39,7 @@ from adi.ad7689 import ad7689
 from adi.ad7746 import ad7746
 from adi.ad7768 import ad7768, ad7768_4
 from adi.ad7799 import ad7799
+from adi.ad9740 import ad9740
 from adi.ad9081 import ad9081
 from adi.ad9081_mc import QuadMxFE, ad9081_mc
 from adi.ad9083 import ad9083

--- a/adi/ad9740.py
+++ b/adi/ad9740.py
@@ -1,0 +1,202 @@
+# Copyright (C) 2025 Analog Devices, Inc.
+#
+# SPDX short identifier: ADIBSD
+
+from decimal import Decimal
+
+from adi.attribute import attribute
+from adi.context_manager import context_manager
+from adi.rx_tx import tx
+
+
+class ad9740(tx, context_manager):
+    """AD9740/AD9742/AD9744/AD9748 10/12/14/8-bit, 210 MSPS DAC with DDS support"""
+
+    _complex_data = False
+    _device_name = "AD9740"
+
+    def disable_dds(self):
+        """Override DDS disable to use data_source attribute instead.
+
+        AD9740 uses data_source control, not the standard DDS raw attribute.
+        When switching to DMA mode, set data_source to 'normal'.
+        """
+        # Set data source to normal (DMA mode)
+        if hasattr(self, 'channel') and len(self.channel) > 0:
+            try:
+                self.channel[0].data_source = "normal"
+            except (AttributeError, OSError):
+                # If data_source doesn't work, just pass
+                # (driver might already be in correct mode)
+                pass
+
+    def __init__(self, uri="", device_name=""):
+        """Constructor for AD9740 driver class"""
+
+        context_manager.__init__(self, uri, self._device_name)
+
+        compatible_parts = [
+            "ad9740",  # 10-bit DAC
+            "ad9742",  # 12-bit DAC
+            "ad9744",  # 14-bit DAC
+            "ad9748",  # 8-bit DAC
+        ]
+
+        self._ctrl = None
+        self._txdac = None
+
+        if not device_name:
+            device_name = compatible_parts[0]
+        else:
+            if device_name not in compatible_parts:
+                raise Exception(
+                    f"Not a compatible device: {device_name}. Supported device names "
+                    f"are: {','.join(compatible_parts)}"
+                )
+
+        # Select the device matching device_name as working device
+        for device in self._ctx.devices:
+            if device.name == device_name:
+                self._ctrl = device
+                self._txdac = device
+                break
+
+        if not self._ctrl:
+            raise Exception("Error in selecting matching device")
+
+        if not self._txdac:
+            raise Exception("Error in selecting matching device")
+
+        self.output_bits = []
+        self.channel = []
+        self._tx_channel_names = []
+        for ch in self._ctrl.channels:
+            name = ch._id
+            output = ch._output
+            self.output_bits.append(ch.data_format.bits)
+            self._tx_channel_names.append(name)
+            self.channel.append(self._channel(self._ctrl, name, output))
+            if output is True:
+                setattr(self, name, self._channel(self._ctrl, name, output))
+
+        tx.__init__(self)
+
+    class _channel(attribute):
+        """AD9740 channel"""
+
+        def __init__(self, ctrl, channel_name, output):
+            self.name = channel_name
+            self._ctrl = ctrl
+            self._output = output
+
+        @property
+        def sample_rate(self):
+            """Sample rate of the DAC (from backend)
+            Note: AD9740 driver doesn't expose sampling_frequency attribute,
+            so we return a default value. Override if needed."""
+            try:
+                return self._get_iio_attr(self.name, "sampling_frequency", True)
+            except (KeyError, OSError):
+                # Attribute doesn't exist, return default (210 MHz from ADF4351)
+                return 210000000
+
+        @sample_rate.setter
+        def sample_rate(self, value):
+            """Set sample rate - may not be supported by all backends"""
+            try:
+                self._set_iio_attr(self.name, "sampling_frequency", True, value)
+            except (KeyError, OSError):
+                # Attribute doesn't exist, silently ignore
+                pass
+
+        @property
+        def raw(self):
+            """Get channel raw value
+            DAC code in the range 0-16383 (14-bit)"""
+            return self._get_iio_attr(self.name, "raw", True)
+
+        @raw.setter
+        def raw(self, value):
+            """Set channel raw value"""
+            self._set_iio_attr(self.name, "raw", True, str(int(value)))
+
+        @property
+        def data_source(self):
+            """Get/Set data source: normal, dds, or ramp"""
+            return self._get_iio_attr_str(self.name, "data_source", True)
+
+        @data_source.setter
+        def data_source(self, value):
+            """Set data source (normal, dds, ramp)"""
+            self._set_iio_attr(self.name, "data_source", True, value)
+
+        @property
+        def data_source_available(self):
+            """Available data sources"""
+            return self._get_iio_attr_str(self.name, "data_source_available", True)
+
+        # DDS Tone 0 controls
+        @property
+        def frequency0(self):
+            """DDS Tone 0 frequency in Hz"""
+            return int(self._get_iio_attr(self.name, "frequency0", True))
+
+        @frequency0.setter
+        def frequency0(self, value):
+            self._set_iio_attr(self.name, "frequency0", True, str(int(value)))
+
+        @property
+        def scale0(self):
+            """DDS Tone 0 scale (0.0 to 1.0)"""
+            return float(self._get_iio_attr_str(self.name, "scale0", True))
+
+        @scale0.setter
+        def scale0(self, value):
+            self._set_iio_attr(self.name, "scale0", True, str(Decimal(value).real))
+
+        @property
+        def phase0(self):
+            """DDS Tone 0 phase in degrees"""
+            # Kernel returns phase in radians as a decimal string
+            radians = float(self._get_iio_attr_str(self.name, "phase0", True))
+            return radians * 180.0 / 3.14159265359  # Convert to degrees
+
+        @phase0.setter
+        def phase0(self, value):
+            """Set phase in degrees"""
+            # Convert degrees to radians for kernel
+            radians = float(value) * 3.14159265359 / 180.0
+            self._set_iio_attr(self.name, "phase0", True, f"{radians:.5f}")
+
+        # DDS Tone 1 controls
+        @property
+        def frequency1(self):
+            """DDS Tone 1 frequency in Hz"""
+            return int(self._get_iio_attr(self.name, "frequency1", True))
+
+        @frequency1.setter
+        def frequency1(self, value):
+            self._set_iio_attr(self.name, "frequency1", True, str(int(value)))
+
+        @property
+        def scale1(self):
+            """DDS Tone 1 scale (0.0 to 1.0)"""
+            return float(self._get_iio_attr_str(self.name, "scale1", True))
+
+        @scale1.setter
+        def scale1(self, value):
+            self._set_iio_attr(self.name, "scale1", True, str(Decimal(value).real))
+
+        @property
+        def phase1(self):
+            """DDS Tone 1 phase in degrees"""
+            # Kernel returns phase in radians as a decimal string
+            radians = float(self._get_iio_attr_str(self.name, "phase1", True))
+            return radians * 180.0 / 3.14159265359  # Convert to degrees
+
+        @phase1.setter
+        def phase1(self, value):
+            """Set phase in degrees"""
+            # Convert degrees to radians for kernel
+            radians = float(value) * 3.14159265359 / 180.0
+            self._set_iio_attr(self.name, "phase1", True, f"{radians:.5f}")

--- a/adi/ad9740.py
+++ b/adi/ad9740.py
@@ -10,51 +10,39 @@ from adi.rx_tx import tx
 
 
 class ad9740(tx, context_manager):
-    """AD9740/AD9742/AD9744/AD9748 10/12/14/8-bit, 210 MSPS DAC with DDS support"""
+    """AD9740/AD9742/AD9744/AD9748 10/12/14/8-bit, 210 MSPS DAC
+
+    Two IIO channels:
+      altvoltage0: DDS tone generator (frequency, scale, phase)
+      voltage0:    DMA data output (data_source, buffer)
+    """
 
     _complex_data = False
     _device_name = "AD9740"
 
     def disable_dds(self):
-        """Override DDS disable to use data_source attribute instead.
-
-        AD9740 uses data_source control, not the standard DDS raw attribute.
-        When switching to DMA mode, set data_source to 'normal'.
-        """
-        # Set data source to normal (DMA mode)
-        if hasattr(self, 'channel') and len(self.channel) > 0:
-            try:
-                self.channel[0].data_source = "normal"
-            except (AttributeError, OSError):
-                # If data_source doesn't work, just pass
-                # (driver might already be in correct mode)
-                pass
+        """Switch to DMA mode by setting data_source to 'normal'."""
+        try:
+            self.voltage0.data_source = "normal"
+        except (AttributeError, OSError):
+            pass
 
     def __init__(self, uri="", device_name=""):
-        """Constructor for AD9740 driver class"""
-
         context_manager.__init__(self, uri, self._device_name)
 
-        compatible_parts = [
-            "ad9740",  # 10-bit DAC
-            "ad9742",  # 12-bit DAC
-            "ad9744",  # 14-bit DAC
-            "ad9748",  # 8-bit DAC
-        ]
+        compatible_parts = ["ad9740", "ad9742", "ad9744", "ad9748"]
+
+        if not device_name:
+            device_name = compatible_parts[0]
+        elif device_name not in compatible_parts:
+            raise Exception(
+                f"Not a compatible device: {device_name}. "
+                f"Supported: {','.join(compatible_parts)}"
+            )
 
         self._ctrl = None
         self._txdac = None
 
-        if not device_name:
-            device_name = compatible_parts[0]
-        else:
-            if device_name not in compatible_parts:
-                raise Exception(
-                    f"Not a compatible device: {device_name}. Supported device names "
-                    f"are: {','.join(compatible_parts)}"
-                )
-
-        # Select the device matching device_name as working device
         for device in self._ctx.devices:
             if device.name == device_name:
                 self._ctrl = device
@@ -64,20 +52,21 @@ class ad9740(tx, context_manager):
         if not self._ctrl:
             raise Exception("Error in selecting matching device")
 
-        if not self._txdac:
-            raise Exception("Error in selecting matching device")
-
-        self.output_bits = []
         self.channel = []
+        self.output_bits = []
         self._tx_channel_names = []
+
         for ch in self._ctrl.channels:
             name = ch._id
             output = ch._output
             self.output_bits.append(ch.data_format.bits)
-            self._tx_channel_names.append(name)
-            self.channel.append(self._channel(self._ctrl, name, output))
-            if output is True:
-                setattr(self, name, self._channel(self._ctrl, name, output))
+            chan_obj = self._channel(self._ctrl, name, output)
+            self.channel.append(chan_obj)
+            if output:
+                setattr(self, name, chan_obj)
+            # Only voltage channels are valid for DMA buffer
+            if name.startswith("voltage"):
+                self._tx_channel_names.append(name)
 
         tx.__init__(self)
 
@@ -89,45 +78,20 @@ class ad9740(tx, context_manager):
             self._ctrl = ctrl
             self._output = output
 
-        @property
-        def sample_rate(self):
-            """Sample rate of the DAC (from backend)
-            Note: AD9740 driver doesn't expose sampling_frequency attribute,
-            so we return a default value. Override if needed."""
+        def _has_attr(self, attr_name):
             try:
-                return self._get_iio_attr(self.name, "sampling_frequency", True)
-            except (KeyError, OSError):
-                # Attribute doesn't exist, return default (210 MHz from ADF4351)
-                return 210000000
-
-        @sample_rate.setter
-        def sample_rate(self, value):
-            """Set sample rate - may not be supported by all backends"""
-            try:
-                self._set_iio_attr(self.name, "sampling_frequency", True, value)
-            except (KeyError, OSError):
-                # Attribute doesn't exist, silently ignore
-                pass
-
-        @property
-        def raw(self):
-            """Get channel raw value
-            DAC code in the range 0-16383 (14-bit)"""
-            return self._get_iio_attr(self.name, "raw", True)
-
-        @raw.setter
-        def raw(self, value):
-            """Set channel raw value"""
-            self._set_iio_attr(self.name, "raw", True, str(int(value)))
+                ch = self._ctrl.find_channel(self.name, self._output)
+                return attr_name in ch.attrs
+            except Exception:
+                return False
 
         @property
         def data_source(self):
-            """Get/Set data source: normal, dds, or ramp"""
+            """Get data source: normal, dds, or ramp (voltage0 only)"""
             return self._get_iio_attr_str(self.name, "data_source", True)
 
         @data_source.setter
         def data_source(self, value):
-            """Set data source (normal, dds, ramp)"""
             self._set_iio_attr(self.name, "data_source", True, value)
 
         @property
@@ -135,10 +99,9 @@ class ad9740(tx, context_manager):
             """Available data sources"""
             return self._get_iio_attr_str(self.name, "data_source_available", True)
 
-        # DDS Tone 0 controls
         @property
         def frequency0(self):
-            """DDS Tone 0 frequency in Hz"""
+            """DDS Tone 0 frequency in Hz (altvoltage0 only)"""
             return int(self._get_iio_attr(self.name, "frequency0", True))
 
         @frequency0.setter
@@ -157,18 +120,14 @@ class ad9740(tx, context_manager):
         @property
         def phase0(self):
             """DDS Tone 0 phase in degrees"""
-            # Kernel returns phase in radians as a decimal string
             radians = float(self._get_iio_attr_str(self.name, "phase0", True))
-            return radians * 180.0 / 3.14159265359  # Convert to degrees
+            return radians * 180.0 / 3.14159265359
 
         @phase0.setter
         def phase0(self, value):
-            """Set phase in degrees"""
-            # Convert degrees to radians for kernel
             radians = float(value) * 3.14159265359 / 180.0
             self._set_iio_attr(self.name, "phase0", True, f"{radians:.5f}")
 
-        # DDS Tone 1 controls
         @property
         def frequency1(self):
             """DDS Tone 1 frequency in Hz"""
@@ -190,13 +149,10 @@ class ad9740(tx, context_manager):
         @property
         def phase1(self):
             """DDS Tone 1 phase in degrees"""
-            # Kernel returns phase in radians as a decimal string
             radians = float(self._get_iio_attr_str(self.name, "phase1", True))
-            return radians * 180.0 / 3.14159265359  # Convert to degrees
+            return radians * 180.0 / 3.14159265359
 
         @phase1.setter
         def phase1(self, value):
-            """Set phase in degrees"""
-            # Convert degrees to radians for kernel
             radians = float(value) * 3.14159265359 / 180.0
             self._set_iio_attr(self.name, "phase1", True, f"{radians:.5f}")

--- a/examples/ad9740_dds.py
+++ b/examples/ad9740_dds.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""
+Simple DDS signal generator for AD974x DACs with waveform display.
+
+Usage:
+    python3 ad9740_dds.py -f 1e6 -s 0.5
+    python3 ad9740_dds.py --frequency 5000000 --scale 1.0
+    python3 ad9740_dds.py -f 1e6 -s 0.5 --device ad9744
+"""
+
+import argparse
+import sys
+import numpy as np
+import matplotlib.pyplot as plt
+import adi
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Generate DDS signal on AD974x DAC',
+        formatter_class=argparse.RawTextHelpFormatter,
+        epilog="""Examples:
+  ad9740_dds.py -f 1e6 -s 0.5          # 1 MHz at 50% scale
+  ad9740_dds.py -f 5000000 -s 1.0      # 5 MHz at full scale
+  ad9740_dds.py -f 100e3 -s 0.25       # 100 kHz at 25% scale
+  ad9740_dds.py -f 1e6 --device ad9744 # Use AD9744 device"""
+    )
+    parser.add_argument('-f', '--frequency', type=float, required=True,
+                        help='Output frequency in Hz (e.g., 1e6 for 1 MHz)')
+    parser.add_argument('-s', '--scale', type=float, default=1.0,
+                        help='Output scale 0.0-1.0 (default: 1.0)')
+    parser.add_argument('-u', '--uri', type=str, default='ip:10.48.65.163',
+                        help='Device URI (default: ip:10.48.65.163)')
+    parser.add_argument('-d', '--device', type=str, default='ad9744',
+                        choices=['ad9748', 'ad9740', 'ad9742', 'ad9744'],
+                        help='DAC device name (default: ad9744)')
+
+    args = parser.parse_args()
+
+    # Validate parameters
+    if args.frequency <= 0:
+        print(f"Error: Frequency must be positive, got {args.frequency}")
+        sys.exit(1)
+
+    if not 0.0 <= args.scale <= 1.0:
+        print(f"Error: Scale must be between 0.0 and 1.0, got {args.scale}")
+        sys.exit(1)
+
+    # Connect to DAC
+    print(f"Connecting to {args.device} at {args.uri}...")
+
+    try:
+        dac = adi.ad9740(uri=args.uri, device_name=args.device)
+    except Exception as e:
+        print(f"Error connecting to DAC: {e}")
+        sys.exit(1)
+
+    # Configure DDS
+    try:
+        dac.channel[0].data_source = 'dds'
+        dac.channel[0].frequency0 = int(args.frequency)
+        dac.channel[0].scale0 = args.scale
+
+        freq_str = f"{args.frequency/1e6:.3f} MHz" if args.frequency >= 1e6 else f"{args.frequency/1e3:.3f} kHz"
+        print(f"DDS configured: {freq_str} at scale {args.scale:.2f}")
+
+    except Exception as e:
+        print(f"Error configuring DDS: {e}")
+        sys.exit(1)
+
+    # Generate expected waveform for display
+    num_cycles = 4
+    samples_per_cycle = 100
+    num_samples = num_cycles * samples_per_cycle
+
+    t = np.linspace(0, num_cycles / args.frequency, num_samples)
+    waveform = args.scale * np.sin(2 * np.pi * args.frequency * t)
+
+    # Convert time to appropriate units for display
+    if args.frequency >= 1e6:
+        t_display = t * 1e6  # microseconds
+        t_unit = 'us'
+    elif args.frequency >= 1e3:
+        t_display = t * 1e3  # milliseconds
+        t_unit = 'ms'
+    else:
+        t_display = t
+        t_unit = 's'
+
+    # Create plot
+    fig, ax = plt.subplots(figsize=(10, 6))
+    ax.plot(t_display, waveform, 'b-', linewidth=1.5)
+    ax.axhline(y=0, color='gray', linestyle='--', linewidth=0.5)
+    ax.set_xlabel(f'Time ({t_unit})')
+    ax.set_ylabel('Amplitude (normalized)')
+    ax.set_title(f'{args.device.upper()} DDS Output: {freq_str} @ {args.scale:.0%} scale')
+    ax.set_ylim(-1.1, 1.1)
+    ax.grid(True, alpha=0.3)
+
+    # Add info text
+    info_text = f"Frequency: {freq_str}\nScale: {args.scale:.2f}\nDevice: {args.device}"
+    ax.text(0.02, 0.98, info_text, transform=ax.transAxes, fontsize=10,
+            verticalalignment='top', bbox=dict(boxstyle='round', facecolor='wheat', alpha=0.5))
+
+    plt.tight_layout()
+    print("Close the plot window to stop DDS and exit.")
+    plt.show()
+
+    print("DDS stopped.")
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/ad9740_dds.py
+++ b/examples/ad9740_dds.py
@@ -16,10 +16,6 @@ import matplotlib.pyplot as plt
 import iio
 import adi
 
-# DDS IP core assumed sample rate (hardcoded in FPGA)
-DDS_ASSUMED_SAMPLE_RATE = 210e6
-
-
 def set_sample_rate(uri, sample_rate):
     """Set the ADF4351 clock frequency (DAC sample rate).
 
@@ -33,26 +29,16 @@ def set_sample_rate(uri, sample_rate):
     try:
         ctx = iio.Context(uri)
 
-        # Try to find ADF4351 device (may have full DT path as name)
-        adf4351 = None
         for dev in ctx.devices:
-            if 'adf4351' in dev.name or 'adf4350' in dev.name:
-                adf4351 = dev
-                break
-
-        if not adf4351:
-            return None
-
-        ch0 = adf4351.find_channel('altvoltage0', True)
-        if not ch0:
-            return None
-
-        # Set the frequency
-        ch0.attrs['frequency'].value = str(int(sample_rate))
-
-        # Read back actual value
-        actual = int(ch0.attrs['frequency'].value)
-        return actual
+            name = dev.name or ''
+            if 'adf4351' in name or 'adf4350' in name:
+                ch0 = dev.find_channel('altvoltage0', True)
+                if ch0 and 'frequency' in ch0.attrs:
+                    ch0.attrs['frequency'].value = str(int(sample_rate))
+                    return int(ch0.attrs['frequency'].value)
+        # ADF4351 in clock-provider mode (no IIO channel):
+        # frequency is fixed at boot from device tree
+        return int(sample_rate)
 
     except Exception as e:
         print(f"Warning: Could not set sample rate: {e}")
@@ -71,43 +57,16 @@ def get_sample_rate(uri):
     try:
         ctx = iio.Context(uri)
 
-        adf4351 = None
         for dev in ctx.devices:
-            if 'adf4351' in dev.name or 'adf4350' in dev.name:
-                adf4351 = dev
-                break
-
-        if not adf4351:
-            return None
-
-        ch0 = adf4351.find_channel('altvoltage0', True)
-        if not ch0:
-            return None
-
-        return int(ch0.attrs['frequency'].value)
+            name = dev.name or ''
+            if 'adf4351' in name or 'adf4350' in name:
+                ch0 = dev.find_channel('altvoltage0', True)
+                if ch0 and 'frequency' in ch0.attrs:
+                    return int(ch0.attrs['frequency'].value)
+        return None
 
     except Exception:
         return None
-
-
-def compensate_dds_frequency(desired_freq, actual_sample_rate):
-    """Compensate DDS frequency for sample rate mismatch.
-
-    The DDS IP core assumes a fixed sample rate (DDS_ASSUMED_SAMPLE_RATE).
-    When the actual sample rate differs, we must scale the frequency request.
-
-    Args:
-        desired_freq: Desired output frequency in Hz
-        actual_sample_rate: Actual DAC sample rate in Hz
-
-    Returns:
-        Compensated frequency to request from DDS
-    """
-    if actual_sample_rate is None or actual_sample_rate == DDS_ASSUMED_SAMPLE_RATE:
-        return desired_freq
-
-    ratio = DDS_ASSUMED_SAMPLE_RATE / actual_sample_rate
-    return desired_freq * ratio
 
 
 def main():
@@ -177,22 +136,14 @@ def main():
         print(f"Error connecting to DAC: {e}")
         sys.exit(1)
 
-    # Configure DDS with sample rate compensation
+    # Configure DDS
     try:
-        # Get actual sample rate for compensation
-        actual_rate = get_sample_rate(args.uri)
-        compensated_freq = compensate_dds_frequency(args.frequency, actual_rate)
-
         dac.channel[0].data_source = 'dds'
-        dac.channel[0].frequency0 = int(compensated_freq)
+        dac.channel[0].frequency0 = int(args.frequency)
         dac.channel[0].scale0 = args.scale
 
         freq_str = f"{args.frequency/1e6:.3f} MHz" if args.frequency >= 1e6 else f"{args.frequency/1e3:.3f} kHz"
         print(f"DDS configured: {freq_str} at scale {args.scale:.2f}")
-
-        # Show compensation info if sample rate differs from default
-        if actual_rate and actual_rate != DDS_ASSUMED_SAMPLE_RATE:
-            print(f"  (compensated request: {compensated_freq/1e6:.3f} MHz for {actual_rate/1e6:.0f} MSPS)")
 
     except Exception as e:
         print(f"Error configuring DDS: {e}")

--- a/examples/ad9740_dds.py
+++ b/examples/ad9740_dds.py
@@ -6,13 +6,108 @@ Usage:
     python3 ad9740_dds.py -f 1e6 -s 0.5
     python3 ad9740_dds.py --frequency 5000000 --scale 1.0
     python3 ad9740_dds.py -f 1e6 -s 0.5 --device ad9744
+    python3 ad9740_dds.py -f 1e6 -s 1.0 --sample-rate 200e6
 """
 
 import argparse
 import sys
 import numpy as np
 import matplotlib.pyplot as plt
+import iio
 import adi
+
+# DDS IP core assumed sample rate (hardcoded in FPGA)
+DDS_ASSUMED_SAMPLE_RATE = 210e6
+
+
+def set_sample_rate(uri, sample_rate):
+    """Set the ADF4351 clock frequency (DAC sample rate).
+
+    Args:
+        uri: IIO context URI
+        sample_rate: Desired sample rate in Hz
+
+    Returns:
+        Actual sample rate set, or None if ADF4351 not found
+    """
+    try:
+        ctx = iio.Context(uri)
+
+        # Try to find ADF4351 device (may have full DT path as name)
+        adf4351 = None
+        for dev in ctx.devices:
+            if 'adf4351' in dev.name or 'adf4350' in dev.name:
+                adf4351 = dev
+                break
+
+        if not adf4351:
+            return None
+
+        ch0 = adf4351.find_channel('altvoltage0', True)
+        if not ch0:
+            return None
+
+        # Set the frequency
+        ch0.attrs['frequency'].value = str(int(sample_rate))
+
+        # Read back actual value
+        actual = int(ch0.attrs['frequency'].value)
+        return actual
+
+    except Exception as e:
+        print(f"Warning: Could not set sample rate: {e}")
+        return None
+
+
+def get_sample_rate(uri):
+    """Get the current ADF4351 clock frequency (DAC sample rate).
+
+    Args:
+        uri: IIO context URI
+
+    Returns:
+        Current sample rate in Hz, or None if ADF4351 not found
+    """
+    try:
+        ctx = iio.Context(uri)
+
+        adf4351 = None
+        for dev in ctx.devices:
+            if 'adf4351' in dev.name or 'adf4350' in dev.name:
+                adf4351 = dev
+                break
+
+        if not adf4351:
+            return None
+
+        ch0 = adf4351.find_channel('altvoltage0', True)
+        if not ch0:
+            return None
+
+        return int(ch0.attrs['frequency'].value)
+
+    except Exception:
+        return None
+
+
+def compensate_dds_frequency(desired_freq, actual_sample_rate):
+    """Compensate DDS frequency for sample rate mismatch.
+
+    The DDS IP core assumes a fixed sample rate (DDS_ASSUMED_SAMPLE_RATE).
+    When the actual sample rate differs, we must scale the frequency request.
+
+    Args:
+        desired_freq: Desired output frequency in Hz
+        actual_sample_rate: Actual DAC sample rate in Hz
+
+    Returns:
+        Compensated frequency to request from DDS
+    """
+    if actual_sample_rate is None or actual_sample_rate == DDS_ASSUMED_SAMPLE_RATE:
+        return desired_freq
+
+    ratio = DDS_ASSUMED_SAMPLE_RATE / actual_sample_rate
+    return desired_freq * ratio
 
 
 def main():
@@ -20,20 +115,23 @@ def main():
         description='Generate DDS signal on AD974x DAC',
         formatter_class=argparse.RawTextHelpFormatter,
         epilog="""Examples:
-  ad9740_dds.py -f 1e6 -s 0.5          # 1 MHz at 50% scale
-  ad9740_dds.py -f 5000000 -s 1.0      # 5 MHz at full scale
-  ad9740_dds.py -f 100e3 -s 0.25       # 100 kHz at 25% scale
-  ad9740_dds.py -f 1e6 --device ad9744 # Use AD9744 device"""
+  ad9740_dds.py -f 1e6 -s 0.5              # 1 MHz at 50% scale
+  ad9740_dds.py -f 5000000 -s 1.0          # 5 MHz at full scale
+  ad9740_dds.py -f 100e3 -s 0.25           # 100 kHz at 25% scale
+  ad9740_dds.py -f 1e6 --device ad9744     # Use AD9744 device
+  ad9740_dds.py -f 1e6 --sample-rate 200e6 # Set DAC clock to 200 MHz"""
     )
     parser.add_argument('-f', '--frequency', type=float, required=True,
                         help='Output frequency in Hz (e.g., 1e6 for 1 MHz)')
     parser.add_argument('-s', '--scale', type=float, default=1.0,
                         help='Output scale 0.0-1.0 (default: 1.0)')
-    parser.add_argument('-u', '--uri', type=str, default='ip:10.48.65.163',
-                        help='Device URI (default: ip:10.48.65.163)')
+    parser.add_argument('-u', '--uri', type=str, default='ip:10.48.65.134',
+                        help='Device URI (default: ip:10.48.65.134)')
     parser.add_argument('-d', '--device', type=str, default='ad9744',
                         choices=['ad9748', 'ad9740', 'ad9742', 'ad9744'],
                         help='DAC device name (default: ad9744)')
+    parser.add_argument('-r', '--sample-rate', type=float, default=None,
+                        help='DAC sample rate in Hz via ADF4351 (e.g., 210e6)')
 
     args = parser.parse_args()
 
@@ -46,6 +144,30 @@ def main():
         print(f"Error: Scale must be between 0.0 and 1.0, got {args.scale}")
         sys.exit(1)
 
+    # Set sample rate if specified
+    if args.sample_rate is not None:
+        if args.sample_rate <= 0:
+            print(f"Error: Sample rate must be positive, got {args.sample_rate}")
+            sys.exit(1)
+
+        print(f"Setting sample rate to {args.sample_rate/1e6:.3f} MHz...")
+        actual_rate = set_sample_rate(args.uri, args.sample_rate)
+
+        if actual_rate is None:
+            print("Warning: ADF4351 not found, sample rate unchanged")
+        else:
+            print(f"Sample rate set to {actual_rate/1e6:.3f} MHz")
+
+            # Validate DDS frequency against Nyquist
+            if args.frequency > actual_rate / 2:
+                print(f"Warning: DDS frequency {args.frequency/1e6:.3f} MHz exceeds "
+                      f"Nyquist limit ({actual_rate/2/1e6:.3f} MHz)")
+    else:
+        # Report current sample rate
+        current_rate = get_sample_rate(args.uri)
+        if current_rate:
+            print(f"Current sample rate: {current_rate/1e6:.3f} MHz")
+
     # Connect to DAC
     print(f"Connecting to {args.device} at {args.uri}...")
 
@@ -55,14 +177,22 @@ def main():
         print(f"Error connecting to DAC: {e}")
         sys.exit(1)
 
-    # Configure DDS
+    # Configure DDS with sample rate compensation
     try:
+        # Get actual sample rate for compensation
+        actual_rate = get_sample_rate(args.uri)
+        compensated_freq = compensate_dds_frequency(args.frequency, actual_rate)
+
         dac.channel[0].data_source = 'dds'
-        dac.channel[0].frequency0 = int(args.frequency)
+        dac.channel[0].frequency0 = int(compensated_freq)
         dac.channel[0].scale0 = args.scale
 
         freq_str = f"{args.frequency/1e6:.3f} MHz" if args.frequency >= 1e6 else f"{args.frequency/1e3:.3f} kHz"
         print(f"DDS configured: {freq_str} at scale {args.scale:.2f}")
+
+        # Show compensation info if sample rate differs from default
+        if actual_rate and actual_rate != DDS_ASSUMED_SAMPLE_RATE:
+            print(f"  (compensated request: {compensated_freq/1e6:.3f} MHz for {actual_rate/1e6:.0f} MSPS)")
 
     except Exception as e:
         print(f"Error configuring DDS: {e}")
@@ -98,7 +228,9 @@ def main():
     ax.grid(True, alpha=0.3)
 
     # Add info text
-    info_text = f"Frequency: {freq_str}\nScale: {args.scale:.2f}\nDevice: {args.device}"
+    sample_rate = get_sample_rate(args.uri)
+    rate_str = f"{sample_rate/1e6:.1f} MHz" if sample_rate else "N/A"
+    info_text = f"Frequency: {freq_str}\nScale: {args.scale:.2f}\nDevice: {args.device}\nSample Rate: {rate_str}"
     ax.text(0.02, 0.98, info_text, transform=ax.transAxes, fontsize=10,
             verticalalignment='top', bbox=dict(boxstyle='round', facecolor='wheat', alpha=0.5))
 

--- a/examples/ad9740_dds.py
+++ b/examples/ad9740_dds.py
@@ -136,11 +136,11 @@ def main():
         print(f"Error connecting to DAC: {e}")
         sys.exit(1)
 
-    # Configure DDS
+    # Configure DDS (altvoltage0 for tone, voltage0 for data_source)
     try:
-        dac.channel[0].data_source = 'dds'
-        dac.channel[0].frequency0 = int(args.frequency)
-        dac.channel[0].scale0 = args.scale
+        dac.altvoltage0.frequency0 = int(args.frequency)
+        dac.altvoltage0.scale0 = args.scale
+        dac.voltage0.data_source = 'dds'
 
         freq_str = f"{args.frequency/1e6:.3f} MHz" if args.frequency >= 1e6 else f"{args.frequency/1e3:.3f} kHz"
         print(f"DDS configured: {freq_str} at scale {args.scale:.2f}")

--- a/examples/ad9740_dma.py
+++ b/examples/ad9740_dma.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""
+Simple DMA signal generator for AD974x DACs with waveform display.
+
+Usage:
+    python3 ad9740_dma.py -f 1e6 -s 0.5
+    python3 ad9740_dma.py --frequency 5000000 --scale 1.0
+    python3 ad9740_dma.py -f 1e6 -s 0.5 --device ad9744
+"""
+
+import argparse
+import sys
+import numpy as np
+import matplotlib.pyplot as plt
+import adi
+
+# Device configuration
+DEVICE_CONFIG = {
+    'ad9748': {'bits': 8,  'shift': 8, 'sample_rate': 210e6},
+    'ad9740': {'bits': 10, 'shift': 6, 'sample_rate': 210e6},
+    'ad9742': {'bits': 12, 'shift': 4, 'sample_rate': 210e6},
+    'ad9744': {'bits': 14, 'shift': 0, 'sample_rate': 210e6},
+}
+
+DEFAULT_BUFFER_SIZE = 4096
+
+
+def check_frequency_valid(frequency, sample_rate, buffer_size):
+    """
+    Check if frequency results in integer number of cycles in the buffer.
+    Returns (is_valid, num_cycles, samples_per_cycle, suggested_freq).
+    """
+    samples_per_cycle = sample_rate / frequency
+    num_cycles = buffer_size / samples_per_cycle
+
+    # Use tolerance of 1e-6 to handle floating point input precision
+    is_integer_cycles = abs(num_cycles - round(num_cycles)) < 1e-6
+
+    # Calculate suggested valid frequency
+    k = round(num_cycles)
+    if k < 1:
+        k = 1
+    suggested_freq = k * sample_rate / buffer_size
+
+    return is_integer_cycles, num_cycles, samples_per_cycle, suggested_freq
+
+
+def generate_sine_samples(frequency, scale, num_samples, device_config, sample_rate):
+    """Generate sine wave samples for DMA transmission."""
+    t = np.arange(num_samples) / sample_rate
+    sine = np.sin(2 * np.pi * frequency * t) * scale
+
+    dac_bits = device_config['bits']
+    msb_shift = device_config['shift']
+
+    # Use signed format (dac_datafmt handles conversion)
+    dac_max = (1 << (dac_bits - 1)) - 1
+    samples = (sine * dac_max).astype(np.int16)
+    samples_aligned = (samples << msb_shift).astype(np.int16)
+
+    return samples_aligned, sine
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Generate DMA sine wave on AD974x DAC',
+        formatter_class=argparse.RawTextHelpFormatter,
+        epilog="""Examples:
+  ad9740_dma.py -f 1e6 -s 0.5          # 1 MHz at 50% scale
+  ad9740_dma.py -f 5000000 -s 1.0      # 5 MHz at full scale
+  ad9740_dma.py -f 100e3 -s 0.25       # 100 kHz at 25% scale
+  ad9740_dma.py -f 1e6 --device ad9740 # Use AD9740 device
+
+Valid frequencies for cyclic DMA must result in integer cycles in the buffer.
+Formula: frequency = k * sample_rate / buffer_size (where k is an integer)
+
+For 210 MHz sample rate and 4096 buffer: valid frequencies are multiples of 51.27 kHz"""
+    )
+    parser.add_argument('-f', '--frequency', type=float, default=1230468.75,
+                        help='Output frequency in Hz (default: 1230468.75 Hz)')
+    parser.add_argument('-s', '--scale', type=float, default=1.0,
+                        help='Output scale 0.0-1.0 (default: 1.0)')
+    parser.add_argument('-u', '--uri', type=str, default='ip:10.48.65.163',
+                        help='Device URI (default: ip:10.48.65.163)')
+    parser.add_argument('-d', '--device', type=str, default='ad9744',
+                        choices=['ad9748', 'ad9740', 'ad9742', 'ad9744'],
+                        help='DAC device name (default: ad9744)')
+    parser.add_argument('-b', '--buffer-size', type=int, default=DEFAULT_BUFFER_SIZE,
+                        help=f'DMA buffer size in samples (default: {DEFAULT_BUFFER_SIZE})')
+
+    args = parser.parse_args()
+
+    # Get device config
+    config = DEVICE_CONFIG[args.device]
+    sample_rate = config['sample_rate']
+
+    # Validate parameters
+    if args.frequency <= 0:
+        print(f"Error: Frequency must be positive, got {args.frequency}")
+        sys.exit(1)
+
+    if not 0.0 <= args.scale <= 1.0:
+        print(f"Error: Scale must be between 0.0 and 1.0, got {args.scale}")
+        sys.exit(1)
+
+    # Check if frequency is valid for cyclic DMA
+    is_valid, num_cycles, samples_per_cycle, suggested_freq = check_frequency_valid(
+        args.frequency, sample_rate, args.buffer_size
+    )
+
+    if not is_valid:
+        print("=" * 70)
+        print("ERROR: Invalid frequency for cyclic DMA buffer")
+        print("=" * 70)
+        print()
+        print(f"  Requested frequency:    {args.frequency:.1f} Hz")
+        print(f"  Sample rate:            {sample_rate:.0f} Hz")
+        print(f"  Buffer size:            {args.buffer_size} samples")
+        print()
+        print(f"  Samples per cycle:      {samples_per_cycle:.3f} (must be integer)")
+        print(f"  Cycles in buffer:       {num_cycles:.6f} (must be integer)")
+        print()
+        print("For cyclic DMA, the frequency must result in an INTEGER number of")
+        print("cycles within the buffer to avoid phase discontinuity at wrap-around.")
+        print()
+        print("Valid frequencies are: f = k * sample_rate / buffer_size")
+        print(f"                       f = k * {sample_rate:.0f} / {args.buffer_size}")
+        print(f"                       f = k * {sample_rate/args.buffer_size:.2f} Hz")
+        print()
+        print(f"  Suggested frequency:    {suggested_freq:.2f} Hz ({round(num_cycles)} cycles)")
+        print()
+
+        # Show nearby valid frequencies
+        k = round(num_cycles)
+        print("Nearby valid frequencies:")
+        for dk in range(-2, 3):
+            if k + dk >= 1:
+                f = (k + dk) * sample_rate / args.buffer_size
+                print(f"    k={k+dk:4d}: {f:12.2f} Hz")
+        print()
+        print("=" * 70)
+        sys.exit(1)
+
+    # Connect to DAC
+    print(f"Connecting to {args.device} at {args.uri}...")
+
+    try:
+        dac = adi.ad9740(uri=args.uri, device_name=args.device)
+        dac.tx_enabled_channels = [0]
+        dac.tx_cyclic_buffer = True
+        dac._tx_data_type = np.dtype('<i2')  # Signed little-endian int16
+    except Exception as e:
+        print(f"Error connecting to DAC: {e}")
+        sys.exit(1)
+
+    # Generate samples
+    samples_aligned, sine_normalized = generate_sine_samples(
+        args.frequency, args.scale, args.buffer_size, config, sample_rate
+    )
+
+    freq_str = f"{args.frequency/1e6:.6f} MHz" if args.frequency >= 1e6 else f"{args.frequency/1e3:.3f} kHz"
+    print(f"DMA configured: {freq_str} at scale {args.scale:.2f}")
+    print(f"  Cycles in buffer: {int(round(num_cycles))}")
+    print(f"  Samples per cycle: {samples_per_cycle:.1f}")
+
+    # Send DMA data
+    try:
+        dac.tx(samples_aligned)
+    except Exception as e:
+        print(f"Error sending DMA data: {e}")
+        sys.exit(1)
+
+    # Generate time axis for display
+    num_display_cycles = 4
+    display_samples = int(num_display_cycles * samples_per_cycle)
+    t = np.arange(display_samples) / sample_rate
+    waveform = args.scale * np.sin(2 * np.pi * args.frequency * t)
+
+    # Convert time to appropriate units for display
+    if args.frequency >= 1e6:
+        t_display = t * 1e6  # microseconds
+        t_unit = 'us'
+    elif args.frequency >= 1e3:
+        t_display = t * 1e3  # milliseconds
+        t_unit = 'ms'
+    else:
+        t_display = t
+        t_unit = 's'
+
+    # Create plot
+    fig, ax = plt.subplots(figsize=(10, 6))
+    ax.plot(t_display, waveform, 'b-', linewidth=1.5)
+    ax.axhline(y=0, color='gray', linestyle='--', linewidth=0.5)
+    ax.set_xlabel(f'Time ({t_unit})')
+    ax.set_ylabel('Amplitude (normalized)')
+    ax.set_title(f'{args.device.upper()} DMA Output: {freq_str} @ {args.scale:.0%} scale')
+    ax.set_ylim(-1.1, 1.1)
+    ax.grid(True, alpha=0.3)
+
+    # Add info text
+    info_text = (f"Frequency: {freq_str}\n"
+                 f"Scale: {args.scale:.2f}\n"
+                 f"Device: {args.device}\n"
+                 f"Cycles: {int(round(num_cycles))}\n"
+                 f"Buffer: {args.buffer_size} samples")
+    ax.text(0.02, 0.98, info_text, transform=ax.transAxes, fontsize=10,
+            verticalalignment='top', bbox=dict(boxstyle='round', facecolor='wheat', alpha=0.5))
+
+    plt.tight_layout()
+    print("Close the plot window to stop DMA and exit.")
+    plt.show()
+
+    # Cleanup
+    try:
+        dac.tx_destroy_buffer()
+    except:
+        pass
+
+    print("DMA stopped.")
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/ad9740_dma.py
+++ b/examples/ad9740_dma.py
@@ -41,21 +41,16 @@ def set_sample_rate(uri, sample_rate):
     try:
         ctx = iio.Context(uri)
 
-        adf4351 = None
         for dev in ctx.devices:
-            if 'adf4351' in dev.name or 'adf4350' in dev.name:
-                adf4351 = dev
-                break
-
-        if not adf4351:
-            return None
-
-        ch0 = adf4351.find_channel('altvoltage0', True)
-        if not ch0:
-            return None
-
-        ch0.attrs['frequency'].value = str(int(sample_rate))
-        return int(ch0.attrs['frequency'].value)
+            name = dev.name or ''
+            if 'adf4351' in name or 'adf4350' in name:
+                ch0 = dev.find_channel('altvoltage0', True)
+                if ch0 and 'frequency' in ch0.attrs:
+                    ch0.attrs['frequency'].value = str(int(sample_rate))
+                    return int(ch0.attrs['frequency'].value)
+        # ADF4351 in clock-provider mode (no IIO channel):
+        # frequency is fixed at boot from device tree
+        return int(sample_rate)
 
     except Exception as e:
         print(f"Warning: Could not set sample rate: {e}")
@@ -74,20 +69,13 @@ def get_sample_rate(uri):
     try:
         ctx = iio.Context(uri)
 
-        adf4351 = None
         for dev in ctx.devices:
-            if 'adf4351' in dev.name or 'adf4350' in dev.name:
-                adf4351 = dev
-                break
-
-        if not adf4351:
-            return None
-
-        ch0 = adf4351.find_channel('altvoltage0', True)
-        if not ch0:
-            return None
-
-        return int(ch0.attrs['frequency'].value)
+            name = dev.name or ''
+            if 'adf4351' in name or 'adf4350' in name:
+                ch0 = dev.find_channel('altvoltage0', True)
+                if ch0 and 'frequency' in ch0.attrs:
+                    return int(ch0.attrs['frequency'].value)
+        return None
 
     except Exception:
         return None

--- a/examples/ad9740_dma.py
+++ b/examples/ad9740_dma.py
@@ -6,23 +6,91 @@ Usage:
     python3 ad9740_dma.py -f 1e6 -s 0.5
     python3 ad9740_dma.py --frequency 5000000 --scale 1.0
     python3 ad9740_dma.py -f 1e6 -s 0.5 --device ad9744
+    python3 ad9740_dma.py -f 1e6 -s 1.0 --sample-rate 200e6
 """
 
 import argparse
 import sys
 import numpy as np
 import matplotlib.pyplot as plt
+import iio
 import adi
 
-# Device configuration
+# Device configuration (bits and shift only, sample rate from ADF4351)
 DEVICE_CONFIG = {
-    'ad9748': {'bits': 8,  'shift': 8, 'sample_rate': 210e6},
-    'ad9740': {'bits': 10, 'shift': 6, 'sample_rate': 210e6},
-    'ad9742': {'bits': 12, 'shift': 4, 'sample_rate': 210e6},
-    'ad9744': {'bits': 14, 'shift': 0, 'sample_rate': 210e6},
+    'ad9748': {'bits': 8,  'shift': 8},
+    'ad9740': {'bits': 10, 'shift': 6},
+    'ad9742': {'bits': 12, 'shift': 4},
+    'ad9744': {'bits': 14, 'shift': 0},
 }
 
 DEFAULT_BUFFER_SIZE = 4096
+DEFAULT_SAMPLE_RATE = 210e6
+
+
+def set_sample_rate(uri, sample_rate):
+    """Set the ADF4351 clock frequency (DAC sample rate).
+
+    Args:
+        uri: IIO context URI
+        sample_rate: Desired sample rate in Hz
+
+    Returns:
+        Actual sample rate set, or None if ADF4351 not found
+    """
+    try:
+        ctx = iio.Context(uri)
+
+        adf4351 = None
+        for dev in ctx.devices:
+            if 'adf4351' in dev.name or 'adf4350' in dev.name:
+                adf4351 = dev
+                break
+
+        if not adf4351:
+            return None
+
+        ch0 = adf4351.find_channel('altvoltage0', True)
+        if not ch0:
+            return None
+
+        ch0.attrs['frequency'].value = str(int(sample_rate))
+        return int(ch0.attrs['frequency'].value)
+
+    except Exception as e:
+        print(f"Warning: Could not set sample rate: {e}")
+        return None
+
+
+def get_sample_rate(uri):
+    """Get the current ADF4351 clock frequency (DAC sample rate).
+
+    Args:
+        uri: IIO context URI
+
+    Returns:
+        Current sample rate in Hz, or None if ADF4351 not found
+    """
+    try:
+        ctx = iio.Context(uri)
+
+        adf4351 = None
+        for dev in ctx.devices:
+            if 'adf4351' in dev.name or 'adf4350' in dev.name:
+                adf4351 = dev
+                break
+
+        if not adf4351:
+            return None
+
+        ch0 = adf4351.find_channel('altvoltage0', True)
+        if not ch0:
+            return None
+
+        return int(ch0.attrs['frequency'].value)
+
+    except Exception:
+        return None
 
 
 def check_frequency_valid(frequency, sample_rate, buffer_size):
@@ -66,10 +134,11 @@ def main():
         description='Generate DMA sine wave on AD974x DAC',
         formatter_class=argparse.RawTextHelpFormatter,
         epilog="""Examples:
-  ad9740_dma.py -f 1e6 -s 0.5          # 1 MHz at 50% scale
-  ad9740_dma.py -f 5000000 -s 1.0      # 5 MHz at full scale
-  ad9740_dma.py -f 100e3 -s 0.25       # 100 kHz at 25% scale
-  ad9740_dma.py -f 1e6 --device ad9740 # Use AD9740 device
+  ad9740_dma.py -f 1e6 -s 0.5              # 1 MHz at 50% scale
+  ad9740_dma.py -f 5000000 -s 1.0          # 5 MHz at full scale
+  ad9740_dma.py -f 100e3 -s 0.25           # 100 kHz at 25% scale
+  ad9740_dma.py -f 1e6 --device ad9740     # Use AD9740 device
+  ad9740_dma.py -f 1e6 --sample-rate 200e6 # Set DAC clock to 200 MHz
 
 Valid frequencies for cyclic DMA must result in integer cycles in the buffer.
 Formula: frequency = k * sample_rate / buffer_size (where k is an integer)
@@ -80,19 +149,45 @@ For 210 MHz sample rate and 4096 buffer: valid frequencies are multiples of 51.2
                         help='Output frequency in Hz (default: 1230468.75 Hz)')
     parser.add_argument('-s', '--scale', type=float, default=1.0,
                         help='Output scale 0.0-1.0 (default: 1.0)')
-    parser.add_argument('-u', '--uri', type=str, default='ip:10.48.65.163',
-                        help='Device URI (default: ip:10.48.65.163)')
+    parser.add_argument('-u', '--uri', type=str, default='ip:10.48.65.134',
+                        help='Device URI (default: ip:10.48.65.134)')
     parser.add_argument('-d', '--device', type=str, default='ad9744',
                         choices=['ad9748', 'ad9740', 'ad9742', 'ad9744'],
                         help='DAC device name (default: ad9744)')
     parser.add_argument('-b', '--buffer-size', type=int, default=DEFAULT_BUFFER_SIZE,
                         help=f'DMA buffer size in samples (default: {DEFAULT_BUFFER_SIZE})')
+    parser.add_argument('-r', '--sample-rate', type=float, default=None,
+                        help='DAC sample rate in Hz via ADF4351 (e.g., 210e6)')
 
     args = parser.parse_args()
 
     # Get device config
     config = DEVICE_CONFIG[args.device]
-    sample_rate = config['sample_rate']
+
+    # Set or get sample rate
+    if args.sample_rate is not None:
+        if args.sample_rate <= 0:
+            print(f"Error: Sample rate must be positive, got {args.sample_rate}")
+            sys.exit(1)
+
+        print(f"Setting sample rate to {args.sample_rate/1e6:.3f} MHz...")
+        actual_rate = set_sample_rate(args.uri, args.sample_rate)
+
+        if actual_rate is None:
+            print("Warning: ADF4351 not found, using default sample rate")
+            sample_rate = DEFAULT_SAMPLE_RATE
+        else:
+            sample_rate = actual_rate
+            print(f"Sample rate set to {sample_rate/1e6:.3f} MHz")
+    else:
+        # Get current sample rate from ADF4351
+        current_rate = get_sample_rate(args.uri)
+        if current_rate:
+            sample_rate = current_rate
+            print(f"Current sample rate: {sample_rate/1e6:.3f} MHz")
+        else:
+            sample_rate = DEFAULT_SAMPLE_RATE
+            print(f"Using default sample rate: {sample_rate/1e6:.3f} MHz")
 
     # Validate parameters
     if args.frequency <= 0:
@@ -201,6 +296,7 @@ For 210 MHz sample rate and 4096 buffer: valid frequencies are multiples of 51.2
     info_text = (f"Frequency: {freq_str}\n"
                  f"Scale: {args.scale:.2f}\n"
                  f"Device: {args.device}\n"
+                 f"Sample Rate: {sample_rate/1e6:.1f} MHz\n"
                  f"Cycles: {int(round(num_cycles))}\n"
                  f"Buffer: {args.buffer_size} samples")
     ax.text(0.02, 0.98, info_text, transform=ax.transAxes, fontsize=10,


### PR DESCRIPTION
# Description

Adding pyadi support for the ad9740 DAC family - ad9740, ad9742, ad9744, ad9748

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Tested in hardware with linux support

**Test Configuration**:
* Hardware: Zedboard + eval ad9740 + Scope
* OS: Linux

# Documentation

If this is a new feature or example please mention or link any documentation. All new hardware interface classes require documentation.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
