### PR TITLE
feat(hw): recovery dispatch workflow + zc706 wiring

### DIFF
--- a/.github/recovery-config.yml
+++ b/.github/recovery-config.yml
@@ -1,0 +1,86 @@
+# Per-place recovery configuration for the hardware-recover workflow.
+#
+# The recover-place.py dispatcher reads this file. Each entry under
+# `places:` is keyed by the labgrid place name and contains the
+# synthesized labgrid env yaml that the place's recovery strategy needs.
+#
+# Boards without a recovery strategy don't appear here — the dispatcher
+# will print "no recovery defined" and exit cleanly. Boards whose
+# strategy is wired but whose artifacts aren't staged yet can leave
+# their block empty (the dispatcher logs a clear skip-with-reason).
+#
+# Reference: labgrid-plugins/examples/zynq7000_recovery/lg_zc706_recovery.yaml
+# Strategy:  adi_lg_plugins.strategies.BootZynq7000JTAGRecovery
+#
+# Once you populate a place block, run:
+#   gh workflow run hardware-recover.yml -f place=<name>
+
+places: {}
+
+# Worked example (commented out — uncomment and fill in to enable bq recovery).
+# Operator must first stage artifacts on the runner host:
+#   /tmp/recovery/{ps7_init.tcl, u-boot.elf}
+#   /tmp/bootgen_extract/system_top.bit
+#   /var/lib/tftpboot/{uImage, devicetree.dtb, uInitrd.recovery}
+#   /tmp/kuiper_cache/2025-03-18-ADI-Kuiper-full.img
+#
+# places:
+#   bq:
+#     env_yaml: |
+#       targets:
+#         main:
+#           features: [adrv9371, zc706, jtag-recovery]
+#           resources:
+#             HomeAssistantOutlet:
+#               url: 'http://10.0.0.24:8123'
+#               token: 'REPLACE_WITH_TOKEN'
+#               entity_id: 'switch.board_0_socket_1'
+#             RawSerialPort:
+#               port: /dev/serial/by-id/usb-Silicon_Labs_CP2103_USB_to_UART_Bridge_Controller_0001-if00-port0
+#               speed: 115200
+#             NetworkService:
+#               address: 10.0.0.23
+#               username: root
+#               password: analog
+#             TFTPServerResource:
+#               address: '10.0.0.41'
+#               port: 3069
+#               root: /var/lib/tftpboot
+#             XilinxDeviceJTAG:
+#               root_target: 1
+#             XilinxVivadoTool:
+#               vivado_path: /opt/Xilinx/Vivado/2023.2
+#               xsdb_path: /opt/Xilinx/Vivado/2023.2/bin/xsdb
+#               version: '2023.2'
+#           drivers:
+#             HomeAssistantPowerDriver: {}
+#             SerialDriver: {}
+#             TFTPServerDriver: {}
+#             XilinxJTAGDriver: {}
+#             ADIShellDriver:
+#               prompt: 'root@.*[#$]'
+#               login_prompt: '(analog|recovery) login: ?'
+#               username: 'root'
+#               password: 'analog'
+#             BootZynq7000JTAGRecovery:
+#               ps7_init_tcl: /tmp/recovery/ps7_init.tcl
+#               uboot_elf: /tmp/recovery/u-boot.elf
+#               bitstream_path: /tmp/bootgen_extract/system_top.bit
+#               a9_target_name: '*Cortex-A9 MPCore #0'
+#               recovery_kernel: 'uImage'
+#               recovery_dtb: 'devicetree.dtb'
+#               recovery_initramfs: 'uInitrd.recovery'
+#               recovery_login_marker: 'recovery login:'
+#               sd_image_path: '/tmp/kuiper_cache/2025-03-18-ADI-Kuiper-full.img'
+#               sd_device: '/dev/mmcblk0'
+#               download_cmd_template: 'wget -q -O - "{url}"'
+#               board_variant: 'zynq-zc706-adv7511-adrv937x'
+#               uboot_prompt: 'Zynq>.*'
+#               kernel_addr: '0x3000000'
+#               dtb_addr: '0x2A00000'
+#               initramfs_addr: '0x10000000'
+#               bootargs: 'console=ttyPS0,115200 earlyprintk loglevel=8 rdinit=/init'
+#               jtag_bootstrap_retries: 1
+#               wait_for_uboot_prompt_timeout: 90
+#               wait_for_recovery_linux_timeout: 240
+#               wait_for_sd_flash_timeout: 1800

