### PR TITLE
adi: ad4630: Syncup attributes

### DIFF
--- a/adi/ad4630.py
+++ b/adi/ad4630.py
@@ -129,30 +129,6 @@ class ad4630(rx, context_manager, attribute):
         """Set the sampling frequency."""
         self._set_iio_dev_attr("sampling_frequency", str(rate))
 
-    @property
-    def sample_averaging_avail(self):
-        """Get list of all the sample averaging values available. Only available in 30bit averaged mode."""
-        return self._get_iio_dev_attr("sample_averaging_available")
-
-    @property
-    def sample_averaging(self):
-        """Get the sample averaging. Only available in 30bit averaged mode."""
-        return self._get_iio_dev_attr_str("sample_averaging")
-
-    @sample_averaging.setter
-    def sample_averaging(self, n_sample):
-        """Set the sample averaging. Only available in 30bit averaged mode."""
-        if str(self.sample_averaging) != "OFF":
-            if str(n_sample) in str(self.sample_averaging_avail):
-                self._set_iio_dev_attr("sample_averaging", str(n_sample))
-            else:
-                raise ValueError(
-                    "Error: Number of avg samples not supported \nUse one of: "
-                    + str(self.sample_averaging_avail)
-                )
-        else:
-            raise Exception("Sample Averaging only available in 30bit averaged mode.")
-
     class _channel(attribute):
         """AD4x30 differential channel."""
 
@@ -181,6 +157,33 @@ class ad4630(rx, context_manager, attribute):
         def calibscale(self, calibscale):
             """Set calibration scale value."""
             self._set_iio_attr(self.name, "calibscale", False, calibscale, self._ctrl)
+
+        @property
+        def oversampling_ratio_avail(self):
+            """Get list of all the oversampling ratio values available. Only available in 30bit averaged mode."""
+            return self._get_iio_attr(
+                self.name, "oversampling_ratio_available", False, self._ctrl
+            )
+
+        @property
+        def oversampling_ratio(self):
+            """Get the oversampling ratio. Only available in 30bit averaged mode."""
+            return self._get_iio_attr_str(
+                self.name, "oversampling_ratio", False, self._ctrl
+            )
+
+        @oversampling_ratio.setter
+        def oversampling_ratio(self, n_sample):
+            """Set the oversampling ratio. Only available in 30bit averaged mode."""
+            if str(n_sample) in str(self.oversampling_ratio_avail):
+                self._set_iio_attr(
+                    self.name, "oversampling_ratio", False, str(n_sample), self._ctrl,
+                )
+            else:
+                raise ValueError(
+                    "Error: Number of avg samples not supported \nUse one of: "
+                    + str(self.oversampling_ratio_avail)
+                )
 
 
 class adaq42xx(ad4630):

--- a/examples/ad4630/ad4630_example_all_mode.py
+++ b/examples/ad4630/ad4630_example_all_mode.py
@@ -34,9 +34,9 @@ def main():
     adc.rx_buffer_size = N
     adc.sample_rate = fs
 
-    """sample_averaging is only supported by 30bit mode. and in this mode it cannot be OFF."""
+    """oversampling_ratio is only supported by 30bit mode. and in this mode it cannot be OFF."""
     if adc.output_data_mode == "30bit_avg":
-        adc.sample_averaging = 16
+        adc.chan0.oversampling_ratio = 16
 
     """ Prints Current output data mode"""
     print(f"Device: {device_name}, Output mode: {adc.output_data_mode}")

--- a/examples/ad4630/ad4630_example_simple_plot.py
+++ b/examples/ad4630/ad4630_example_simple_plot.py
@@ -22,7 +22,7 @@ adc.rx_buffer_size = 500
 adc.sample_rate = 2000000
 
 try:
-    adc.sample_averaging = 16
+    adc.chan0.oversampling_ratio = 16
 except:
     print("Sample average not supported in this mode")
 


### PR DESCRIPTION
Sync up attribute names with respect to linux driver

# Description

Summarize the change and the motivation. Link the issue this fixes.

Fixes # (issue)

## Type of change

- [ ] Bug fix
- [ ] New device class interface
- [ ] New feature on an existing class
- [ ] Breaking change
- [ ] Documentation only
- [ ] Test or CI only

# How has this been tested?

State explicitly whether this was tested against **real hardware**, an **emulated context** (iio-emu), or **not run**. Name the part(s) and the context URI or board used.

- Hardware / emulation:
- Commands run (e.g. `python3 -m pytest -k ad4080 --adi-hw-map`):
- Result:

**Test configuration**
* Kernel / libiio version:
* OS:
* FPGA carrier (if applicable):

# Documentation

- [ ] No documentation change needed
- [ ] Updated existing docs under `doc/source/`
- [ ] Added a new device page and linked it from the relevant toctree

# New device class interfaces

Skip this section if the PR does not add a new device class.

- [ ] Class extends one of the common base classes in `adi.device_base` (`rx_chan_comp`, `tx_chan_comp`, or a `_no_buff` variant). If not, explain why in the description. See the [Device Base Classes](https://analogdevicesinc.github.io/pyadi-iio/dev/device_base.html) developer doc page.
- [ ] `compatible_parts` lists every part number this class supports
- [ ] Part numbers added to `supported_parts.md` (verify with `invoke checkparts`)
- [ ] Emulation context (xml_gen, not iio_genxml) added under `test/emu/` and referenced from a test
- [ ] Tests added that run against the emulation context in CI

# Checklist

- [ ] `invoke precommit` passes locally
- [ ] All commits are signed off (`Signed-off-by: Name <email>`)
- [ ] No new warnings from the build or doc generation
- [ ] Dependent changes in libiio, kernel, or HDL are merged and referenced
