### PR TITLE
ci(hw): rename caller job hw -> hardware

### DIFF
--- a/.github/workflows/hardware-test.yml
+++ b/.github/workflows/hardware-test.yml
@@ -27,7 +27,7 @@ on:
     - cron: "0 8 * * *"
 
 jobs:
-  hw:
+  hardware:
     if: >-
       github.event_name != 'pull_request' ||
       contains(github.event.pull_request.labels.*.name, 'hw-test')


### PR DESCRIPTION
## Summary
- Rename the sole hardware-test caller job `hw` -> `hardware`. The job id is the check-name prefix, so leg checks become `hardware / hw-dynamic (<board> / <carrier>)` instead of `hw / hw-dynamic (...)`.
- No other change; the job is not referenced by any `needs`/outputs.

## Test plan
- [ ] PR checks render as `hardware / hw-dynamic (<board> / <carrier>)`