### PR TITLE
feat(hw): power down the DUT after labgrid tests finish

### DIFF
--- a/.github/scripts/power-off-dut.py
+++ b/.github/scripts/power-off-dut.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Power off the DUT referenced by ``LG_ENV`` (best-effort test teardown).
+
+Run at the end of a hw-matrix leg's pytest step, while the place is still
+acquired, so the board is left powered down once labgrid tests finish.
+Tries each known power driver in turn; if none is bound, or power-off
+fails, it logs and exits 0 — teardown must never turn a green run red.
+
+Mirrors the resource shapes the coordinator generates: the ZC706 places
+expose ``HomeAssistantPowerDriver`` and the ZCU102/VCU118 places expose
+``VesyncPowerDriver``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Order doesn't matter — only one is bound per target — but list the
+# drivers actually used across the lab first.
+POWER_DRIVERS = (
+    "HomeAssistantPowerDriver",
+    "VesyncPowerDriver",
+    "NetworkPowerDriver",
+    "USBPowerDriver",
+)
+
+
+def main() -> int:
+    lg_env = os.environ.get("LG_ENV")
+    if not lg_env:
+        print("[power-off] LG_ENV not set; nothing to power off", file=sys.stderr)
+        return 0
+
+    try:
+        from labgrid.environment import Environment
+    except ImportError as exc:
+        print(f"[power-off] labgrid not importable: {exc}", file=sys.stderr)
+        return 0
+
+    try:
+        target = Environment(lg_env).get_target("main")
+    except Exception as exc:
+        print(f"[power-off] could not load target from LG_ENV: {exc}", file=sys.stderr)
+        return 0
+
+    driver = None
+    chosen = None
+    for name in POWER_DRIVERS:
+        try:
+            driver = target.get_driver(name)
+        except Exception:
+            driver = None
+        if driver is not None:
+            chosen = name
+            break
+
+    if chosen is None:
+        print("[power-off] no power driver bound to target; skipping", file=sys.stderr)
+        return 0
+
+    try:
+        target.activate(driver)
+        driver.off()
+        print(f"[power-off] DUT powered off via {chosen}", file=sys.stderr)
+    except Exception as exc:
+        print(f"[power-off] {chosen}.off() failed: {exc}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/hardware-test.yml
+++ b/.github/workflows/hardware-test.yml
@@ -8,6 +8,7 @@ name: Hardware Tests (GHA)
 #
 # Triggered by:
 #   * workflow_dispatch (manual)
+#   * push to `main` — validate hardware on every landed change
 #   * PRs labeled `hw-test` — keeps every push from burning lab time
 #   * Nightly cron at 08:00 UTC
 
@@ -18,6 +19,8 @@ permissions:
 
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
   pull_request:
     types: [labeled, opened, synchronize, reopened]
   schedule:

--- a/.github/workflows/hardware-test.yml
+++ b/.github/workflows/hardware-test.yml
@@ -67,6 +67,11 @@ jobs:
       # pytest-libiio from running its crashing avahi scan at collection.
       pytest_cmd_template: |
         set -euo pipefail
+        # Power the DUT down once tests finish — on pass, on pytest failure
+        # (set -e exit), or if boot/discovery never completed. Runs while the
+        # place is still acquired (the Release step is separate). Best-effort:
+        # power-off-dut.py never fails the leg, and `|| true` guards the trap.
+        trap '"$VENV_DIR/bin/python" .github/scripts/power-off-dut.py || true' EXIT
         # tail -1: boot-and-discover-uri.py prints `ip:<addr>` as its last line,
         # but adi_lg_plugins/drivers/shelldriver.py:_run_uboot leaks debug
         # prints to stdout while the BootZynq7000JTAGRecovery strategy issues


### PR DESCRIPTION
## Summary
- Add `.github/scripts/power-off-dut.py` — loads `LG_ENV`, finds the bound power driver (HomeAssistant on the ZC706 places, Vesync on ZCU102/VCU118), and powers the board off. Best-effort: never fails the leg.
- Invoke it from the `pytest_cmd_template` via an `EXIT` trap, so the DUT is powered down once tests finish — on pass, on pytest failure (`set -e` exit), or if boot/discovery never completed. Runs while the place is still acquired, before the Release step.

## Test plan
- [x] `power-off-dut.py` powers off bq (HomeAssistantPowerDriver) — verified outlet `get()` → False
- [x] `power-off-dut.py` powers off mini2 (VesyncPowerDriver)
- [x] bandit + pre-commit clean
- [ ] HW CI legs leave each board powered down after the run