### PR TITLE
feat(hw): upload HW test results to local Prism at rpi5.local

### DIFF
--- a/.github/scripts/_prism_client.py
+++ b/.github/scripts/_prism_client.py
@@ -1,0 +1,190 @@
+"""Stdlib-only HTTP client for the Prism API.
+
+Shared by the other scripts in this directory (`seed_demo.py`,
+`upload_run.py`) so the login + CSRF + multipart dance lives in exactly
+one place. No external dependencies — works anywhere Python 3.10+ is
+installed (CI runners included).
+
+Session state (auth + CSRF cookies) is held in an in-memory cookie jar
+so all subsequent `self._request` calls automatically carry the login
+cookie and, for mutations, the `X-Prism-Csrf` header.
+"""
+
+from __future__ import annotations
+
+import http.cookiejar
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+
+__all__ = ["PrismClient"]
+
+
+class PrismClient:
+    def __init__(self, base_url: str) -> None:
+        # Reject non-http(s) schemes up front so the noqa: S310 below is true.
+        # urllib's default opener handles file://, ftp://, data://, etc., which
+        # an attacker who can set PRISM_URL could abuse for local-file
+        # disclosure / SSRF. See ruff S310. This guard must mirror the one in
+        # clients/python-pytest/src/pytest_prism/client.py since this file is
+        # the vendoring source for pyadi-iio's prism-report plugin.
+        scheme = urllib.parse.urlsplit(base_url).scheme.lower()
+        if scheme not in ("http", "https"):
+            raise ValueError(
+                f"PrismClient base_url must be http or https; got scheme {scheme!r}"
+            )
+        self.base_url = base_url.rstrip("/")
+        self.jar = http.cookiejar.CookieJar()
+        self.opener = urllib.request.build_opener(
+            urllib.request.HTTPCookieProcessor(self.jar)
+        )
+
+    # --------------------------------------------------------------------- #
+    # Low-level request plumbing
+    # --------------------------------------------------------------------- #
+
+    def _read_cookie(self, name: str) -> str | None:
+        for c in self.jar:
+            if c.name == name:
+                return c.value
+        return None
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        body: bytes | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> tuple[int, bytes]:
+        url = f"{self.base_url}{path}"
+        # base_url's scheme is validated to http/https in __init__, so this is safe.
+        req = urllib.request.Request(
+            url, data=body, method=method, headers=headers or {}
+        )  # noqa: S310
+        csrf = self._read_cookie("prism_csrf")
+        if csrf and method in ("POST", "PUT", "PATCH", "DELETE"):
+            req.add_header("X-Prism-Csrf", csrf)
+        try:
+            with self.opener.open(req) as resp:
+                return resp.status, resp.read()
+        except urllib.error.HTTPError as exc:
+            return exc.code, exc.read()
+
+    # --------------------------------------------------------------------- #
+    # Auth
+    # --------------------------------------------------------------------- #
+
+    def login(self, email: str, password: str) -> None:
+        payload = json.dumps({"email": email, "password": password}).encode("utf-8")
+        code, body = self._request(
+            "POST",
+            "/api/v1/auth/login",
+            body=payload,
+            headers={"Content-Type": "application/json"},
+        )
+        if code != 200:
+            raise RuntimeError(f"login failed: HTTP {code} {body!r}")
+
+    # --------------------------------------------------------------------- #
+    # Projects
+    # --------------------------------------------------------------------- #
+
+    def ensure_project(self, slug: str, name: str, description: str = "") -> None:
+        """Create the project if it doesn't exist. 409 (already exists) is fine."""
+        payload = json.dumps(
+            {"slug": slug, "name": name, "description": description}
+        ).encode("utf-8")
+        code, body = self._request(
+            "POST",
+            "/api/v1/projects",
+            body=payload,
+            headers={"Content-Type": "application/json"},
+        )
+        if code not in (201, 409):
+            raise RuntimeError(f"project create failed: HTTP {code} {body!r}")
+
+    def project_exists(self, slug: str) -> bool:
+        code, _ = self._request("GET", f"/api/v1/projects/{urllib.parse.quote(slug)}")
+        return code == 200
+
+    # --------------------------------------------------------------------- #
+    # Runs
+    # --------------------------------------------------------------------- #
+
+    def list_runs(self, project_slug: str) -> list[dict[str, object]]:
+        code, body = self._request(
+            "GET", f"/api/v1/runs?project={urllib.parse.quote(project_slug)}"
+        )
+        if code != 200:
+            raise RuntimeError(f"list runs failed: HTTP {code} {body!r}")
+        result: list[dict[str, object]] = json.loads(body)
+        return result
+
+    def get_run(self, run_id: str) -> dict[str, object]:
+        code, body = self._request("GET", f"/api/v1/runs/{urllib.parse.quote(run_id)}")
+        if code != 200:
+            raise RuntimeError(f"get run failed: HTTP {code} {body!r}")
+        result: dict[str, object] = json.loads(body)
+        return result
+
+    def delete_run(self, run_id: str) -> None:
+        code, body = self._request(
+            "DELETE", f"/api/v1/runs/{urllib.parse.quote(run_id)}"
+        )
+        if code not in (204, 404):
+            raise RuntimeError(f"delete run failed: HTTP {code} {body!r}")
+
+    def upload_run(
+        self,
+        *,
+        project_slug: str,
+        run_name: str,
+        junit_xml: bytes,
+        archive_zip: bytes | None = None,
+        tags: dict[str, str] | None = None,
+    ) -> dict[str, object]:
+        """POST /api/v1/runs with a hand-built multipart body.
+
+        Returns the parsed JSON response (includes run `id` + initial `status`).
+        Raises RuntimeError on any non-201.
+        """
+        boundary = f"----prism{uuid.uuid4().hex}"
+        parts: list[bytes] = []
+
+        def _add_field(name: str, value: str) -> None:
+            parts.append(f"--{boundary}\r\n".encode())
+            parts.append(
+                f'Content-Disposition: form-data; name="{name}"\r\n\r\n'.encode()
+            )
+            parts.append(value.encode("utf-8"))
+            parts.append(b"\r\n")
+
+        def _add_file(
+            name: str, filename: str, content_type: str, content: bytes
+        ) -> None:
+            parts.append(f"--{boundary}\r\n".encode())
+            parts.append(
+                f'Content-Disposition: form-data; name="{name}"; filename="{filename}"\r\n'.encode()
+            )
+            parts.append(f"Content-Type: {content_type}\r\n\r\n".encode())
+            parts.append(content)
+            parts.append(b"\r\n")
+
+        metadata = {"project_slug": project_slug, "name": run_name, "tags": tags or {}}
+        _add_field("metadata", json.dumps(metadata))
+        _add_file("junit", "junit.xml", "application/xml", junit_xml)
+        if archive_zip is not None:
+            _add_file("archive", "archive.zip", "application/zip", archive_zip)
+        parts.append(f"--{boundary}--\r\n".encode())
+        body = b"".join(parts)
+        headers = {"Content-Type": f"multipart/form-data; boundary={boundary}"}
+        code, resp_body = self._request(
+            "POST", "/api/v1/runs", body=body, headers=headers
+        )
+        if code != 201:
+            raise RuntimeError(f"upload {run_name!r} failed: HTTP {code} {resp_body!r}")
+        result: dict[str, object] = json.loads(resp_body)
+        return result