--- a/.github/scripts/recover-place.py
+++ b/.github/scripts/recover-place.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Dispatch hardware recovery for a labgrid place.
+
+Looks up the place's `daughter-board` tag on the coordinator, then runs
+the per-board recovery routine. Boards that don't yet have a recovery
+strategy print "no recovery defined" and exit 0 — that's intentional;
+the scaffold is built out as strategies become available.
+
+Today's coverage:
+    zc706 + adrv9371  →  adi_lg_plugins.strategies.BootZynq7000JTAGRecovery
+                         (consumes recovery-config.yml under .github/)
+
+Usage:
+    LG_COORDINATOR=10.0.0.41:20408 recover-place.py <place> [target_state]
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import sys
+import tempfile
+import urllib.request
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+RECOVERY_CONFIG = REPO_ROOT / ".github" / "recovery-config.yml"
+
+
+def _coord_api_base() -> str:
+    coord = os.environ.get("LG_COORDINATOR") or os.environ.get("ADI_LG_COORDINATOR", "")
+    if not coord:
+        raise SystemExit("LG_COORDINATOR not set (expected host:port for the gRPC coord)")
+    host = coord.split(":")[0]
+    return f"http://{host}:8000"
+
+
+def _fetch_place(name: str) -> dict:
+    url = f"{_coord_api_base()}/api/places/{name}"
+    with urllib.request.urlopen(url, timeout=15) as resp:
+        return json.load(resp)
+
+
+def _load_recovery_config() -> dict:
+    if not RECOVERY_CONFIG.exists():
+        return {}
+    import yaml
+    return yaml.safe_load(RECOVERY_CONFIG.read_text()) or {}
+
+
+def _no_recovery(place_name: str, board: str | None) -> int:
+    print(
+        f"[recover-place] no recovery strategy defined for "
+        f"place={place_name!r} board={board!r}; nothing to do.",
+        file=sys.stderr,
+    )
+    return 0
+
+
+def _zc706_recovery(place_name: str, board: str, target_state: str, config: dict) -> int:
+    """Run BootZynq7000JTAGRecovery against the place.
+
+    The strategy needs a *full* labgrid env with explicit JTAG/TFTP
+    resources — RemotePlace can't supply XilinxDeviceJTAG /
+    TFTPServerResource if the exporter hasn't registered them. We
+    materialize an env from recovery-config.yml's per-place override
+    block, falling back to the RemotePlace shape for whatever resources
+    are exported. Operator prereqs (Vivado/xsdb, Digilent drivers,
+    TFTP root, BOOT.BIN-extracted artifacts) are documented in
+    labgrid-plugins/examples/zynq7000_recovery/lg_zc706_recovery.yaml.
+    """
+    place_cfg = (config.get("places") or {}).get(place_name)
+    if not place_cfg:
+        print(
+            f"[recover-place] {place_name!r}: zc706 recovery requires a per-place "
+            f"block in {RECOVERY_CONFIG.relative_to(REPO_ROOT)} with paths to "
+            "ps7_init.tcl / u-boot.elf / bitstream / SD image. Skipping until "
+            "the operator stages those artifacts.",
+            file=sys.stderr,
+        )
+        return 0
+
+    env_yaml = place_cfg.get("env_yaml")
+    if not env_yaml:
+        print(
+            f"[recover-place] {place_name!r}: missing `env_yaml` in recovery-config.yml. "
+            "See labgrid-plugins/examples/zynq7000_recovery/ for a working template.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Stage the env yaml to a temp file and hand to labgrid.
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", prefix=f"recovery-{place_name}-", delete=False
+    ) as f:
+        f.write(env_yaml)
+        env_path = f.name
+
+    try:
+        from labgrid.environment import Environment
+        from labgrid.strategy import Strategy
+    except ImportError as exc:
+        print(f"[recover-place] labgrid not importable: {exc}", file=sys.stderr)
+        return 1
+
+    env = Environment(env_path)
+    target = env.get_target("main")
+    strategy = target.get_driver(Strategy)
+    print(f"[recover-place] running {type(strategy).__name__}.transition({target_state!r})...")
+    strategy.transition(target_state)
+    print(f"[recover-place] {place_name!r}: recovery complete ({target_state}).")
+    return 0
+
+
+# board name (from coordinator daughter-board tag) → handler.
+# Add new entries as recovery strategies become available.
+HANDLERS = {
+    "adrv9371": _zc706_recovery,  # zc706 + adrv9371 (e.g. bq)
+}
+
+
+def main() -> int:
+    args = sys.argv[1:]
+    if not args:
+        print("usage: recover-place.py <place> [target_state]", file=sys.stderr)
+        return 2
+    place_name = args[0]
+    target_state = args[1] if len(args) >= 2 else "sd_boot_verified"
+
+    place = _fetch_place(place_name)
+    board = (place.get("tags") or {}).get("daughter-board")
+    handler = HANDLERS.get(board)
+    if handler is None:
+        return _no_recovery(place_name, board)
+
+    config = _load_recovery_config()
+    return handler(place_name, board, target_state, config)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/recover-place.py
+++ b/.github/scripts/recover-place.py
@@ -30,7 +30,9 @@ RECOVERY_CONFIG = REPO_ROOT / ".github" / "recovery-config.yml"
 def _coord_api_base() -> str:
     coord = os.environ.get("LG_COORDINATOR") or os.environ.get("ADI_LG_COORDINATOR", "")
     if not coord:
