### PR TITLE
ci(hw): run Prism uploader with python3

### DIFF
--- a/.github/workflows/hardware-test.yml
+++ b/.github/workflows/hardware-test.yml
@@ -104,7 +104,7 @@ jobs:
       # PRISM_URL / PRISM_EMAIL / PRISM_PASSWORD / PRISM_PROJECT / PRISM_JUNIT
       # / PRISM_RUN_NAME / PRISM_BOARD / PRISM_CARRIER / PRISM_PLACE / VENV_DIR.
       prism_upload_cmd: >-
-        "$VENV_DIR/bin/python" .github/scripts/prism_upload_run.py "$PRISM_JUNIT"
+        python3 .github/scripts/prism_upload_run.py "$PRISM_JUNIT"
         --url "$PRISM_URL" --project "$PRISM_PROJECT" --run-name "$PRISM_RUN_NAME"
         --auto-create-project
         --tag "board=$PRISM_BOARD" --tag "carrier=$PRISM_CARRIER"


### PR DESCRIPTION
The uploader is stdlib-only; use system python3 instead of $VENV_DIR/bin/python (the reusable workflow no longer overrides VENV_DIR). Fixes the exit-127 'No such file' from the first wired run.