### PR TITLE
compat: update v1 RX/TX classes for new libiio multi buffer API

### DIFF
--- a/adi/compat.py
+++ b/adi/compat.py
@@ -40,11 +40,12 @@ class compat_libiio_v1_rx:
 
         self._rx_buffer_mask.channels = channels
 
-        self._rxbuf = iio.Buffer(self._rxadc, self._rx_buffer_mask)
+        self._rxbuf = self._rxadc.get_buffer()
         self._rx_stream = iio.Stream(
             buffer=self._rxbuf,
-            nb_blocks=self._rx_buffer_num_blocks,
+            mask=self._rx_buffer_mask,
             samples_count=self.rx_buffer_size,
+            nb_blocks=self._rx_buffer_num_blocks,
         )
 
     def _rx_buffered_data(self):
@@ -72,6 +73,7 @@ class compat_libiio_v1_tx:
     _tx_stream = None
     _tx_buffer_num_blocks = 4
     _tx_block = None
+    _tx_buf_stream = None
 
     def _tx_init_channels(self):
         if not self._tx_buffer_mask:
@@ -91,15 +93,17 @@ class compat_libiio_v1_tx:
 
         self._tx_buffer_mask.channels = channels
 
-        self._txbuf = iio.Buffer(self._txdac, self._tx_buffer_mask)
+        self._txbuf = self._txdac.get_buffer()
         if not self._tx_cyclic_buffer:
             self._tx_stream = iio.Stream(
                 buffer=self._txbuf,
-                nb_blocks=self._tx_buffer_num_blocks,
+                mask=self._tx_buffer_mask,
                 samples_count=self._tx_buffer_size,
+                nb_blocks=self._tx_buffer_num_blocks,
             )
         else:
-            self._tx_block = iio.Block(self._txbuf, self._tx_buffer_size)
+            self._tx_buf_stream = self._txbuf.open(self._tx_buffer_mask)
+            self._tx_block = iio.Block(self._tx_buf_stream, self._tx_buffer_size)
 
     def _tx_buffer_push(self, data):
         """Push data to TX buffer.
@@ -109,7 +113,7 @@ class compat_libiio_v1_tx:
         if self._tx_cyclic_buffer:
             self._tx_block.write(data)
             self._tx_block.enqueue(None, self._tx_cyclic_buffer)
-            self._txbuf.enabled = True
+            self._tx_buf_stream.started = True
         else:
             block = next(self._tx_stream)
             block.write(data)


### PR DESCRIPTION
# Description

Update the libiio v1 compatibility classes (`compat_libiio_v1_rx` and `compat_libiio_v1_tx` in `adi/compat.py`) to work with the new libiio multi-buffer API.

The libiio v1 Python bindings changed how buffers are created and opened. `Buffer` is no longer constructed by the user with a device and mask, it is now a pre-existing hardware object retrieved via `device.get_buffer()`. The channel mask is applied separately when opening a stream over the buffer via `iio_buffer_open()`. As a result, `Stream` now requires `mask` as an explicit argument, `Block` must be created from a `BufferStream` instead of a `Buffer`, and `buffer.enabled` is replaced by `buf_stream.started`.

Note: I am not very familiar with Python so a second opinion on the implementation would be welcome, but the changes have been tested on real hardware and behave correctly end to end.


## Type of change

- [x] Bug fix

# How has this been tested?

Tested on an ADALM-PLUTO with a loopback cable between TX and RX, against libiio build `1aa9ef29`. `examples/pluto.py` was run and produced 20 consecutive RX buffers correctly with the signal settling after the first few AGC buffers.

To confirm the new multi-buffer API was actually used, `iio.version` reported `(1, 0, '1aa9ef29')` and `sdr._rxadc.get_buffer()` returned a valid `Buffer` object — `get_buffer()` does not exist on pylibiio 0.26 so its presence proves the new path was taken.

- Hardware / emulation: ADALM-PLUTO with a loopback cable between TX and RX
- Result: RX stream and TX cyclic passed across 20 consecutive buffers

**Test configuration**
* Kernel / libiio version: libiio `1aa9ef29` (multi-buffer build), kernel `6.6.114.1-microsoft-standard-WSL2`
* OS: Ubuntu on WSL2

# Documentation

- [x] No documentation change needed

# Checklist

- [x] `invoke precommit` passes locally
- [x] All commits are signed off (`Signed-off-by: Marius Lucacel <marius.lucacel@analog.com>`)
- [ ] Dependent changes in libiio, kernel, or HDL are merged and referenced