-        raise SystemExit("LG_COORDINATOR not set (expected host:port for the gRPC coord)")
+        raise SystemExit(
+            "LG_COORDINATOR not set (expected host:port for the gRPC coord)"
+        )
     host = coord.split(":")[0]
     return f"http://{host}:8000"
 
@@ -45,6 +47,7 @@ def _load_recovery_config() -> dict:
     if not RECOVERY_CONFIG.exists():
         return {}
     import yaml
+
     return yaml.safe_load(RECOVERY_CONFIG.read_text()) or {}
 
 
@@ -57,7 +60,9 @@ def _no_recovery(place_name: str, board: str | None) -> int:
     return 0
 
 
-def _zc706_recovery(place_name: str, board: str, target_state: str, config: dict) -> int:
+def _zc706_recovery(
+    place_name: str, board: str, target_state: str, config: dict
+) -> int:
     """Run BootZynq7000JTAGRecovery against the place.
 
     The strategy needs a *full* labgrid env with explicit JTAG/TFTP
@@ -106,7 +111,9 @@ def _zc706_recovery(place_name: str, board: str, target_state: str, config: dict
     env = Environment(env_path)
     target = env.get_target("main")
     strategy = target.get_driver(Strategy)
-    print(f"[recover-place] running {type(strategy).__name__}.transition({target_state!r})...")
+    print(
+        f"[recover-place] running {type(strategy).__name__}.transition({target_state!r})..."
+    )
     strategy.transition(target_state)
     print(f"[recover-place] {place_name!r}: recovery complete ({target_state}).")
     return 0

--- a/.github/workflows/hardware-recover.yml
+++ b/.github/workflows/hardware-recover.yml
@@ -1,0 +1,104 @@
+name: Hardware Recovery (GHA)
+
+# Manual hardware recovery for a single labgrid place.
+#
+# When a DUT is quarantined via `disabled=<reason>` on the coordinator
+# (see hw-matrix dynamic_mode), the operator can run this workflow to
+# reach the corresponding recovery strategy. Today only ZC706-class
+# boards (BootZynq7000JTAGRecovery) have a wired recovery path; the
+# dispatcher prints "no recovery defined" for any other board and
+# exits 0 — the scaffold is here so new strategies plug in by adding
+# an entry to .github/scripts/recover-place.py:HANDLERS.
+#
+# Prerequisites the operator must stage before triggering this for
+# a ZC706 board (see labgrid-plugins/examples/zynq7000_recovery/
+# lg_zc706_recovery.yaml for the canonical reference):
+#   * Vivado/xsdb on PATH on the recovery runner.
+#   * Digilent JTAG drivers + udev rule unbinding ftdi_sio from
+#     the FT232H so xsdb can claim it.
+#   * ps7_init.tcl / u-boot.elf / FPGA bitstream extracted from a
+#     known-good BOOT.BIN (`bootgen -arch zynq -read BOOT.BIN`).
+#   * TFTP root populated with uImage, devicetree.dtb, and either a
+#     pre-built uInitrd.recovery or the busybox source for the
+#     auto-build path.
+#   * The Kuiper SD image at the path referenced by recovery-config.yml.
+#   * A per-place block in .github/recovery-config.yml with the
+#     synthesized labgrid env yaml. Leave the block missing to
+#     dry-run / skip cleanly.
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      place:
+        description: 'Labgrid place to recover (e.g. bq)'
+        required: true
+        type: string
+      target_state:
+        description: 'Recovery strategy state to drive to'
+        required: false
+        default: 'sd_boot_verified'
+        type: choice
+        options:
+          - powered_off
+          - powered_on
+          - jtag_bootstrap
+          - uboot_prompt
+          - tftp_recovery_kernel
+          - linux_recovery
+          - sd_flash_done
+          - sd_boot_verified
+
+jobs:
+  recover:
+    runs-on: [self-hosted, hw-coordinator]
+    timeout-minutes: 45
+    env:
+      LG_COORDINATOR: ${{ vars.ADI_LG_COORDINATOR }}
+      VENV_DIR: $HOME/.cache/hw-ci/recovery-venv
+    concurrency:
+      group: hw-place-${{ vars.ADI_LG_COORDINATOR }}-${{ inputs.place }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup uv venv
+        uses: tfcollins/labgrid-plugins/.github/actions/setup-uv-venv@main
+        with:
+          venv_dir: ${{ env.VENV_DIR }}
+          install_cmd: |
+            set -euo pipefail
+            uv pip install --quiet --python "$VENV_DIR/bin/python" PyYAML
+            uv pip install --quiet --python "$VENV_DIR/bin/python" \
+              "adi-labgrid-plugins[kuiper] @ git+https://github.com/tfcollins/labgrid-plugins.git"
+
+      - name: Acquire place
+        uses: tfcollins/labgrid-plugins/.github/actions/acquire-place@main
+        with:
+          coordinator: ${{ vars.ADI_LG_COORDINATOR }}
+          place: ${{ inputs.place }}
+          labgrid_client: ${{ env.VENV_DIR }}/bin/labgrid-client
+          wait_minutes: 30
+
+      - name: Dispatch recovery
+        env:
+          LG_COORDINATOR: ${{ vars.ADI_LG_COORDINATOR }}
+          PLACE: ${{ inputs.place }}
+          TARGET_STATE: ${{ inputs.target_state }}
+        run: |
+          set -euo pipefail
+          "$VENV_DIR/bin/python" .github/scripts/recover-place.py "$PLACE" "$TARGET_STATE"
+
+      - name: Release place
+        if: always()
+        env:
+          LG_COORDINATOR: ${{ vars.ADI_LG_COORDINATOR }}
+        run: |
+          set -euo pipefail
+          LGCLIENT="$VENV_DIR/bin/labgrid-client"
+          if [[ -x "$LGCLIENT" ]]; then
+            "$LGCLIENT" -x "$LG_COORDINATOR" -p "${{ inputs.place }}" release || true
+            "$LGCLIENT" -x "$LG_COORDINATOR" cancel-reservation --all 2>/dev/null || true
+          fi


### PR DESCRIPTION
Adds a manual ``Hardware Recovery (GHA)`` workflow keyed on a labgrid place name. The dispatcher looks up the place's ``daughter-board`` tag on the coordinator and routes to a per-board recovery handler.

## Why a separate small PR

GitHub Actions only honors ``workflow_dispatch`` when the workflow file exists on the **default branch**. Cherry-picking just the recovery scaffold (3 files, 331 lines) onto main first makes the trigger invokable; the larger ``feature/gha-hw-workflow`` rollout will pick it up transitively.

## Today's coverage

- ``adrv9371`` (zc706 carrier) → ``adi_lg_plugins.strategies.BootZynq7000JTAGRecovery``
- everything else → prints ``no recovery defined`` and exits 0

New boards plug in by adding an entry to ``HANDLERS`` in ``.github/scripts/recover-place.py`` — no workflow changes needed.

## Verified

- ``yaml.safe_load`` parses both the workflow and ``recovery-config.yml``
- ``ast.parse`` clean on the dispatcher
- Dispatcher dry-run against the live coordinator (10.0.0.41:8000):
  - ``recover-place.py nuc`` → ``no recovery strategy defined for place='nuc' board='daq3'`` (exit 0)
  - ``recover-place.py bq`` → ``'bq': zc706 recovery requires a per-place block ... Skipping until the operator stages those artifacts.`` (exit 0)

## Operator prereqs before bq recovery can run end-to-end

Documented inline in ``.github/recovery-config.yml`` and ``labgrid-plugins/examples/zynq7000_recovery/lg_zc706_recovery.yaml``:

- Vivado/xsdb on the recovery runner
- Digilent JTAG drivers + udev rule unbinding ``ftdi_sio`` from the FT232H
- ``ps7_init.tcl`` / ``u-boot.elf`` / ``system_top.bit`` extracted via ``bootgen``
- TFTP root with ``uImage`` / ``devicetree.dtb`` / ``uInitrd.recovery``
- Kuiper SD image staged
- ``places.bq.env_yaml`` block populated in ``recovery-config.yml`` (currently shipped as commented-out template)

## Test plan
- [x] dispatcher exit 0 on both code paths against live coordinator
- [ ] after merge: ``gh workflow run hardware-recover.yml -f place=bq`` reaches the dispatcher
- [ ] once bq artifacts are staged: full recovery run drives ``BootZynq7000JTAGRecovery`` to ``sd_boot_verified``