### PR TITLE
adi:compat: Fix channel enabling for tx device

### DIFF
--- a/adi/compat.py
+++ b/adi/compat.py
@@ -174,6 +174,12 @@ class compat_libiio_v0_tx:
     """Compatibility class for libiio v0.X TX."""
 
     def _tx_init_channels(self):
+        for m in self._tx_channel_names:
+            v = self._txdac.find_channel(m, True)
+            if not v:
+                raise Exception(f"Channel {m} not found")
+            v.enabled = False
+
         if self._complex_data:
             for m in self.tx_enabled_channels:
                 v = self._txdac.find_channel(self._tx_channel_names[m * 2], True)


### PR DESCRIPTION
# Description

For Tx Device (DAC), previously enabled channels are not getting disabled when new set of channels are enabled in subsequent session.

Fixes # (issue)

## Type of change

- [x] Bug fix
- [ ] New device class interface
- [ ] New feature on an existing class
- [ ] Breaking change
- [ ] Documentation only
- [ ] Test or CI only

# How has this been tested?

This has been tested on a DAC hardware. Steps followed:
1. Enable channel 0 and perform data streaming.
2. Enable channel 1 for data streaming. At this point, both the channels 0,1 are active.

Commands:
```Python
# Channel 0
dev.tx_enabled_channels = ["voltage0"]
dev.tx(data)
dev.tx_destroy_buffer()

# Channel 1
dev.tx_enabled_channels = ["voltage1"]
dev.tx(data) # At this point, IIO firmware gets channel mask as 0x11
dev.tx_destroy_buffer()
```

**Test configuration**
* libiio version: 0.26
* OS: Windows
* FPGA carrier (if applicable):

# Documentation

- [ ] No documentation change needed
- [ ] Updated existing docs under `doc/source/`
- [ ] Added a new device page and linked it from the relevant toctree

# New device class interfaces

Skip this section if the PR does not add a new device class.

- [ ] Class extends one of the common base classes in `adi.device_base` (`rx_chan_comp`, `tx_chan_comp`, or a `_no_buff` variant). If not, explain why in the description. See the [Device Base Classes](https://analogdevicesinc.github.io/pyadi-iio/dev/device_base.html) developer doc page.
- [ ] `compatible_parts` lists every part number this class supports
- [ ] Part numbers added to `supported_parts.md` (verify with `invoke checkparts`)
- [ ] Emulation context (xml_gen, not iio_genxml) added under `test/emu/` and referenced from a test
- [ ] Tests added that run against the emulation context in CI

# Checklist

- [ ] `invoke precommit` passes locally
- [x] All commits are signed off (`Signed-off-by: Name <email>`)
- [ ] No new warnings from the build or doc generation
- [ ] Dependent changes in libiio, kernel, or HDL are merged and referenced