--- a/.github/scripts/prism_upload_run.py
+++ b/.github/scripts/prism_upload_run.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Upload a pytest JUnit XML result to a Prism server.
+
+Typical use from CI:
+
+    python3 scripts/upload_run.py results.xml \\
+      --project my-service --run-name "$CI_JOB_ID" \\
+      --tag branch=$GIT_BRANCH --tag sha=$GIT_SHA --wait
+
+All `--foo` flags fall back to `PRISM_FOO`-style environment variables,
+so a hardened CI pipeline can skip the command-line switches entirely:
+
+    PRISM_URL=...  PRISM_EMAIL=...  PRISM_PASSWORD=...  \\
+    PRISM_PROJECT=my-service  PRISM_RUN_NAME="$CI_JOB_ID"  \\
+      python3 scripts/upload_run.py results.xml
+
+Exit codes:
+  0  success
+  2  bad argument or input file not found
+  3  authentication failed
+  4  project not found (pass --auto-create-project to create it)
+  5  upload failed (HTTP error from the server)
+  6  --wait timed out before ingest finished
+
+Stdlib-only — works on any CI runner with Python 3.10+.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+
+# The shared client lives next to this file; use a path-relative import so the
+# script works when invoked from anywhere (e.g. `python3 /repo/scripts/...`).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _prism_client import PrismClient  # noqa: E402  (import after sys.path tweak)
+
+EXIT_OK = 0
+EXIT_BAD_INPUT = 2
+EXIT_AUTH = 3
+EXIT_NO_PROJECT = 4
+EXIT_UPLOAD = 5
+EXIT_WAIT_TIMEOUT = 6
+
+
+def _parse_tag(raw: str) -> tuple[str, str]:
+    if "=" not in raw:
+        raise argparse.ArgumentTypeError(f"--tag expects key=value, got {raw!r}")
+    k, v = raw.split("=", 1)
+    k = k.strip()
+    v = v.strip()
+    if not k:
+        raise argparse.ArgumentTypeError(f"--tag key is empty in {raw!r}")
+    return k, v
+
+
+def _env(name: str, default: str | None = None) -> str | None:
+    v = os.environ.get(name)
+    return v if v else default
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="upload_run.py",
+        description="Upload a pytest JUnit XML to Prism.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Each --foo flag also accepts a PRISM_FOO environment variable "
+            "(e.g. PRISM_URL, PRISM_EMAIL, PRISM_PROJECT, PRISM_RUN_NAME)."
+        ),
+    )
+    p.add_argument("junit", type=Path, help="Path to the JUnit XML file.")
+    p.add_argument(
+        "--url",
+        default=_env("PRISM_URL", "http://localhost:8000"),
+        help="Prism API base URL (env: PRISM_URL).",
+    )
+    p.add_argument(
+        "--email", default=_env("PRISM_EMAIL"), help="Login email (env: PRISM_EMAIL)."
+    )
+    p.add_argument(
+        "--password",
+        default=_env("PRISM_PASSWORD"),
+        help="Login password (env: PRISM_PASSWORD).",
+    )
+    p.add_argument(
+        "--project",
+        default=_env("PRISM_PROJECT"),
+        help="Target project slug (env: PRISM_PROJECT).",
+    )
+    p.add_argument(
+        "--run-name",
+        dest="run_name",
+        default=_env("PRISM_RUN_NAME"),
+        help="Name for this Test Suite Run (env: PRISM_RUN_NAME).",
+    )
+    p.add_argument(
+        "--tag",
+        action="append",
+        type=_parse_tag,
+        default=[],
+        metavar="key=value",
+        help="Repeatable. Arbitrary tag on the run (branch=main, sha=abc123).",
+    )
+    p.add_argument(
+        "--archive",
+        type=Path,
+        default=None,
+        help="Optional .zip of measurement artifacts to upload alongside the JUnit.",
+    )
+    p.add_argument(
+        "--auto-create-project",
+        action="store_true",
+        help="Create the target project if it doesn't exist.",
+    )
+    p.add_argument(
+        "--wait",
+        nargs="?",
+        type=int,
+        const=60,
+        default=None,
+        metavar="SECONDS",
+        help="After upload, poll every 2s until the run is no longer "
+        "pending. Bare flag uses a 60s timeout; pass a value for longer.",
+    )
+    verbosity = p.add_mutually_exclusive_group()
+    verbosity.add_argument(
+        "--quiet",
+        "-q",
+        action="store_true",
+        help="Only print the final result line; errors still go to stderr.",
+    )
+    verbosity.add_argument(
+        "--verbose", "-v", action="store_true", help="Print each step to stdout."
+    )
+    return p
+
+
+def _require(args: argparse.Namespace, name: str, env: str) -> str | None:
+    val: str | None = getattr(args, name, None)
+    if not val:
+        print(
+            f"error: --{name.replace('_', '-')} is required (or set {env})",
+            file=sys.stderr,
+        )
+        return None
+    return val
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    # --- Validate required args ------------------------------------------- #
+    missing = []
+    for attr, env in (
+        ("email", "PRISM_EMAIL"),
+        ("password", "PRISM_PASSWORD"),
+        ("project", "PRISM_PROJECT"),
+        ("run_name", "PRISM_RUN_NAME"),
+    ):
+        if not getattr(args, attr, None):
+            missing.append(f"--{attr.replace('_', '-')} (or {env})")
+    if missing:
+        print(
+            "error: missing required argument(s): " + ", ".join(missing),
+            file=sys.stderr,
+        )
+        return EXIT_BAD_INPUT
+
+    if not args.junit.exists() or not args.junit.is_file():
+        print(f"error: JUnit file not found: {args.junit}", file=sys.stderr)
+        return EXIT_BAD_INPUT
+    if args.archive is not None and (
+        not args.archive.exists() or not args.archive.is_file()
+    ):
+        print(f"error: archive file not found: {args.archive}", file=sys.stderr)
+        return EXIT_BAD_INPUT
+
+    say = (lambda _m: None) if args.quiet else print
+
+    # --- Auth ------------------------------------------------------------- #
+    client = PrismClient(args.url)
+    if args.verbose:
+        say(f"→ logging in to {args.url} as {args.email}")
+    try:
+        client.login(args.email, args.password)
+    except RuntimeError as exc:
+        print(f"error: authentication failed — {exc}", file=sys.stderr)
+        return EXIT_AUTH
+
+    # --- Project ---------------------------------------------------------- #
+    if args.auto_create_project:
+        client.ensure_project(
+            args.project, args.project, description="Auto-created by upload_run.py"
+        )
+    elif not client.project_exists(args.project):
+        print(
+            f"error: project {args.project!r} not found. "
+            "Pass --auto-create-project to create it, or create it in the UI first.",
+            file=sys.stderr,
+        )
+        return EXIT_NO_PROJECT
+
+    # --- Read payloads ---------------------------------------------------- #
+    junit_bytes = args.junit.read_bytes()
+    archive_bytes = args.archive.read_bytes() if args.archive is not None else None
+    tags = dict(args.tag)
+
+    if args.verbose:
+        say(
+            f"→ uploading {args.junit.name} ({len(junit_bytes)} bytes) "
+            f"as run {args.run_name!r} in project {args.project!r}"
+            + (
+                f" with archive {args.archive.name} ({len(archive_bytes or b'')} bytes)"
+                if archive_bytes
+                else ""
+            )
+        )
+
+    # --- Upload ----------------------------------------------------------- #
+    try:
+        result = client.upload_run(
+            project_slug=args.project,
+            run_name=args.run_name,
+            junit_xml=junit_bytes,
+            archive_zip=archive_bytes,
+            tags=tags,
+        )
+    except RuntimeError as exc:
+        print(f"error: upload failed — {exc}", file=sys.stderr)
+        return EXIT_UPLOAD
+
+    run_id: str = str(result["id"])
+    status: str = str(result.get("status", "pending"))
+
+    # --- Optional wait-for-ingest ---------------------------------------- #
+    if args.wait is not None:
+        if args.verbose:
+            say(f"→ waiting up to {args.wait}s for ingest to finish …")
+        deadline = time.monotonic() + args.wait
+        while status == "pending":
+            if time.monotonic() >= deadline:
+                print(
+                    f"warning: timed out after {args.wait}s; run {run_id} is still pending",
+                    file=sys.stderr,
+                )
+                # Still print the normal success line so CI can capture the ID.
+                print(f"uploaded {args.run_name} (id={run_id}, status=pending)")
+                return EXIT_WAIT_TIMEOUT
+            time.sleep(2)
+            try:
+                detail = client.get_run(run_id)
+            except RuntimeError as exc:
+                print(f"warning: could not poll run status — {exc}", file=sys.stderr)
+                break
+            status = str(detail.get("status", status))
+
+    print(f"uploaded {args.run_name} (id={run_id}, status={status})")
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.github/workflows/hardware-test.yml
+++ b/.github/workflows/hardware-test.yml
@@ -99,4 +99,14 @@ jobs:
       # reusable-workflow level. Upload step is continue-on-error so a
       # Prism outage / missing URL won't redden a HW run.
       prism_upload: ${{ vars.PRISM_UPLOAD_ENABLED == 'true' }}
+      # Run the vendored tfcollins/prism uploader (stdlib-only; no pip/clone
+      # of the private Prism repo needed). The reusable workflow exports
+      # PRISM_URL / PRISM_EMAIL / PRISM_PASSWORD / PRISM_PROJECT / PRISM_JUNIT
+      # / PRISM_RUN_NAME / PRISM_BOARD / PRISM_CARRIER / PRISM_PLACE / VENV_DIR.
+      prism_upload_cmd: >-
+        "$VENV_DIR/bin/python" .github/scripts/prism_upload_run.py "$PRISM_JUNIT"
+        --url "$PRISM_URL" --project "$PRISM_PROJECT" --run-name "$PRISM_RUN_NAME"
+        --auto-create-project
+        --tag "board=$PRISM_BOARD" --tag "carrier=$PRISM_CARRIER"
+        --tag "place=$PRISM_PLACE" --tag "sha=$GITHUB_SHA"
     secrets: inherit


### PR DESCRIPTION
## Summary
- Vendor `tfcollins/prism`'s stdlib-only uploader (`.github/scripts/prism_upload_run.py` + `_prism_client.py`) — the Prism repo is private, so the runner can't pip-install/clone it.
- Set `prism_upload_cmd` (consumed by labgrid-plugins hw-matrix `@main`, PR #28) to run the vendored uploader against each leg's JUnit, tagging board/carrier/place/sha and auto-creating the project.
- Enabled via `vars.PRISM_UPLOAD_ENABLED=true`; target `vars.PRISM_URL=http://rpi5.local:8088`; creds in `secrets.PRISM_EMAIL`/`PRISM_PASSWORD`. Upload is continue-on-error.

## Test plan
- [x] Vendored uploader passes pre-commit + uploads a test run to rpi5 Prism locally
- [ ] A real HW run's per-leg results appear in the rpi5 Prism `pyadi-iio` project