### PR TITLE
doc: family taxonomy + concepts page + FAQ for end-user docs

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -20,6 +20,11 @@ jobs:
           bash ./.github/scripts/install_pydeps.sh
           pip install -r requirements_doc.txt
 
+      - name: Verify every per-part doc is assigned to a family
+        run: |
+          pip install invoke
+          invoke checkdocs
+
       - name: Check doc build
         run: |
           cd doc

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -20,11 +20,6 @@ jobs:
           bash ./.github/scripts/install_pydeps.sh
           pip install -r requirements_doc.txt
 
-      - name: Verify every per-part doc is assigned to a family
-        run: |
-          pip install invoke
-          invoke checkdocs
-
       - name: Check doc build
         run: |
           cd doc
@@ -73,3 +68,7 @@ jobs:
       - name: Check if emulation support exists
         run: |
           invoke checkemulation
+
+      - name: Check per-part doc coverage
+        run: |
+          invoke checkdocs

--- a/doc/source/attr/index.rst
+++ b/doc/source/attr/index.rst
@@ -20,3 +20,6 @@ If more detail is required about a specific property it can be directly inspecte
   :language: none
 
 For complete documentation about class properties reference the :doc:`supported devices</devices/index>` classes.
+
+.. seealso::
+   :doc:`Concepts: properties and attributes <../concepts>`

--- a/doc/source/buffers/index.rst
+++ b/doc/source/buffers/index.rst
@@ -1,6 +1,10 @@
 Buffers
 ==================
 
+.. seealso::
+   :doc:`Concepts: the rx() and tx() methods <../concepts>` for the data
+   shape contract before reading the mechanics below.
+
 Using buffers or transmitting and receiving data is done through interacting with two methods.
 
 For receivers this is the **rx** method. How data is captured and therefore produced by this method is dependent on two main properties:

--- a/doc/source/concepts.rst
+++ b/doc/source/concepts.rst
@@ -66,7 +66,8 @@ For parts with a capture buffer, ``rx()`` returns a NumPy array:
 * **Single enabled channel:** a single ndarray.
 * **Multiple enabled channels:** a list of ndarrays, one per channel.
 * **Complex parts** (transceivers, AD9081, etc.): the dtype is
-  ``complex64``; I and Q are already combined.
+  ``complex128`` (NumPy promotes the underlying ``int16`` I and Q into
+  a 128-bit complex); I and Q are already combined.
 * **Real parts** (precision ADCs, IMUs): the native dtype — typically
   ``int16`` or ``int32``.
 
@@ -121,7 +122,7 @@ process — you can't realistically refill the buffer in time otherwise.
 
 The catch: once a cyclic buffer is loaded, you must call
 ``tx_destroy_buffer()`` before pushing a new one. Forgetting this is
-the most common cause of "my second tx() call hangs or errors."
+the most common cause of "my second tx() call fails with a clear exception."
 
 Raw vs. SI units
 ----------------

--- a/doc/source/concepts.rst
+++ b/doc/source/concepts.rst
@@ -1,0 +1,151 @@
+Concepts
+========
+
+This page is the bridge between the quick start and the per-device API
+reference. After reading it, the rest of the documentation should stop
+feeling magical.
+
+How a pyadi-iio device class is built
+-------------------------------------
+
+Every device class is a composition of small mixins:
+
+* ``context_manager`` — owns the libiio context (``iio.Context``). This is
+  what the ``uri=`` argument feeds into.
+* ``attribute`` — reads and writes IIO channel-attributes and device-attributes.
+  Every Python property on a device class goes through this layer.
+* ``rx`` and/or ``tx`` — for parts that have a sample-capture or
+  sample-output buffer. These mixins provide the ``rx()`` and ``tx()``
+  methods.
+
+A class like ``adi.ad9361`` looks like ``class ad9361(rx_tx, ...)`` and
+inherits properties from each mixin. When you do ``sdr.rx_lo = 2_400_000_000``,
+the ``rx_lo`` setter is defined on the AD9361 class and uses the ``attribute``
+layer to write the corresponding IIO attribute through ``context_manager``'s
+context.
+
+This is why ``dir(sdr)`` shows a large attribute list: every mixin contributes,
+plus the part-specific properties on top.
+
+URIs and connecting to a device
+-------------------------------
+
+A URI tells libiio which backend to use to reach the device:
+
+* ``ip:192.168.2.1`` — network backend over TCP.
+* ``ip:pluto.local`` — same, resolved via mDNS.
+* ``usb:1.24.5`` — USB backend at bus 1, device 24, interface 5.
+* ``serial:/dev/ttyUSB0,115200`` — serial backend.
+* ``local:`` — local backend (process running on the target board itself).
+
+When you construct a device class without ``uri=``, pyadi-iio falls through
+to auto-discovery: it scans available contexts and picks the first one that
+exposes a matching device name. This works well for a single USB device on
+a developer machine; it's ambiguous if you have two Plutos plugged in.
+
+Device classes are context managers. Either pattern works:
+
+.. code-block:: python
+
+   sdr = adi.ad9361(uri="ip:192.168.2.1")
+   try:
+       data = sdr.rx()
+   finally:
+       sdr.close()
+
+.. code-block:: python
+
+   with adi.ad9361(uri="ip:192.168.2.1") as sdr:
+       data = sdr.rx()
+
+The ``rx()`` and ``tx()`` methods
+---------------------------------
+
+For parts with a capture buffer, ``rx()`` returns a NumPy array:
+
+* **Single enabled channel:** a single ndarray.
+* **Multiple enabled channels:** a list of ndarrays, one per channel.
+* **Complex parts** (transceivers, AD9081, etc.): the dtype is
+  ``complex64``; I and Q are already combined.
+* **Real parts** (precision ADCs, IMUs): the native dtype — typically
+  ``int16`` or ``int32``.
+
+``rx_buffer_size`` is the number of **samples per channel**, not the total
+sample count across all enabled channels. With two channels enabled and
+``rx_buffer_size = 1024``, you get two arrays of 1024 samples each.
+
+``tx()`` accepts the same shape it would return: an ndarray for one
+channel, a list of ndarrays for many. For complex TX devices, pass a
+complex-dtype array; pyadi-iio splits it into the I and Q DMA streams.
+
+Indexing into channels:
+
+* For real parts, channel indices map directly to IIO channel order
+  (channel 0 is the first channel).
+* For complex parts, channel indices count complex pairs. ``rx_enabled_channels = [0]``
+  on a transceiver means "enable I/Q pair 0," which is two underlying IIO channels.
+
+See :doc:`buffers/index` for buffer mechanics in depth.
+
+Properties and attributes
+-------------------------
+
+Properties on device classes map to libiio attributes:
+
+* **Device attributes** — apply to the whole device (e.g., sample rate).
+* **Channel attributes** — apply to a single channel (e.g., per-channel gain).
+
+Reads and writes hit libiio every time. Most properties don't cache, so
+setting one and reading it back is a real round-trip. Some drivers clamp
+or snap the value to a supported grid — if ``sdr.rx_lo = 2_400_000_001``
+reads back as ``2_399_999_968``, the driver picked the closest legal
+value.
+
+Writes can raise on:
+
+* out-of-range values,
+* read-only attributes on this driver variant,
+* a channel index that isn't present on this part.
+
+See :doc:`attr/index` for the property model in depth.
+
+Cyclic vs. one-shot buffers
+---------------------------
+
+By default, ``tx()`` pushes a one-shot buffer: the data plays once.
+
+With ``tx_cyclic_buffer = True`` set before the first ``tx()``, the
+buffer plays in a loop until you tear it down. Cyclic mode is the only
+sensible way to keep transmitting at multi-GSPS rates from a Python
+process — you can't realistically refill the buffer in time otherwise.
+
+The catch: once a cyclic buffer is loaded, you must call
+``tx_destroy_buffer()`` before pushing a new one. Forgetting this is
+the most common cause of "my second tx() call hangs or errors."
+
+Raw vs. SI units
+----------------
+
+Some drivers expose data in scientific units. Setting
+``rx_output_type = "SI"`` makes ``rx()`` return floats with the
+appropriate scale applied (e.g., m/s² for an accelerometer, volts for
+a voltage ADC). The default is ``raw`` — the integer codes coming out
+of the converter. Not every part supports SI; check the family page or
+the per-part autodoc.
+
+libiio underneath
+-----------------
+
+Everything ultimately goes through libiio's Python bindings (``iio``).
+The ``iio.Context`` is accessible as ``sdr.ctx`` on every device, and
+you can drop down to libiio directly when you need an attribute pyadi-iio
+hasn't surfaced. See :doc:`libiio` for the direct-access patterns.
+
+Where to go next
+----------------
+
+* :doc:`Quick Start <guides/quick>` — install and run your first capture.
+* :doc:`Supported devices <devices/index>` — find your part by family.
+* :doc:`Buffers in depth <buffers/index>` — rx/tx buffer mechanics.
+* :doc:`libiio direct access <libiio>` — when to bypass pyadi-iio.
+* :doc:`Troubleshooting <guides/troubleshooting>` — common errors and fixes.

--- a/doc/source/devices/families/beamformers.rst
+++ b/doc/source/devices/families/beamformers.rst
@@ -1,0 +1,13 @@
+Beamformers & Phased Array
+==========================
+
+Beamforming front-ends and phased-array reference designs.
+
+Family overview content lands in Phase 4. See the parts list below for the
+device classes in this family.
+
+.. toctree::
+   :maxdepth: 1
+
+   ../adi.adar1000
+   ../adi.cn0566

--- a/doc/source/devices/families/beamformers.rst
+++ b/doc/source/devices/families/beamformers.rst
@@ -1,10 +1,110 @@
 Beamformers & Phased Array
 ==========================
 
-Beamforming front-ends and phased-array reference designs.
+Beamforming front-ends and phased-array reference designs. Small
+family but high-touch — these parts have richer per-channel control
+than the rest of the RF front-end family because they manage phase /
+attenuation per element.
 
-Family overview content lands in Phase 4. See the parts list below for the
-device classes in this family.
+Parts in this family
+--------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 60 15
+
+   * - Part
+     - Highlights
+     - Platform
+   * - :doc:`ADAR1000 <../adi.adar1000>`
+     - 4-channel 8 – 16 GHz beamformer; ``adar1000_array`` for stacking
+     - ADAR1000 EVM
+   * - :doc:`CN0566 <../adi.cn0566>`
+     - Phaser: 8-element X-band phased array kit with Pluto + ADAR1000s
+     - CN0566 kit
+
+Mental model
+------------
+
+Per-element phase and gain set the beam steering / shaping. Each
+ADAR1000 controls 4 channels, exposed via ``bf.channels[i]``. The
+``adar1000_array`` class manages multiple ADAR1000 chips as a single
+logical array and exposes array-level helpers such as ``frequency``
+and ``element_spacing`` for steering math.
+
+CN0566 is a complete kit — it integrates a Pluto SDR, two ADAR1000s,
+and an 8-element antenna into one beamforming system. The pyadi-iio
+class exposes both the SDR (via the Pluto subclass) and the
+beamforming controls.
+
+Minimal example
+---------------
+
+.. code-block:: python
+
+   import adi
+
+   # Single ADAR1000 wired as a 1x4 array. chip_id must match the
+   # ADAR1000 label in the device tree; array_element_map and
+   # channel_element_map are required.
+   bf = adi.adar1000(
+       uri="ip:analog.local",
+       chip_id="csb1_chip1",
+       array_element_map=[[1, 2, 3, 4]],
+       channel_element_map=[1, 2, 3, 4],
+   )
+
+   bf.mode = "tx"
+   for ch in bf.channels:
+       ch.tx_enable = True
+
+   # Progressive 45° phase ramp across the 4 elements
+   for i, ch in enumerate(bf.channels):
+       ch.tx_phase = i * 45
+       ch.tx_gain = 0x67
+
+   bf.latch_tx_settings()   # push staged phase/gain to the chip
+
+For multi-chip arrays, use ``adi.adar1000_array(...)``; it exposes
+``frequency``, ``element_spacing``, and azimuth/elevation steering
+helpers in addition to per-element control.
+
+Common properties
+-----------------
+
+* ``bf.channels[i].rx_phase`` / ``tx_phase`` — per-element phase in
+  degrees.
+* ``bf.channels[i].rx_gain`` / ``tx_gain`` — per-element gain code.
+* ``bf.mode`` — ``"rx"`` or ``"tx"`` path select.
+* ``bf.latch_rx_settings()`` / ``bf.latch_tx_settings()`` — push
+  staged values to the chip.
+* On ``adar1000_array``: ``frequency``, ``element_spacing``,
+  ``rx_azimuth`` / ``rx_elevation`` (and ``tx_`` equivalents) for
+  steering math.
+
+Common gotchas
+--------------
+
+* Phase and gain are staged; nothing takes effect until
+  ``latch_*_settings()`` is called.
+* ``array_element_map`` and ``channel_element_map`` are **required**
+  constructor arguments — instantiating ``adi.adar1000(...)`` without
+  them raises an exception.
+* ``chip_id`` must match the ADAR1000's label in the device tree
+  (default ``"csb1_chip1"``); a mismatch raises *Device not found*.
+* Multi-chip arrays require all chips to be configured before any
+  ``latch`` is meaningful — otherwise beam shape is undefined.
+* CN0566 / Phaser kit needs a specific HDL build on the Pluto to
+  expose the beamformer SPI — using a stock Pluto won't work.
+
+See also
+--------
+
+* :doc:`Concepts <../../concepts>`
+* :doc:`RF Transceivers <rf_transceivers>` — the SDR side of CN0566.
+
+Reference (per-part API)
+------------------------
 
 .. toctree::
    :maxdepth: 1

--- a/doc/source/devices/families/clocks_plls.rst
+++ b/doc/source/devices/families/clocks_plls.rst
@@ -1,0 +1,20 @@
+Clocks, PLLs & Synthesizers
+===========================
+
+PLL/synthesizer parts (ADF series) and clock generators (HMC).
+
+Family overview content lands in Phase 4. See the parts list below for the
+device classes in this family.
+
+.. toctree::
+   :maxdepth: 1
+
+   ../adi.adf4030
+   ../adi.adf4159
+   ../adi.adf4355
+   ../adi.adf4371
+   ../adi.adf4377
+   ../adi.adf4382
+   ../adi.adf5610
+   ../adi.adf5611
+   ../adi.hmc7044

--- a/doc/source/devices/families/clocks_plls.rst
+++ b/doc/source/devices/families/clocks_plls.rst
@@ -1,10 +1,104 @@
 Clocks, PLLs & Synthesizers
 ===========================
 
-PLL/synthesizer parts (ADF series) and clock generators (HMC).
+Frequency synthesizers (ADF series) and clock-tree distribution parts
+(HMC). No data buffer — these are control-plane devices. You configure
+output frequencies and read back lock status.
 
-Family overview content lands in Phase 4. See the parts list below for the
-device classes in this family.
+Parts in this family
+--------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 60 15
+
+   * - Part
+     - Highlights
+     - Interface
+   * - :doc:`ADF4030 <../adi.adf4030>`
+     - 10-channel BAW-based PLL clock generator
+     - SPI
+   * - :doc:`ADF4159 <../adi.adf4159>`
+     - Direct-modulation fractional-N PLL (FMCW radar)
+     - SPI
+   * - :doc:`ADF4355 / 4371 / 4377 / 4382 <../adi.adf4355>`
+     - Wideband fractional-N PLLs, 4–13 GHz range
+     - SPI
+   * - :doc:`ADF5610 / 5611 <../adi.adf5610>`
+     - Microwave PLL+VCO, up to 15 GHz
+     - SPI
+   * - :doc:`HMC7044 <../adi.hmc7044>`
+     - 14-output clock distribution / JESD-friendly clocking
+     - SPI
+
+Mental model
+------------
+
+These are pure control parts: no ``rx()``, no ``tx()``. Properties set
+the output frequency, reference frequency, charge-pump current, etc.,
+and readbacks tell you whether the PLL is locked.
+
+Most parts in this family are used **as supporting infrastructure** for
+JESD ADCs/DACs and transceivers — HMC7044 in particular shows up as the
+clock source for nearly every JESD-class system. They're rarely the
+center of an application by themselves; the ADF4159 (FMCW radar) is
+the main exception.
+
+Minimal example
+---------------
+
+Property names are part-specific. ADF4371 exposes one frequency knob
+per RF output (``rf8_frequency``, ``rf16_frequency``, ``rf32_frequency``,
+``rfaux8_frequency``):
+
+.. code-block:: python
+
+   import adi
+
+   pll = adi.adf4371(uri="ip:analog.local")
+   pll.rf8_frequency = 5_000_000_000   # 5 GHz on the 8 GHz output
+
+ADF4159 uses a single ``frequency`` property; HMC7044 exposes one
+``<channel>_frequency`` per output (14 outputs). Always check the
+per-part API page linked below.
+
+Common properties
+-----------------
+
+* ``frequency`` / ``rf<n>_frequency`` / ``<channel>_frequency`` —
+  target output frequency in Hz. Naming is part-specific.
+* ``reference_frequency`` — input reference frequency (for parts that
+  expose it, e.g. ADF4377, HMC7044).
+* ``charge_pump_current`` — loop filter charge-pump setting.
+* For multi-output parts (HMC7044, ADF4030): per-output configuration
+  via per-channel properties.
+
+Common gotchas
+--------------
+
+* "Locked" status depends on the loop filter being correctly designed
+  for the target frequency. A frequency that lies outside the lock
+  range will silently fail to acquire — check whatever lock-detect
+  property the part exposes.
+* HMC7044 in JESD systems is usually pre-configured by an HDL-level
+  init script; touching its properties from pyadi-iio can break the
+  JESD link clocking.
+* Reference frequencies are part-specific; setting a target output
+  outside the achievable range gets clamped on some parts and rejected
+  on others.
+* ADF4371 has no single ``frequency`` property — each of the four RF
+  outputs (8 GHz, aux 8 GHz, 16 GHz, 32 GHz) has its own
+  ``rf<n>_frequency`` setter.
+
+See also
+--------
+
+* :doc:`Concepts <../../concepts>`
+* :doc:`JESD ADCs <jesd_adcs>` / :doc:`JESD DACs <jesd_dacs>` for the
+  systems these clocks support.
+
+Reference (per-part API)
+------------------------
 
 .. toctree::
    :maxdepth: 1

--- a/doc/source/devices/families/eval_systems.rst
+++ b/doc/source/devices/families/eval_systems.rst
@@ -1,11 +1,133 @@
 Multi-Chip / Eval Systems
 =========================
 
-Board-level evaluation systems — FMC/DAQ daughter cards, CN0xxx reference
-designs, multi-SOM configurations.
+Board-level evaluation systems — FMC and DAQ daughter cards, CN0xxx
+reference designs, and multi-SOM stacks. Each class in this family
+binds to a *board*, not a *chip* — the class wires up the multiple
+underlying drivers (ADC + DAC + clock + amp) into a single Python
+object so a user doesn't have to configure them individually.
 
-Family overview content lands in Phase 4. See the parts list below for the
-device classes in this family.
+Parts in this family
+--------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 55 15
+
+   * - Board / system
+     - Highlights
+     - Pairs with
+   * - :doc:`DAQ2 <../adi.daq2>`
+     - AD9680 + AD9144 FMC card, 1 GSPS TX/RX
+     - FMC FPGA
+   * - :doc:`DAQ3 <../adi.daq3>`
+     - AD9680 + AD9152, 2.25 GSPS DAC
+     - FMC FPGA
+   * - :doc:`FMCADC3 <../adi.fmcadc3>`
+     - Quad 1 GSPS ADC FMC card
+     - FMC FPGA
+   * - :doc:`FMCJESDADC1 <../adi.fmcjesdadc1>`
+     - Dual AD9250 250 MSPS card
+     - FMC FPGA
+   * - :doc:`FMComms5 <../adi.fmcomms5>`
+     - Dual AD9361 MIMO 4×4
+     - ZC706 / ZCU102
+   * - :doc:`FMComms11 <../adi.fmcomms11>`
+     - AD9162 + AD9625, 12 GSPS DAC + 2.5 GSPS ADC
+     - FMC FPGA
+   * - :doc:`FMC VNA <../adi.fmc_vna>`
+     - Vector network analyzer FMC
+     - FMC FPGA
+   * - :doc:`QuadMxFE_multi <../adi.QuadMxFE_multi>`
+     - Quad AD9081 multi-chip stack
+     - VCU118 / custom
+   * - :doc:`CN0511 <../adi.cn0511>`
+     - DDS reference design (Raspberry Pi)
+     - RPi
+   * - :doc:`CN0532 <../adi.cn0532>`
+     - Multi-channel data acquisition reference
+     - ZC706
+   * - :doc:`CN0540 <../adi.cn0540>`
+     - 24-bit DAQ reference
+     - SDP-K1
+   * - :doc:`CN0554 <../adi.cn0554>`
+     - 12-channel ADC + 8-channel DAC RPi HAT
+     - RPi
+   * - :doc:`CN0556 <../adi.cn0556>`
+     - Programmable power supply reference
+     - SDP-K1
+   * - :doc:`CN0565 <../adi.cn0565>`
+     - Bioimpedance / EIT reference
+     - ADuCM355
+   * - :doc:`CN0575 <../adi.cn0575>`
+     - RPi temperature / fan controller reference
+     - RPi
+   * - :doc:`CN0579 <../adi.cn0579>`
+     - High-precision DAQ reference
+     - SDP-K1
+
+Mental model
+------------
+
+Each class typically wraps multiple underlying device classes. For
+example, ``DAQ2`` exposes ``rx()`` (from the AD9680 ADC) and ``tx()``
+(from the AD9144 DAC) on a single object, plus the FPGA-side DDS
+controls. The class handles the dance of finding all the right IIO
+devices in the context and connecting them.
+
+``_mc`` (multi-chip) classes are similar but for parts that span
+multiple identical chips — see ``QuadMxFE_multi`` for four
+synchronized AD9081s. The chip-level multi-chip classes (``ad9081_mc``,
+``ad9084_mc``) live in the JESD ADCs family; this family is for
+board-level stacks.
+
+Minimal example
+---------------
+
+.. code-block:: python
+
+   import adi
+
+   daq = adi.DAQ2(uri="ip:analog.local")
+   daq.rx_enabled_channels = [0, 1]
+   daq.rx_buffer_size = 1024
+   rx_data = daq.rx()
+   daq.dds_single_tone(10_000_000, 0.9)   # generate a 10 MHz tone on TX
+
+Common properties
+-----------------
+
+* All standard ``rx()`` / ``tx()`` properties from the underlying
+  ADC / DAC classes.
+* DDS properties (``dds_single_tone``, ``dds_frequencies``,
+  ``dds_scales``) for transmit-capable boards — see
+  :doc:`../../fpga/index`.
+* Multi-chip variants: per-chip indexing into the underlying device
+  collections.
+
+Common gotchas
+--------------
+
+* Eval systems pair a specific HDL design with the board. Using
+  pyadi-iio against a Vivado-built design that differs from ADI's
+  reference HDL will partially or fully fail, often silently.
+* Multi-chip stacks need clock alignment (synchronization). Use
+  ``sync_start`` (see :doc:`../../fpga/index`) for deterministic
+  TX→RX capture.
+* CN0xxx classes are often very narrowly tailored to their reference
+  design — they aren't general-purpose wrappers around the underlying
+  chips.
+
+See also
+--------
+
+* :doc:`Concepts <../../concepts>`
+* :doc:`FPGA features (DDS, DMA sync) <../../fpga/index>`
+* :doc:`JESD ADCs <jesd_adcs>` / :doc:`JESD DACs <jesd_dacs>` for the
+  underlying converters.
+
+Reference (per-part API)
+------------------------
 
 .. toctree::
    :maxdepth: 1

--- a/doc/source/devices/families/eval_systems.rst
+++ b/doc/source/devices/families/eval_systems.rst
@@ -1,0 +1,28 @@
+Multi-Chip / Eval Systems
+=========================
+
+Board-level evaluation systems — FMC/DAQ daughter cards, CN0xxx reference
+designs, multi-SOM configurations.
+
+Family overview content lands in Phase 4. See the parts list below for the
+device classes in this family.
+
+.. toctree::
+   :maxdepth: 1
+
+   ../adi.QuadMxFE_multi
+   ../adi.cn0511
+   ../adi.cn0532
+   ../adi.cn0540
+   ../adi.cn0554
+   ../adi.cn0556
+   ../adi.cn0565
+   ../adi.cn0575
+   ../adi.cn0579
+   ../adi.daq2
+   ../adi.daq3
+   ../adi.fmc_vna
+   ../adi.fmcadc3
+   ../adi.fmcjesdadc1
+   ../adi.fmcomms5
+   ../adi.fmcomms11

--- a/doc/source/devices/families/imus_motion.rst
+++ b/doc/source/devices/families/imus_motion.rst
@@ -1,11 +1,113 @@
 IMUs & Motion Sensors
 =====================
 
-Inertial measurement units (ADIS16xxx series) and standalone accelerometers /
-gyroscopes (ADXL, ADXRS).
+Inertial measurement units (ADIS16xxx series) and standalone motion
+sensors (ADXL accelerometers, ADXRS gyros). The ADIS family is the
+flagship — 6-DOF or 10-DOF IMUs with on-chip filtering, calibration,
+and SPI/UART interfaces. The ADXL/ADXRS parts are lighter-weight
+accelerometers and gyros without the full IMU pipeline.
 
-Family overview content lands in Phase 4. See the parts list below for the
-device classes in this family.
+Parts in this family
+--------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 50 20
+
+   * - Part
+     - Highlights
+     - Interface
+   * - :doc:`ADIS16375 <../adi.adis16375>` (and 16480/85/88/90/95/97)
+     - Tactical-grade IMUs, 6/10 DOF
+     - SPI
+   * - :doc:`ADIS16460 <../adi.adis16460>`
+     - Industrial-grade 6-DOF IMU
+     - SPI
+   * - :doc:`ADIS16475 <../adi.adis16475>`
+     - Industrial 6-DOF, low-noise
+     - SPI
+   * - :doc:`ADIS16507 <../adi.adis16507>`
+     - High-performance 6-DOF
+     - SPI
+   * - :doc:`ADIS16545 / 16547 <../adi.adis16545>`
+     - Precision 6-DOF
+     - SPI
+   * - :doc:`ADIS16550 <../adi.adis16550>`
+     - Next-gen 6-DOF
+     - SPI
+   * - :doc:`ADXL313 / 345 / 355 / 380 <../adi.adxl345>`
+     - 3-axis accelerometers, varying precision
+     - SPI / I²C
+   * - :doc:`ADXRS290 <../adi.adxrs290>`
+     - Dual-axis ultra-low-noise gyro
+     - SPI
+
+Mental model
+------------
+
+IMUs expose multiple channel types: ``accel_x/y/z``, ``anglvel_x/y/z``,
+``temp``, and (on some parts) ``magn_x/y/z`` and ``deltaangl_*``,
+``deltavelocity_*``. The default ``rx()`` returns a list of arrays in the
+order of ``rx_enabled_channels``, which can be confusing across mixed
+units (m/s² for accel, rad/s for gyro).
+
+For mixed-unit IMUs, set ``rx_annotated = True`` to get a dict keyed by
+channel name. Set ``rx_output_type = "SI"`` to get floats in m/s² / rad/s
+instead of raw integer codes.
+
+Minimal example
+---------------
+
+.. code-block:: python
+
+   import adi
+
+   imu = adi.adis16495(uri="serial:/dev/ttyUSB0,115200")
+   imu.rx_enabled_channels = [3, 0, 6]   # accel_x, anglvel_x, temp
+   imu.rx_buffer_size = 32
+   imu.rx_annotated = True
+   imu.rx_output_type = "SI"
+
+   data = imu.rx()
+   print(data["accel_x"])
+
+Common properties
+-----------------
+
+* ``rx_enabled_channels`` — indices map to channel names; see the
+  per-part autodoc for the order.
+* ``rx_annotated`` — return a dict instead of a list.
+* ``rx_output_type`` — "raw" or "SI".
+* ``sample_rate`` — internal sample rate (most parts run from an
+  internal clock).
+* ``burst_data_selection`` (ADIS parts) — selects which fields go in
+  the burst-read packet.
+
+Common gotchas
+--------------
+
+* Channel indexing varies between ADIS sub-families. The order
+  ``[accel_x, accel_y, accel_z, anglvel_x, anglvel_y, anglvel_z]`` is
+  common but not universal. Use ``rx_annotated = True`` if you're not
+  sure.
+* SI scaling for the ``temp`` channel converts to °C; for accel/gyro
+  it's m/s² / rad/s. The same scaling does not apply to the deltangle /
+  deltvelocity channels in the same way.
+* Some ADIS parts require a hard reset (toggle the reset pin) after
+  power-up before they respond on SPI.
+* ADXL parts have low-power modes that quietly halve the effective
+  sample rate — read back ``sampling_frequency`` after configuration.
+* Mag-equipped IMUs (ADIS16480, 16488, etc.) need a calibration step
+  for the magnetometer to give useful values.
+
+See also
+--------
+
+* :doc:`Concepts <../../concepts>` — annotated output and SI units.
+* :doc:`Examples: annotated IMU output <../../guides/examples>`
+
+Reference (per-part API)
+------------------------
 
 .. toctree::
    :maxdepth: 1

--- a/doc/source/devices/families/imus_motion.rst
+++ b/doc/source/devices/families/imus_motion.rst
@@ -1,0 +1,30 @@
+IMUs & Motion Sensors
+=====================
+
+Inertial measurement units (ADIS16xxx series) and standalone accelerometers /
+gyroscopes (ADXL, ADXRS).
+
+Family overview content lands in Phase 4. See the parts list below for the
+device classes in this family.
+
+.. toctree::
+   :maxdepth: 1
+
+   ../adi.adis16375
+   ../adi.adis16460
+   ../adi.adis16475
+   ../adi.adis16480
+   ../adi.adis16485
+   ../adi.adis16488
+   ../adi.adis16490
+   ../adi.adis16495
+   ../adi.adis16497
+   ../adi.adis16507
+   ../adi.adis16545
+   ../adi.adis16547
+   ../adi.adis16550
+   ../adi.adxl313
+   ../adi.adxl345
+   ../adi.adxl355
+   ../adi.adxl380
+   ../adi.adxrs290

--- a/doc/source/devices/families/jesd_adcs.rst
+++ b/doc/source/devices/families/jesd_adcs.rst
@@ -1,0 +1,26 @@
+High-Speed / JESD ADCs
+======================
+
+GSPS-class analog-to-digital converters with JESD204B/C serial data paths,
+typically driven by an HDL design on an FPGA.
+
+Family overview content lands in Phase 4. See the parts list below for the
+device classes in this family.
+
+.. toctree::
+   :maxdepth: 1
+
+   ../adi.ad6676
+   ../adi.ad9081
+   ../adi.ad9081_mc
+   ../adi.ad9083
+   ../adi.ad9084
+   ../adi.ad9084_mc
+   ../adi.ad9094
+   ../adi.ad9213
+   ../adi.ad9250
+   ../adi.ad9265
+   ../adi.ad9434
+   ../adi.ad9467
+   ../adi.ad9625
+   ../adi.ad9680

--- a/doc/source/devices/families/jesd_adcs.rst
+++ b/doc/source/devices/families/jesd_adcs.rst
@@ -1,11 +1,131 @@
 High-Speed / JESD ADCs
 ======================
 
-GSPS-class analog-to-digital converters with JESD204B/C serial data paths,
-typically driven by an HDL design on an FPGA.
+High-speed ADCs that move samples to an FPGA — most use JESD204B/C serial
+lanes; a few use parallel CMOS or LVDS. Use these for wideband radar,
+instrumentation, communications test, or any application where high
+sample rates are required. A part in this family is always paired with
+an HDL design on an FPGA that provides the link partner (JESD or
+parallel) and DMA.
 
-Family overview content lands in Phase 4. See the parts list below for the
-device classes in this family.
+Parts in this family
+--------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 55 25
+
+   * - Part
+     - Highlights
+     - Typical platform
+   * - :doc:`AD6676 <../adi.ad6676>`
+     - IF-sampling ADC, 200 MHz IF
+     - AD6676 EVM
+   * - :doc:`AD9081 <../adi.ad9081>` / :doc:`AD9081-MC <../adi.ad9081_mc>`
+     - 4-channel, 4 GSPS RX (multi-chip variant for QuadMxFE)
+     - QuadMxFE
+   * - :doc:`AD9083 <../adi.ad9083>`
+     - 16-channel, 125 MSPS, JESD204B
+     - AD9083 EVM
+   * - :doc:`AD9084 <../adi.ad9084>` / :doc:`AD9084-MC <../adi.ad9084_mc>`
+     - 4 GSPS, JESD204C, multi-chip Triton platform
+     - Triton
+   * - :doc:`AD9094 <../adi.ad9094>`
+     - 4-channel, 1 GSPS, JESD204B
+     - AD9094 EVM
+   * - :doc:`AD9213 <../adi.ad9213>`
+     - 12-bit, 10 GSPS
+     - AD9213 EVM
+   * - :doc:`AD9250 <../adi.ad9250>`
+     - Dual 14-bit, 250 MSPS
+     - AD9250 / DAQ-class
+   * - :doc:`AD9265 <../adi.ad9265>`
+     - 16-bit, 125 MSPS (parallel CMOS, sometimes JESD-paired)
+     - AD9265 EVM
+   * - :doc:`AD9434 <../adi.ad9434>`
+     - 12-bit, 500 MSPS
+     - AD9434 EVM
+   * - :doc:`AD9467 <../adi.ad9467>`
+     - 16-bit, 250 MSPS
+     - AD9467 EVM
+   * - :doc:`AD9625 <../adi.ad9625>`
+     - 12-bit, 2.5 GSPS
+     - AD9625 EVM
+   * - :doc:`AD9680 <../adi.ad9680>`
+     - Dual 14-bit, 1.25 GSPS
+     - FMCDAQ2
+
+Mental model
+------------
+
+These parts always live behind an FPGA. The pyadi-iio class talks to the
+IIO driver running on the FPGA's processor (Zynq, ZynqMP, MicroBlaze),
+which talks to the part over SPI for control and over JESD204 for data.
+
+``rx()`` returns either real ndarrays or ``complex128`` ndarrays depending
+on whether the HDL profile includes a digital downconverter (DDC).
+``rx_buffer_size`` is samples per channel; the DMA fills it.
+
+Sample rate is **fixed by the HDL profile**, not settable at runtime in
+most cases. Decimation and NCO frequency (when a DDC is present) are
+runtime-settable. See :doc:`../../concepts` for the buffer / data-shape
+contract.
+
+Minimal example
+---------------
+
+.. code-block:: python
+
+   import adi
+
+   adc = adi.ad9680(uri="ip:analog.local")
+   adc.rx_enabled_channels = [0, 1]
+   adc.rx_buffer_size = 1024
+
+   data = adc.rx()       # list of 2 ndarrays
+
+Common properties
+-----------------
+
+* ``rx_enabled_channels`` — indices of enabled channels (real-valued
+  for parts without a DDC, complex pairs for parts with a DDC).
+* ``rx_buffer_size`` — samples per channel.
+* ``sampling_frequency`` — fixed by the HDL profile; read-only on most
+  parts.
+* DDC properties (where present): ``rx_main_nco_frequencies``,
+  ``rx_channel_nco_frequencies``, ``rx_main_nco_phases``,
+  ``rx_test_mode``.
+* AD9081/AD9084: per-channel and per-main NCO frequency/phase arrays;
+  fine/coarse decimation.
+
+Common gotchas
+--------------
+
+* ``sampling_frequency`` is read-only or HDL-driven on most parts. The
+  way to change it is to flash an HDL design with the desired rate, not
+  to set the property at runtime.
+* Multi-chip variants (``_mc``) bind to multiple IIO devices in one
+  context. If discovery fails, run ``iio_info -u <uri>`` to confirm all
+  expected device names are present.
+* AD9081 / AD9084 DDC channel indexing is non-obvious: complex pairs
+  correspond to (main NCO, channel NCO) tuples. See the per-part page.
+* JESD link bring-up issues surface as zero / garbage samples. Use
+  ``adi.jesd`` (with the ``[jesd]`` extra) to inspect link status.
+* DMA underflows (``rx()`` returns less data than ``rx_buffer_size``)
+  usually mean upstream JESD isn't producing samples — check link state
+  before debugging the Python side.
+
+See also
+--------
+
+* :doc:`Concepts <../../concepts>`
+* :doc:`Examples: multi-channel capture <../../guides/examples>`
+* :doc:`Utility / Infrastructure (JESD debug) <utility>`
+* :doc:`Multi-Chip / Eval Systems <eval_systems>` for board-level
+  platforms like QuadMxFE and Triton.
+
+Reference (per-part API)
+------------------------
 
 .. toctree::
    :maxdepth: 1

--- a/doc/source/devices/families/jesd_dacs.rst
+++ b/doc/source/devices/families/jesd_dacs.rst
@@ -1,0 +1,19 @@
+High-Speed / JESD DACs
+======================
+
+GSPS-class digital-to-analog converters with JESD204B/C serial data paths,
+typically driven by an HDL design on an FPGA.
+
+Family overview content lands in Phase 4. See the parts list below for the
+device classes in this family.
+
+.. toctree::
+   :maxdepth: 1
+
+   ../adi.ad9136
+   ../adi.ad9144
+   ../adi.ad9152
+   ../adi.ad9162
+   ../adi.ad9166
+   ../adi.ad9172
+   ../adi.ad9739a

--- a/doc/source/devices/families/jesd_dacs.rst
+++ b/doc/source/devices/families/jesd_dacs.rst
@@ -1,11 +1,113 @@
 High-Speed / JESD DACs
 ======================
 
-GSPS-class digital-to-analog converters with JESD204B/C serial data paths,
-typically driven by an HDL design on an FPGA.
+GSPS-class DACs that receive samples from an FPGA — most use JESD204B or
+204C serial lanes; the AD9739A uses parallel LVDS. The mirror image of
+the JESD ADC family: complex baseband in, RF or wideband real out,
+fixed sample rate set by the HDL profile.
 
-Family overview content lands in Phase 4. See the parts list below for the
-device classes in this family.
+Parts in this family
+--------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 55 25
+
+   * - Part
+     - Highlights
+     - Typical platform
+   * - :doc:`AD9136 <../adi.ad9136>`
+     - Dual 16-bit, 2.8 GSPS, JESD204B
+     - AD9136 EVM
+   * - :doc:`AD9144 <../adi.ad9144>`
+     - Quad 16-bit, 2.8 GSPS, JESD204B
+     - FMCDAQ2
+   * - :doc:`AD9152 <../adi.ad9152>`
+     - Dual 16-bit, 2.25 GSPS, JESD204B
+     - FMCDAQ3
+   * - :doc:`AD9162 <../adi.ad9162>`
+     - 16-bit, 12 GSPS interpolating
+     - AD9162 EVM
+   * - :doc:`AD9166 <../adi.ad9166>`
+     - 16-bit, 12 GSPS with on-chip NCO
+     - AD9166 EVM
+   * - :doc:`AD9172 <../adi.ad9172>`
+     - Dual 16-bit, 12.6 GSPS, JESD204B
+     - AD9172 EVM
+   * - :doc:`AD9739A <../adi.ad9739a>`
+     - 14-bit, 2.5 GSPS, LVDS
+     - AD9739A EVM
+
+Mental model
+------------
+
+``tx()`` accepts an ndarray (or list of ndarrays, one per enabled
+channel) and pushes it to the DAC via DMA. For parts that include a
+digital upconverter (DUC), the input is complex baseband and the part
+mixes to the configured NCO frequency. For parts without a DUC, the
+input is real, at the DAC sample rate.
+
+Like the JESD ADC family, sample rate is HDL-fixed. Interpolation
+factors, NCO frequencies, and per-channel scaling are runtime-settable.
+
+For continuous waveforms at GSPS rates, use cyclic mode
+(``tx_cyclic_buffer = True``) — Python can't keep refilling the buffer
+fast enough otherwise.
+
+Minimal example
+---------------
+
+.. code-block:: python
+
+   import adi
+   import numpy as np
+
+   dac = adi.ad9172(uri="ip:analog.local")
+   dac.tx_enabled_channels = [0]
+
+   N = 1024
+   fc = 1e6
+   t = np.arange(N) / dac.sample_rate
+   iq = (np.cos(2 * np.pi * fc * t) + 1j * np.sin(2 * np.pi * fc * t)) * 2**14
+
+   dac.tx_cyclic_buffer = True
+   dac.tx(iq)
+
+Common properties
+-----------------
+
+* ``tx_enabled_channels`` — indices of enabled channels.
+* ``tx_cyclic_buffer`` — enable cyclic playback.
+* ``sample_rate`` / ``sampling_frequency`` — HDL-driven; usually read-only.
+* DUC properties: NCO frequencies, interpolation factors, channel
+  scaling.
+* DDS properties on FPGA-side helpers (``dds_single_tone``,
+  ``dds_frequencies``) — see :doc:`../../fpga/index`.
+
+Common gotchas
+--------------
+
+* Cyclic mode requires ``tx_destroy_buffer()`` before re-arming. See
+  :doc:`../../guides/troubleshooting`.
+* For parts with a DUC, the input dtype must be complex. Passing a
+  real ndarray either errors or silently does the wrong thing.
+* NCO frequencies must be within the supported range for the configured
+  interpolation; out-of-range values get clamped.
+* The FPGA-side DDS (``dds_*`` properties) and the chip-side DUC NCO are
+  different things — pyadi-iio exposes both. The DDS replaces the DMA
+  source; the DUC NCO mixes the DMA output.
+
+See also
+--------
+
+* :doc:`Concepts <../../concepts>`
+* :doc:`Examples: cyclic TX <../../guides/examples>`
+* :doc:`FPGA features (DDS, DMA sync) <../../fpga/index>`
+* :doc:`Multi-Chip / Eval Systems <eval_systems>` for board-level
+  TX platforms (FMCDAQ2, FMCDAQ3).
+
+Reference (per-part API)
+------------------------
 
 .. toctree::
    :maxdepth: 1

--- a/doc/source/devices/families/precision_adcs.rst
+++ b/doc/source/devices/families/precision_adcs.rst
@@ -1,0 +1,42 @@
+Precision ADCs
+==============
+
+Lower-speed, high-resolution ADCs — SAR, sigma-delta, and integrated
+signal-chain parts. Covers single-ended SPI/I2C ADCs through multi-channel
+simultaneous-sampling ADCs.
+
+Family overview content lands in Phase 4. See the parts list below for the
+device classes in this family.
+
+.. toctree::
+   :maxdepth: 1
+
+   ../adi.ad4020
+   ../adi.ad405x
+   ../adi.ad4080
+   ../adi.ad4110
+   ../adi.ad4130
+   ../adi.ad4170
+   ../adi.ad4630
+   ../adi.ad469x
+   ../adi.ad4858
+   ../adi.ad514x
+   ../adi.ad7091rx
+   ../adi.ad7124
+   ../adi.ad7134
+   ../adi.ad717x
+   ../adi.ad719x
+   ../adi.ad738x
+   ../adi.ad7490
+   ../adi.ad7606
+   ../adi.ad7689
+   ../adi.ad7768
+   ../adi.ad777x
+   ../adi.ad7799
+   ../adi.ada4355
+   ../adi.adaq8092
+   ../adi.ltc2314_14
+   ../adi.ltc2378
+   ../adi.ltc2387
+   ../adi.ltc2499
+   ../adi.max11205

--- a/doc/source/devices/families/precision_adcs.rst
+++ b/doc/source/devices/families/precision_adcs.rst
@@ -1,12 +1,96 @@
 Precision ADCs
 ==============
 
-Lower-speed, high-resolution ADCs — SAR, sigma-delta, and integrated
-signal-chain parts. Covers single-ended SPI/I2C ADCs through multi-channel
-simultaneous-sampling ADCs.
+Lower-speed, high-resolution ADCs. Covers SAR (e.g., AD7689, AD4020),
+sigma-delta (e.g., AD7124, AD4130), and integrated signal-chain parts
+(e.g., AD4630, AD4858, ADAQ8092). Most parts connect over SPI or I²C
+through an IIO driver in the kernel and don't require FPGA-side HDL,
+though the higher-throughput parts can be paired with an FMC card and
+FPGA DMA.
 
-Family overview content lands in Phase 4. See the parts list below for the
-device classes in this family.
+Parts in this family
+--------------------
+
+This family is large (~30 parts). High-level groups:
+
+* **SAR ADCs (single / multi-channel):** AD4000-series (AD4020,
+  AD4080), AD4858, AD7091RX, AD738x, AD7490, AD7606, AD7689, AD777x,
+  LTC2378, LTC2387, LTC2314_14.
+* **Sigma-delta ADCs:** AD4110, AD4130, AD4170, AD7124, AD7134,
+  AD717x, AD719x, AD7768, AD7799, LTC2499.
+* **Integrated signal-chain / DAQ-class:** AD4630 / ADAQ42xx,
+  AD469x, AD514x, ADA4355, ADAQ8092, AD405x.
+* **High-resolution measurement-class:** AD7799, MAX11205.
+
+Mental model
+------------
+
+Most parts in this family expose one or more channels, each with a
+``raw`` and ``scale`` attribute. Calling ``rx()`` returns the raw
+integer codes; setting ``rx_output_type = "SI"`` returns floats in the
+appropriate engineering unit (volts, ohms, °C — depends on the driver).
+
+Sample rate is configurable on most parts (``sampling_frequency`` or
+``sample_rate``, depending on the driver). For SPI-attached parts, the
+practical limit is the kernel SPI clock, not the part itself. For
+FPGA-DMA-attached parts (AD4858, AD4630), the rate is HDL-driven like
+the JESD family.
+
+Multi-channel parts return a list of ndarrays from ``rx()`` when
+multiple channels are enabled. Some parts also expose per-channel
+sub-objects (``adc.channel["voltage0"].scale``).
+
+Minimal example
+---------------
+
+.. code-block:: python
+
+   import adi
+
+   adc = adi.ad7124(uri="ip:analog.local")
+   adc.sample_rate = 100
+   adc.rx_enabled_channels = [0]
+   adc.rx_buffer_size = 16
+   adc.rx_output_type = "SI"
+
+   data = adc.rx()      # float array in volts (after scaling)
+
+Common properties
+-----------------
+
+* ``rx_enabled_channels`` — channel indices to capture.
+* ``rx_buffer_size`` — samples per channel.
+* ``sampling_frequency`` / ``sample_rate`` — device- or per-channel
+  attribute, depending on the part.
+* ``rx_output_type`` — "raw" or "SI".
+* Per-channel sub-objects (``adc.channel["voltageN"].scale``, etc.)
+  for parts that expose channel-level control.
+
+Common gotchas
+--------------
+
+* Not every part supports ``rx_output_type = "SI"``. Check the per-part
+  autodoc; for parts that don't, multiply ``raw * scale`` yourself.
+* Sigma-delta ADCs have ODR / settling-time interactions. Changing the
+  sample rate and immediately calling ``rx()`` may return values from
+  before the rate took effect.
+* Some integrated signal-chain parts (AD4630, ADAQ8092) need an FPGA
+  with a matching HDL profile — they behave more like JESD parts than
+  like SPI parts despite the lower converter rate.
+* Multi-channel parts that share a single converter (e.g., AD7689 with
+  a mux) cannot truly sample channels simultaneously; the data is a
+  time-sliced interleave.
+* The LTC2499 and similar sigma-delta parts default to slow conversion
+  rates — calling ``rx()`` blocks until the conversion completes.
+
+See also
+--------
+
+* :doc:`Concepts <../../concepts>` — raw vs. SI units, annotated output.
+* :doc:`Examples: multi-channel capture <../../guides/examples>`
+
+Reference (per-part API)
+------------------------
 
 .. toctree::
    :maxdepth: 1

--- a/doc/source/devices/families/precision_dacs.rst
+++ b/doc/source/devices/families/precision_dacs.rst
@@ -1,11 +1,105 @@
 Precision DACs
 ==============
 
-Lower-speed, high-resolution DACs — SPI/I2C parts with on-chip references,
-including multi-function DAC+ADC combos.
+Lower-speed, high-resolution DACs. SPI/I²C parts with on-chip references
+that map well to test, instrumentation, and bias/setpoint applications.
+Includes multi-function parts like the AD5592R (combo DAC + ADC + GPIO).
 
-Family overview content lands in Phase 4. See the parts list below for the
-device classes in this family.
+Parts in this family
+--------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 50 25
+
+   * - Part
+     - Highlights
+     - Typical platform
+   * - :doc:`AD353xR <../adi.ad353xr>`
+     - 16-bit, multi-channel, internal reference
+     - AD353xR EVM
+   * - :doc:`AD3552R / AD3552R-HS <../adi.ad3552r>`
+     - 16-bit, dual-channel, low-noise; HS variant: high-speed mode
+     - AD3552R EVM
+   * - :doc:`AD5592R <../adi.ad5592r>`
+     - Combo: 8-channel ADC + DAC + GPIO
+     - AD5592R EVM
+   * - :doc:`AD5627 <../adi.ad5627>`
+     - Dual 12-bit, I²C
+     - AD5627 EVM
+   * - :doc:`AD5686 <../adi.ad5686>`
+     - Quad 16-bit, SPI
+     - AD5686 EVM
+   * - :doc:`AD5706R / AD5710R / AD5754R <../adi.ad5706r>`
+     - Single / dual / quad 16-bit, integrated reference
+     - AD57xxR EVM
+   * - :doc:`AD579x <../adi.ad579x>`
+     - 16-bit, high-precision
+     - AD579x EVM
+   * - :doc:`LTC2664 / LTC2672 / LTC2688 <../adi.ltc2664>`
+     - 12 / 16-bit, multi-channel, with toggling and softspan
+     - LTC EVM
+
+Mental model
+------------
+
+Most parts in this family operate on a per-channel "set this output
+voltage" pattern rather than a streaming buffer. The pyadi-iio class
+exposes a ``channel`` collection; each channel has a ``raw`` setter
+(integer code) and often a ``scale`` for converting to volts.
+
+Some parts (AD3552R-HS, AD5754R) support streaming TX through a DMA;
+those expose ``tx()`` like the JESD DAC family.
+
+Minimal example
+---------------
+
+.. code-block:: python
+
+   import adi
+
+   dac = adi.ad5686(uri="ip:analog.local")
+   # Set channel 0 to mid-scale
+   dac.channel[0].raw = 32768
+
+For streaming-capable parts:
+
+.. code-block:: python
+
+   dac = adi.ad3552r_hs(uri="ip:analog.local")
+   dac.tx_enabled_channels = [0]
+   dac.tx_cyclic_buffer = True
+   dac.tx(waveform.astype("int16"))
+
+Common properties
+-----------------
+
+* ``channel[i].raw`` — integer code for channel ``i``.
+* ``channel[i].scale`` — scale factor to volts (where supported).
+* ``channel[i].powerdown`` / ``powerdown_mode`` — per-channel power state.
+* For streaming parts: ``tx_enabled_channels``, ``tx_cyclic_buffer``,
+  ``sampling_frequency``.
+
+Common gotchas
+--------------
+
+* Most parts in this family do **not** have a ``tx()`` buffer. They
+  output a static voltage. Look for ``channel[i].raw`` instead.
+* The internal reference must be enabled before the scale value is
+  valid on some parts.
+* Combo parts (AD5592R) require channel-direction configuration
+  (input vs. output) before reads/writes make sense.
+* LTC2688 and similar parts have "toggle" and "dither" modes that
+  pyadi-iio exposes as separate properties; default state may differ
+  from what you expect.
+
+See also
+--------
+
+* :doc:`Concepts <../../concepts>`
+
+Reference (per-part API)
+------------------------
 
 .. toctree::
    :maxdepth: 1

--- a/doc/source/devices/families/precision_dacs.rst
+++ b/doc/source/devices/families/precision_dacs.rst
@@ -1,0 +1,25 @@
+Precision DACs
+==============
+
+Lower-speed, high-resolution DACs — SPI/I2C parts with on-chip references,
+including multi-function DAC+ADC combos.
+
+Family overview content lands in Phase 4. See the parts list below for the
+device classes in this family.
+
+.. toctree::
+   :maxdepth: 1
+
+   ../adi.ad353xr
+   ../adi.ad3552r
+   ../adi.ad3552r_hs
+   ../adi.ad5592r
+   ../adi.ad5627
+   ../adi.ad5686
+   ../adi.ad5706r
+   ../adi.ad5710r
+   ../adi.ad5754r
+   ../adi.ad579x
+   ../adi.ltc2664
+   ../adi.ltc2672
+   ../adi.ltc2688

--- a/doc/source/devices/families/rf_frontend.rst
+++ b/doc/source/devices/families/rf_frontend.rst
@@ -1,12 +1,83 @@
 RF Front-End
 ============
 
-Discrete RF signal-conditioning parts — amplifiers, attenuators, mixers,
-switches, and tunable filters that typically sit between an antenna and a
-transceiver or converter.
+Discrete RF signal-conditioning parts: amplifiers, attenuators, mixers,
+switches, and tunable filters. These sit between an antenna and a
+transceiver/converter and are typically controlled per-set-point, not
+streamed.
 
-Family overview content lands in Phase 4. See the parts list below for the
-device classes in this family.
+Parts in this family
+--------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 60 15
+
+   * - Part
+     - Highlights
+     - Type
+   * - :doc:`ADA4961 <../adi.ada4961>`
+     - DC – 4 GHz digitally controlled VGA
+     - VGA
+   * - :doc:`ADL5240 <../adi.adl5240>`
+     - 0.1 – 4 GHz analog VGA
+     - VGA
+   * - :doc:`ADL5960 <../adi.adl5960>`
+     - 100 MHz – 20 GHz vector network analyzer front-end
+     - Mixer / RX
+   * - :doc:`ADL8113 <../adi.adl8113>`
+     - 4-port SP4T RF switch
+     - Switch
+   * - :doc:`ADMV8818 <../adi.admv8818>`
+     - 2 – 18 GHz digitally tunable filter
+     - Filter
+   * - :doc:`ADRF5720 <../adi.adrf5720>`
+     - 9 kHz – 60 GHz digital attenuator
+     - Attenuator
+
+Mental model
+------------
+
+All control-plane: no buffers. Configure a gain or attenuation, switch
+state, or filter passband, and the device sits in that state until
+reconfigured.
+
+Minimal example
+---------------
+
+.. code-block:: python
+
+   import adi
+
+   atten = adi.adrf5720(uri="ip:analog.local")
+   atten.attenuation = 15.5   # dB
+
+Common properties
+-----------------
+
+* ``gain`` / ``attenuation`` — signed value in dB.
+* ``frequency`` — for tunable filters and mixers, the center / LO
+  frequency.
+* ``switch_state`` / channel-state for switches.
+
+Common gotchas
+--------------
+
+* These parts are often controlled by GPIO or a simple SPI register
+  write. The pyadi-iio class abstracts that, but firmware on the host
+  system has to provide the IIO driver — make sure the driver is in
+  the device tree before construction.
+* Step-size resolution is part-specific (e.g., 0.25 dB for ADRF5720).
+  Setting a value that isn't on the supported grid gets clamped.
+
+See also
+--------
+
+* :doc:`Concepts <../../concepts>`
+* :doc:`RF Transceivers <rf_transceivers>` — common pairing.
+
+Reference (per-part API)
+------------------------
 
 .. toctree::
    :maxdepth: 1

--- a/doc/source/devices/families/rf_frontend.rst
+++ b/doc/source/devices/families/rf_frontend.rst
@@ -1,0 +1,19 @@
+RF Front-End
+============
+
+Discrete RF signal-conditioning parts — amplifiers, attenuators, mixers,
+switches, and tunable filters that typically sit between an antenna and a
+transceiver or converter.
+
+Family overview content lands in Phase 4. See the parts list below for the
+device classes in this family.
+
+.. toctree::
+   :maxdepth: 1
+
+   ../adi.ada4961
+   ../adi.adl5240
+   ../adi.adl5960
+   ../adi.adl8113
+   ../adi.admv8818
+   ../adi.adrf5720

--- a/doc/source/devices/families/rf_transceivers.rst
+++ b/doc/source/devices/families/rf_transceivers.rst
@@ -1,0 +1,19 @@
+RF Transceivers
+===============
+
+Integrated RF transceivers — wide-tuning-range parts that combine ADC, DAC,
+mixer, and LO into one device.
+
+Family overview content lands in Phase 4. See the parts list below for the
+device classes in this family.
+
+.. toctree::
+   :maxdepth: 1
+
+   ../adi.ad936x
+   ../adi.ad937x
+   ../adi.adrv9002
+   ../adi.adrv9009
+   ../adi.adrv9009_zu11eg
+   ../adi.adrv9009_zu11eg_fmcomms8
+   ../adi.adrv9009_zu11eg_multi

--- a/doc/source/devices/families/rf_transceivers.rst
+++ b/doc/source/devices/families/rf_transceivers.rst
@@ -1,11 +1,114 @@
 RF Transceivers
 ===============
 
-Integrated RF transceivers — wide-tuning-range parts that combine ADC, DAC,
-mixer, and LO into one device.
+Integrated RF transceivers combine the entire signal chain — ADC, DAC,
+mixer, LO, and digital filtering — into one device. You give them an LO
+frequency, a sample rate, and a buffer size; you get complex baseband
+samples in and out. Use a part in this family when you need a wide
+tuning range (typically 70 MHz to 6 GHz) and don't want to design a
+discrete RF front-end.
 
-Family overview content lands in Phase 4. See the parts list below for the
-device classes in this family.
+Parts in this family
+--------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 50 25
+
+   * - Part
+     - Highlights
+     - Typical platform
+   * - :doc:`Pluto / AD9361 / AD9363 / AD9364 <../adi.ad936x>`
+     - 70 MHz – 6 GHz, up to 2×2 MIMO, ~56 MHz BW
+     - PlutoSDR, FMComms2/3/4
+   * - :doc:`AD9371 / AD9375 <../adi.ad937x>`
+     - 300 MHz – 6 GHz, 2×2, ~100 MHz BW
+     - ADRV9371 SOM
+   * - :doc:`ADRV9002 <../adi.adrv9002>`
+     - 30 MHz – 6 GHz, 2×2, narrowband + wideband modes
+     - ADRV9002 SOM
+   * - :doc:`ADRV9009 (and ADRV9008-1/-2) <../adi.adrv9009>`
+     - 75 MHz – 6 GHz, 2×2, ~200 MHz BW
+     - ADRV9009 SOM
+   * - :doc:`ADRV9009-ZU11EG (single / FMComms8 / multi) <../adi.adrv9009_zu11eg>`
+     - Quad ADRV9009 on Zynq UltraScale+ MPSoC
+     - ADRV9009-ZU11EG eval
+
+Mental model
+------------
+
+Every part in this family is a complex transceiver. ``rx()`` returns a
+``complex64`` ndarray (or list of them, one per enabled MIMO channel),
+and ``tx()`` takes the same shape. ``rx_enabled_channels = [0]`` means
+"enable channel 0," which is the full I/Q pair — never just I or just Q.
+
+LO, gain, and sample rate are usually device-wide properties; gain mode
+("slow_attack", "manual", "fast_attack") controls how the AGC behaves.
+See :doc:`../../concepts` for the underlying property model.
+
+Minimal example
+---------------
+
+.. code-block:: python
+
+   import adi
+
+   sdr = adi.Pluto(uri="ip:192.168.2.1")
+   sdr.sample_rate = 2_000_000
+   sdr.rx_lo = 2_400_000_000
+   sdr.tx_lo = 2_400_000_000
+   sdr.rx_rf_bandwidth = 2_000_000
+   sdr.gain_control_mode_chan0 = "slow_attack"
+   sdr.rx_buffer_size = 4096
+
+   data = sdr.rx()      # complex64, length 4096
+
+Common properties
+-----------------
+
+These appear on most parts in the family (exact names may vary
+between AD9361 and ADRV9009-class parts):
+
+* ``sample_rate`` — device-wide sample rate in Hz.
+* ``rx_lo`` / ``tx_lo`` — receive and transmit LO frequencies in Hz.
+* ``rx_rf_bandwidth`` / ``tx_rf_bandwidth`` — analog filter bandwidths.
+* ``rx_hardwaregain_chan0`` (and ``_chan1`` for MIMO) — RX gain in dB.
+* ``tx_hardwaregain_chan0`` (and ``_chan1``) — TX attenuation in dB
+  (negative number; closer to 0 is louder).
+* ``gain_control_mode_chan0`` (and ``_chan1`` for MIMO) — AGC mode
+  ("slow_attack", "fast_attack", "manual").
+
+For the full property list see the per-part autodoc below.
+
+Common gotchas
+--------------
+
+* ``rx_enabled_channels = [0]`` enables the full I/Q pair, not a single
+  scalar channel. Indexing into the returned data with ``data[0]`` on
+  a single-channel capture gives you the first complex sample, not the
+  I channel.
+* ``tx_cyclic_buffer = True`` plus a second ``tx()`` without
+  ``tx_destroy_buffer()`` in between will fail. See
+  :doc:`../../guides/troubleshooting`.
+* ``sample_rate`` snaps to legal values. Read it back after setting to
+  confirm what hardware actually programmed.
+* On ADRV9009-class parts, the FPGA HDL profile sets fixed sample-rate
+  and bandwidth options — those rates aren't fully arbitrary.
+* For MIMO parts, RX and TX channels can be enabled independently
+  (``rx_enabled_channels`` and ``tx_enabled_channels`` are distinct).
+* ADRV9009-ZU11EG variants use the ``[jesd]`` extra
+  (``pip install pyadi-iio[jesd]``) for JESD204 debug helpers.
+
+See also
+--------
+
+* :doc:`Concepts <../../concepts>` — rx/tx data shape, properties.
+* :doc:`Examples <../../guides/examples>` — capture+plot, cyclic TX.
+* :doc:`Buffers <../../buffers/index>` — buffer mechanics.
+* :doc:`Troubleshooting <../../guides/troubleshooting>` — common errors.
+
+Reference (per-part API)
+------------------------
 
 .. toctree::
    :maxdepth: 1

--- a/doc/source/devices/families/rf_transceivers.rst
+++ b/doc/source/devices/families/rf_transceivers.rst
@@ -38,7 +38,7 @@ Mental model
 ------------
 
 Every part in this family is a complex transceiver. ``rx()`` returns a
-``complex64`` ndarray (or list of them, one per enabled MIMO channel),
+``complex128`` ndarray (or list of them, one per enabled MIMO channel),
 and ``tx()`` takes the same shape. ``rx_enabled_channels = [0]`` means
 "enable channel 0," which is the full I/Q pair — never just I or just Q.
 
@@ -61,7 +61,7 @@ Minimal example
    sdr.gain_control_mode_chan0 = "slow_attack"
    sdr.rx_buffer_size = 4096
 
-   data = sdr.rx()      # complex64, length 4096
+   data = sdr.rx()      # complex128, length 4096
 
 Common properties
 -----------------

--- a/doc/source/devices/families/sensors_specialty.rst
+++ b/doc/source/devices/families/sensors_specialty.rst
@@ -1,11 +1,115 @@
 Sensors & Specialty
 ===================
 
-Non-IMU sensing and specialty parts — temperature, capacitance, isolated
-inputs, resolver-to-digital, optical/PPG, lidar.
+Non-IMU sensing parts and specialty converters that don't fit a cleaner
+bucket: temperature, capacitance, isolated inputs, resolver-to-digital,
+optical / photoplethysmography, current sense, and lidar.
 
-Family overview content lands in Phase 4. See the parts list below for the
-device classes in this family.
+Parts in this family
+--------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 60 15
+
+   * - Part
+     - Highlights
+     - Quantity
+   * - :doc:`AD2S1210 <../adi.ad2s1210>`
+     - Resolver-to-digital converter
+     - Angle
+   * - :doc:`AD5940 <../adi.ad5940>`
+     - High-precision impedance / electrochemical AFE
+     - Impedance
+   * - :doc:`AD7291 <../adi.ad7291>`
+     - 8-channel voltage + temperature monitor
+     - V / °C
+   * - :doc:`AD7405 <../adi.ad7405>`
+     - Isolated 16-bit sigma-delta modulator
+     - V
+   * - :doc:`AD7746 <../adi.ad7746>`
+     - Capacitance-to-digital converter
+     - F
+   * - :doc:`ADA4356 LiDAR <../adi.ada4356_lidar>`
+     - LiDAR analog front-end
+     - Optical
+   * - :doc:`ADPD188 / ADPD410x / ADPD1080 <../adi.adpd1080>`
+     - Optical / photoplethysmography front-ends
+     - Optical
+   * - :doc:`ADT7420 <../adi.adt7420>`
+     - High-accuracy I²C digital temperature sensor
+     - °C
+   * - :doc:`FMCLIDAR1 <../adi.fmclidar1>`
+     - FMC LiDAR evaluation card
+     - Time-of-flight
+   * - :doc:`LM75 <../adi.lm75>`
+     - I²C temperature sensor (legacy)
+     - °C
+   * - :doc:`LTC2983 <../adi.ltc2983>`
+     - Multi-channel temperature measurement
+     - °C
+   * - :doc:`MAX14001 <../adi.max14001>`
+     - Isolated analog input
+     - V
+   * - :doc:`MAX31855 / MAX31865 <../adi.max31855>`
+     - Thermocouple / RTD-to-digital
+     - °C
+   * - :doc:`MAX9611 <../adi.max9611>`
+     - Current-sense amplifier + 12-bit ADC
+     - A
+
+Mental model
+------------
+
+Most parts in this family expose one or more channels with ``raw`` and
+``scale`` (or a SI-output mode). Conversion runs on demand —
+``adc.rx()`` (where supported) or ``adc.channel[i].raw`` (for
+register-poll parts) triggers a conversion.
+
+Some parts have a streaming buffer (ADPD410x, AD5940) for continuous
+optical / impedance capture. Most don't.
+
+Minimal example
+---------------
+
+.. code-block:: python
+
+   import adi
+
+   temp = adi.adt7420(uri="ip:analog.local")
+   # The ADT7420 exposes a single ``temp`` channel; read its value:
+   print(temp.temp.temp_val)   # raw temperature reading (millidegrees C on Linux)
+
+Common properties
+-----------------
+
+* ``temp.temp_val`` (temperature-class parts) — direct read from the
+  temperature channel.
+* ``channel[i].raw`` / ``channel[i].scale`` — raw codes and scaling.
+* ``rx_output_type = "SI"`` — for streaming parts that support it.
+
+Common gotchas
+--------------
+
+* Thermocouple parts (MAX31855) and RTD parts (MAX31865) report fault
+  conditions through separate properties; a read of the temperature
+  value may return garbage during a fault.
+* Optical parts (ADPD series) have complex LED / sample-timing
+  configuration — read the per-part datasheet for the right setup
+  sequence.
+* AD5940 has many modes (impedance, electrochemical, temperature);
+  each requires a different setup script.
+* The FMCLIDAR1 card and the ADA4356-LiDAR AFE both relate to LiDAR
+  but operate at different levels — FMCLIDAR1 is a board-level eval
+  product; ADA4356-LiDAR is the discrete AFE.
+
+See also
+--------
+
+* :doc:`Concepts <../../concepts>` — raw vs. SI units.
+
+Reference (per-part API)
+------------------------
 
 .. toctree::
    :maxdepth: 1

--- a/doc/source/devices/families/sensors_specialty.rst
+++ b/doc/source/devices/families/sensors_specialty.rst
@@ -1,0 +1,29 @@
+Sensors & Specialty
+===================
+
+Non-IMU sensing and specialty parts — temperature, capacitance, isolated
+inputs, resolver-to-digital, optical/PPG, lidar.
+
+Family overview content lands in Phase 4. See the parts list below for the
+device classes in this family.
+
+.. toctree::
+   :maxdepth: 1
+
+   ../adi.ad2s1210
+   ../adi.ad5940
+   ../adi.ad7291
+   ../adi.ad7405
+   ../adi.ad7746
+   ../adi.ada4356_lidar
+   ../adi.adpd188
+   ../adi.adpd410x
+   ../adi.adpd1080
+   ../adi.adt7420
+   ../adi.fmclidar1
+   ../adi.lm75
+   ../adi.ltc2983
+   ../adi.max14001
+   ../adi.max31855
+   ../adi.max31865
+   ../adi.max9611

--- a/doc/source/devices/families/utility.rst
+++ b/doc/source/devices/families/utility.rst
@@ -1,12 +1,88 @@
 Utility / Infrastructure
 ========================
 
-Helper classes that don't represent a standalone product — JESD204
-debug, generic muxes, TDD controllers, AXI trigger blocks, switches,
-generic 1-bit ADC/DAC.
+Helper classes that don't represent a standalone end-user product:
+JESD204 debug, generic mux drivers, TDD (time-division-duplex)
+controllers, AXI trigger blocks, switches, and generic 1-bit
+ADC/DAC for GPIO-style use.
 
-Family overview content lands in Phase 4. See the parts list below for the
-device classes in this family.
+Parts in this family
+--------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 65 5
+
+   * - Class
+     - Highlights
+     -
+   * - :doc:`adi.jesd <../adi.jesd>`
+     - JESD204 link debug. Requires the ``[jesd]`` extra (paramiko).
+     -
+   * - :doc:`adi.gen_mux <../adi.gen_mux>`
+     - Generic mux / multiplexer driver
+     -
+   * - :doc:`adi.tdd <../adi.tdd>` / :doc:`adi.tddn <../adi.tddn>`
+     - Time-division-duplex controllers (tdd: legacy, tddn: new)
+     -
+   * - :doc:`adi.axi_aion_trig <../adi.axi_aion_trig>`
+     - AXI ION trigger control block (HDL trigger logic)
+     -
+   * - :doc:`adi.adg2128 <../adi.adg2128>`
+     - 12×8 analog crosspoint switch matrix
+     -
+   * - :doc:`adi.one_bit_adc_dac <../adi.one_bit_adc_dac>`
+     - GPIO exposed as 1-bit ADC / DAC for state control
+     -
+
+Mental model
+------------
+
+These classes don't share a common shape with the rest of the
+library — they exist to give Python-level access to infrastructure
+pieces (clocking debug, GPIO, switching) that appear alongside the
+"main" data converters. Each has its own minimal API specific to its
+purpose.
+
+The ``adi.jesd`` class is the most commonly used: when a JESD ADC or
+DAC isn't producing samples, it's the first place to look. It connects
+over SSH to the FPGA-side debugfs and reports link state per lane.
+
+Minimal example
+---------------
+
+.. code-block:: python
+
+   import adi
+
+   jesd = adi.jesd(address="192.168.2.1")
+   print(jesd.get_status("ad9680_rx"))
+
+Common properties
+-----------------
+
+Class-specific — see each class's autodoc.
+
+Common gotchas
+--------------
+
+* ``adi.jesd`` requires paramiko (``pip install pyadi-iio[jesd]``) and
+  SSH access to the FPGA-side OS. Won't work against a stripped-down
+  embedded image without an SSH server.
+* ``adi.tdd`` is the legacy interface; new HDL designs use the
+  ``adi.tddn`` version. Picking the wrong one will report bogus values.
+* ``adi.one_bit_adc_dac`` provides GPIO control through the IIO
+  framework — useful for FPGA-controlled enables and resets, but the
+  GPIO line has to be exposed in the device tree.
+
+See also
+--------
+
+* :doc:`Concepts <../../concepts>`
+* :doc:`Troubleshooting: JESD extras <../../guides/troubleshooting>`
+
+Reference (per-part API)
+------------------------
 
 .. toctree::
    :maxdepth: 1

--- a/doc/source/devices/families/utility.rst
+++ b/doc/source/devices/families/utility.rst
@@ -1,0 +1,20 @@
+Utility / Infrastructure
+========================
+
+Helper classes that don't represent a standalone product — JESD204
+debug, generic muxes, TDD controllers, AXI trigger blocks, switches,
+generic 1-bit ADC/DAC.
+
+Family overview content lands in Phase 4. See the parts list below for the
+device classes in this family.
+
+.. toctree::
+   :maxdepth: 1
+
+   ../adi.adg2128
+   ../adi.axi_aion_trig
+   ../adi.gen_mux
+   ../adi.jesd
+   ../adi.one_bit_adc_dac
+   ../adi.tdd
+   ../adi.tddn

--- a/doc/source/devices/index.rst
+++ b/doc/source/devices/index.rst
@@ -1,158 +1,56 @@
 Supported Devices
 =================
 
+pyadi-iio supports ~150 ADI parts. Devices are grouped into families that
+share usage patterns. Pick the family that matches your part to read the
+shared usage notes, then drill into the per-part API reference under it.
 
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
 
+   * - Family
+     - Description
+   * - :doc:`RF Transceivers <families/rf_transceivers>`
+     - Integrated wide-tuning RF transceivers (Pluto, AD9361, ADRV9002/9009).
+   * - :doc:`High-Speed / JESD ADCs <families/jesd_adcs>`
+     - GSPS-class ADCs with JESD204 data paths (AD9081, AD9084, AD9680, ...).
+   * - :doc:`High-Speed / JESD DACs <families/jesd_dacs>`
+     - GSPS-class DACs with JESD204 data paths (AD9136, AD9162, AD9172, ...).
+   * - :doc:`Precision ADCs <families/precision_adcs>`
+     - SAR / sigma-delta / integrated-signal-chain ADCs.
+   * - :doc:`Precision DACs <families/precision_dacs>`
+     - SPI/I2C DACs and DAC+ADC combos.
+   * - :doc:`IMUs & Motion Sensors <families/imus_motion>`
+     - ADIS16xxx IMUs, ADXL accelerometers, ADXRS gyroscopes.
+   * - :doc:`Clocks, PLLs & Synthesizers <families/clocks_plls>`
+     - ADF synthesizers and HMC clock generators.
+   * - :doc:`RF Front-End <families/rf_frontend>`
+     - Discrete amplifiers, attenuators, mixers, switches, tunable filters.
+   * - :doc:`Beamformers & Phased Array <families/beamformers>`
+     - ADAR1000, CN0566.
+   * - :doc:`Sensors & Specialty <families/sensors_specialty>`
+     - Temperature, capacitance, isolated, resolver, optical, lidar.
+   * - :doc:`Multi-Chip / Eval Systems <families/eval_systems>`
+     - FMC/DAQ daughter cards, CN0xxx reference designs, multi-SOM systems.
+   * - :doc:`Utility / Infrastructure <families/utility>`
+     - JESD debug, gen_mux, tdd, tddn, switches, helpers.
 
 .. toctree::
-   :maxdepth: 2
+   :hidden:
 
-   adi.QuadMxFE_multi
-   adi.ad2s1210
-   adi.ad353xr
-   adi.ad3552r
-   adi.ad3552r_hs
-   adi.ad4020
-   adi.ad405x
-   adi.ad4080
-   adi.ad4110
-   adi.ad4130
-   adi.ad4170
-   adi.ad4630
-   adi.ad469x
-   adi.ad514x
-   adi.ad5592r
-   adi.ad5627
-   adi.ad5686
-   adi.ad5706r
-   adi.ad5710r
-   adi.ad579x
-   adi.ad5754r
-   adi.ad5940
-   adi.ad6676
-   adi.ad7091rx
-   adi.ad7124
-   adi.ad7134
-   adi.ad717x
-   adi.ad719x
-   adi.ad7291
-   adi.ad738x
-   adi.ad7405
-   adi.ad7490
-   adi.ad7606
-   adi.ad7689
-   adi.ad7746
-   adi.ad7768
-   adi.ad777x
-   adi.ad7799
-   adi.ad9081
-   adi.ad9081_mc
-   adi.ad9083
-   adi.ad9084
-   adi.ad9084_mc
-   adi.ad9094
-   adi.ad9136
-   adi.ad9144
-   adi.ad9152
-   adi.ad9162
-   adi.ad9166
-   adi.ad9172
-   adi.ad9213
-   adi.ad9250
-   adi.ad9265
-   adi.ad936x
-   adi.ad937x
-   adi.ad9434
-   adi.ad9467
-   adi.ad9625
-   adi.ad9680
-   adi.ad4858
-   adi.ad9739a
-   adi.ada4355
-   adi.ada4356_lidar
-   adi.ada4961
-   adi.adaq8092
-   adi.adar1000
-   adi.adf4030
-   adi.adf4159
-   adi.adf4355
-   adi.adf4371
-   adi.adf4382
-   adi.adf4377
-   adi.adf5610
-   adi.adf5611
-   adi.adg2128
-   adi.adis16375
-   adi.adis16460
-   adi.adis16475
-   adi.adis16480
-   adi.adis16485
-   adi.adis16488
-   adi.adis16490
-   adi.adis16495
-   adi.adis16497
-   adi.adis16507
-   adi.adis16545
-   adi.adis16547
-   adi.adis16550
-   adi.adl5240
-   adi.adl5960
-   adi.adl8113
-   adi.admv8818
-   adi.adpd1080
-   adi.adpd188
-   adi.adpd410x
-   adi.adrf5720
-   adi.adrv9002
-   adi.adrv9009
-   adi.adrv9009_zu11eg
-   adi.adrv9009_zu11eg_fmcomms8
-   adi.adrv9009_zu11eg_multi
-   adi.adt7420
-   adi.adxl313
-   adi.adxl345
-   adi.adxl355
-   adi.adxl380
-   adi.adxrs290
-   adi.axi_aion_trig
-   adi.cn0511
-   adi.cn0532
-   adi.cn0540
-   adi.cn0554
-   adi.cn0556
-   adi.cn0565
-   adi.cn0566
-   adi.cn0575
-   adi.cn0579
-   adi.daq2
-   adi.daq3
-   adi.fmc_vna
-   adi.fmcadc3
-   adi.fmcjesdadc1
-   adi.fmclidar1
-   adi.fmcomms5
-   adi.fmcomms11
-   adi.gen_mux
-   adi.hmc7044
-   adi.jesd
-   adi.lm75
-   adi.ltc2314_14
-   adi.ltc2378
-   adi.ltc2387
-   adi.ltc2499
-   adi.ltc2664
-   adi.ltc2688
-   adi.ltc2672
-   adi.ltc2983
-   adi.max11205
-   adi.max14001
-   adi.max31855
-   adi.max31865
-   adi.max9611
-
-   adi.one_bit_adc_dac
-   adi.tdd
-   adi.tddn
+   families/rf_transceivers
+   families/jesd_adcs
+   families/jesd_dacs
+   families/precision_adcs
+   families/precision_dacs
+   families/imus_motion
+   families/clocks_plls
+   families/rf_frontend
+   families/beamformers
+   families/sensors_specialty
+   families/eval_systems
+   families/utility
 
 -----
 

--- a/doc/source/guides/connectivity.rst
+++ b/doc/source/guides/connectivity.rst
@@ -1,6 +1,9 @@
 Connectivity
 ===================
 
+.. seealso::
+   :doc:`Concepts: URIs and connecting to a device <../concepts>`
+
 Since pyadi-iio is built on top of libiio, it can use the different `backends <https://wiki.analog.com/resources/tools-software/linux-software/libiio>`_ which allow device control and data transfer to and from devices remotely. These backends include serial, Ethernet, PCIe, USB, and of course locally connected devices can be controlled through the local backend. Connecting to a board remotely over a specific backend is done by defining a specific universal resource indicator (URI) and passing it to the class constructors for a specific device. Here is a simple example that uses the Ethernet backend with a target board with IP address 192.168.2.1:
 
 .. code-block:: python

--- a/doc/source/guides/examples.rst
+++ b/doc/source/guides/examples.rst
@@ -1,74 +1,138 @@
 Examples
-===================
+========
 
-Here is a collection of small examples which demonstrate how to interface with different devices in different ways.
+End-to-end workflows that combine connection, configuration, capture,
+and post-processing. Each example assumes ``pyadi-iio``, ``numpy``, and
+``matplotlib`` are installed; replace the example URI with one that
+matches your hardware.
 
-Configuring hardware properties and reading back settings
+For shorter snippets covering one feature at a time, see the
+:doc:`concepts page <../concepts>` and the :doc:`buffers page <../buffers/index>`.
+For longer scripts (including FPGA-board-specific demos), see the
+``examples/`` directory in the
+`source repository <https://github.com/analogdevicesinc/pyadi-iio/tree/master/examples>`_.
 
-.. code-block:: python
+Capture and plot
+----------------
 
-  # Import the library
-  import adi
-
-  # Create a device interface
-  sdr = adi.ad9361()
-  # Configure properties
-  sdr.rx_rf_bandwidth = 4000000
-  sdr.rx_lo = 2000000000
-  sdr.tx_lo = 2000000000
-  sdr.tx_cyclic_buffer = True
-  sdr.tx_hardwaregain = -30
-  sdr.gain_control_mode = "slow_attack"
-  # Read back properties from hardware
-  print(sdr.rx_hardwaregain)
-
-Send data to a device and receiving data from a device
+Connect to a PlutoSDR, configure the LO and sample rate, capture a
+buffer, and plot the magnitude spectrum.
 
 .. code-block:: python
 
-  import adi
-  import numpy as np
+   import adi
+   import numpy as np
+   import matplotlib.pyplot as plt
 
-  sdr = adi.ad9361()
-  data = np.arange(1, 10, 3)
-  # Send
-  sdr.tx(data)
-  # Receive
-  data_rx = sdr.rx()
+   sdr = adi.Pluto(uri="ip:192.168.2.1")
+   sdr.sample_rate = 2_000_000
+   sdr.rx_lo = 2_400_000_000
+   sdr.rx_rf_bandwidth = 2_000_000
+   sdr.gain_control_mode = "slow_attack"
+   sdr.rx_buffer_size = 4096
 
-Configure the DDS of a transmit capable FPGA based device
+   data = sdr.rx()  # complex64 ndarray, length 4096
 
-.. code-block:: python
+   fft = np.fft.fftshift(np.fft.fft(data))
+   psd = 20 * np.log10(np.abs(fft) + 1e-12)
+   freqs = np.fft.fftshift(np.fft.fftfreq(len(data), 1 / sdr.sample_rate))
 
-  import adi
+   plt.plot(freqs / 1e6, psd)
+   plt.xlabel("Frequency offset (MHz)")
+   plt.ylabel("Magnitude (dB)")
+   plt.show()
 
-  sdr = adi.DAQ2()
-  # Configure DDS
-  tone_freq_hz = 1000  # In Hz
-  tone_scale = 0.9  # Range: 0-1.0
-  tx_channel = 1  # Starts at 0
-  sdr.dds_single_tone(tone_freq_hz, tone_scale, tx_channel)
+The data shape is ``complex64`` because the Pluto is a complex part. The
+:doc:`concepts page <../concepts>` covers the data shape contract for
+both complex and real parts.
 
+Cyclic TX of a tone
+-------------------
 
-Using URIs to access specific devices over the network
-
-.. code-block:: python
-
-  import adi
-
-  # Create device from specific uri address
-  sdr = adi.ad9361(uri="ip:192.168.2.1")
-  data = sdr.rx()
-
-Using URIs to access specific devices over USB
+Generate a complex sinusoid and transmit it in a loop. Cyclic mode is
+the practical way to keep multi-MSPS transmitters fed from Python — see
+the buffer mechanics on the :doc:`buffers page <../buffers/index>`.
 
 .. code-block:: python
 
-  import adi
+   import adi
+   import numpy as np
 
-  # Create device from specific uri address
-  sdr = adi.Pluto(uri="usb:1.24.5")
-  data = sdr.rx()
+   sdr = adi.Pluto(uri="ip:192.168.2.1")
+   sdr.sample_rate = 2_000_000
+   sdr.tx_lo = 2_400_000_000
+   sdr.tx_rf_bandwidth = 2_000_000
+   sdr.tx_hardwaregain_chan0 = -10
 
+   N = 1024
+   fc = 100_000
+   t = np.arange(N) / sdr.sample_rate
+   iq = (np.cos(2 * np.pi * fc * t) + 1j * np.sin(2 * np.pi * fc * t)) * 2**14
 
-Other complex examples are available in the `source repository <https://github.com/analogdevicesinc/pyadi-iio/tree/master/examples>`_
+   sdr.tx_cyclic_buffer = True
+   sdr.tx(iq.astype(np.complex64))
+
+   # The buffer is now repeating in hardware. Leave it running, or...
+   sdr.tx_destroy_buffer()  # required before re-arming with new data
+
+Common gotcha: once a cyclic buffer is loaded, any further ``tx()`` call
+will fail until ``tx_destroy_buffer()`` is called.
+
+Multi-channel capture
+---------------------
+
+A multi-channel ADC returns a list of arrays, one per enabled channel.
+
+.. code-block:: python
+
+   import adi
+
+   adc = adi.ad7768_4(uri="ip:analog.local")
+   adc.rx_buffer_size = 1024
+
+   # Single channel — returns one ndarray
+   adc.rx_enabled_channels = [0]
+   chan0 = adc.rx()
+   print(type(chan0), chan0.shape)  # ndarray, (1024,)
+
+   # Two channels — returns a list of ndarrays
+   adc.rx_enabled_channels = [0, 1]
+   data = adc.rx()
+   print(type(data), len(data), data[0].shape)  # list, 2, (1024,)
+
+The single-vs-list output behavior is intentional: scalar in, scalar
+out — but it can surprise users who expect a list of length 1 with one
+channel enabled. See the :doc:`concepts page <../concepts>` for the
+full data shape contract.
+
+Annotated output for IMUs
+-------------------------
+
+For IMUs with mixed channel types (acceleration, angular velocity,
+temperature) the array-of-arrays output is hard to read. Setting
+``rx_annotated = True`` makes ``rx()`` return a dict keyed by channel
+name.
+
+.. code-block:: python
+
+   import adi
+
+   imu = adi.adis16495(uri="serial:/dev/ttyUSB0,115200")
+   imu.rx_buffer_size = 16
+   imu.rx_enabled_channels = [0, 3]  # accel_x and anglvel_x
+   imu.rx_annotated = True
+
+   data = imu.rx()
+   print(data.keys())          # dict_keys(['accel_x', 'anglvel_x'])
+   print(data["accel_x"][:4])
+
+Combine with ``rx_output_type = "SI"`` to get the values in m/s² and
+rad/s instead of raw codes.
+
+See also
+--------
+
+* :doc:`Concepts <../concepts>`
+* :doc:`Buffers <../buffers/index>`
+* :doc:`FPGA features (DDS, DMA sync) <../fpga/index>`
+* Longer scripts in the `examples/` directory of the repo.

--- a/doc/source/guides/examples.rst
+++ b/doc/source/guides/examples.rst
@@ -31,7 +31,7 @@ buffer, and plot the magnitude spectrum.
    sdr.gain_control_mode = "slow_attack"
    sdr.rx_buffer_size = 4096
 
-   data = sdr.rx()  # complex64 ndarray, length 4096
+   data = sdr.rx()  # complex128 ndarray, length 4096
 
    fft = np.fft.fftshift(np.fft.fft(data))
    psd = 20 * np.log10(np.abs(fft) + 1e-12)
@@ -42,7 +42,7 @@ buffer, and plot the magnitude spectrum.
    plt.ylabel("Magnitude (dB)")
    plt.show()
 
-The data shape is ``complex64`` because the Pluto is a complex part. The
+The data shape is ``complex128`` because the Pluto is a complex part. The
 :doc:`concepts page <../concepts>` covers the data shape contract for
 both complex and real parts.
 
@@ -70,7 +70,7 @@ the buffer mechanics on the :doc:`buffers page <../buffers/index>`.
    iq = (np.cos(2 * np.pi * fc * t) + 1j * np.sin(2 * np.pi * fc * t)) * 2**14
 
    sdr.tx_cyclic_buffer = True
-   sdr.tx(iq.astype(np.complex64))
+   sdr.tx(iq)
 
    # The buffer is now repeating in hardware. Leave it running, or...
    sdr.tx_destroy_buffer()  # required before re-arming with new data

--- a/doc/source/guides/examples.rst
+++ b/doc/source/guides/examples.rst
@@ -10,7 +10,7 @@ For shorter snippets covering one feature at a time, see the
 :doc:`concepts page <../concepts>` and the :doc:`buffers page <../buffers/index>`.
 For longer scripts (including FPGA-board-specific demos), see the
 ``examples/`` directory in the
-`source repository <https://github.com/analogdevicesinc/pyadi-iio/tree/master/examples>`_.
+`source repository <https://github.com/analogdevicesinc/pyadi-iio/tree/main/examples>`_.
 
 Capture and plot
 ----------------
@@ -28,7 +28,7 @@ buffer, and plot the magnitude spectrum.
    sdr.sample_rate = 2_000_000
    sdr.rx_lo = 2_400_000_000
    sdr.rx_rf_bandwidth = 2_000_000
-   sdr.gain_control_mode = "slow_attack"
+   sdr.gain_control_mode_chan0 = "slow_attack"
    sdr.rx_buffer_size = 4096
 
    data = sdr.rx()  # complex128 ndarray, length 4096
@@ -119,7 +119,7 @@ name.
 
    imu = adi.adis16495(uri="serial:/dev/ttyUSB0,115200")
    imu.rx_buffer_size = 16
-   imu.rx_enabled_channels = [0, 3]  # accel_x and anglvel_x
+   imu.rx_enabled_channels = [3, 0]  # accel_x and anglvel_x
    imu.rx_annotated = True
 
    data = imu.rx()
@@ -135,4 +135,4 @@ See also
 * :doc:`Concepts <../concepts>`
 * :doc:`Buffers <../buffers/index>`
 * :doc:`FPGA features (DDS, DMA sync) <../fpga/index>`
-* Longer scripts in the `examples/` directory of the repo.
+* Longer scripts in the ``examples/`` directory of the repo.

--- a/doc/source/guides/quick.rst
+++ b/doc/source/guides/quick.rst
@@ -65,18 +65,13 @@ To deactivate the virtual environment run:
 
   deactivate
 
+.. note::
+
+   For development work on pyadi-iio itself (not just using it), run
+   ``make dev`` from the repo root. It creates ``venv/``, activates it,
+   and installs the dev requirements in one step.
+
 Once the virtual environment is activated, you can install pyadi-iio as normal with pip.
-
-Here is a full example of a virtual environment setup and install of pyadi-iio:
-
-.. code-block:: bash
-
-  dave@hal:~$ python3 -m venv /home/dave/venv/pyadi-iio
-  dave@hal:~$ source /home/dave/venv/pyadi-iio/bin/activate
-  (pyadi-iio) dave@hal:~$ pip install pyadi-iio
-  Collecting pyadi-iio
-    Downloading ...
-
 
 Conda Install
 -------------
@@ -94,28 +89,35 @@ Check for libiio with the following from a command prompt or terminal:
 
 .. code-block:: bash
 
-  dave@hal:~$ python3
-  Python 3.6.8 (default, Jan 14 2019, 11:02:34)
-  [GCC 8.0.1 20180414 (experimental) [trunk revision 259383]] on linux
+  $ python3
+  Python 3.10.12 (main, Sep 12 2023, 09:00:00) [GCC 11.4.0] on linux
   Type "help", "copyright", "credits" or "license" for more information.
   >>> import iio
   >>> iio.version
-  (0, 18, 'eec5616')
+  (1, 0, 'release')
 
-
-If that worked, try the follow to see if pyadi-iio is there:
+If that worked, check that pyadi-iio is there:
 
 .. code-block:: bash
 
-  dave@hal:~$ python3
-  Python 3.6.8 (default, Jan 14 2019, 11:02:34)
-  [GCC 8.0.1 20180414 (experimental) [trunk revision 259383]] on linux
+  $ python3
+  Python 3.10.12 (main, Sep 12 2023, 09:00:00) [GCC 11.4.0] on linux
   Type "help", "copyright", "credits" or "license" for more information.
   >>> import adi
   >>> adi.__version__
-  '0.0.5'
+  '0.0.21'
   >>> adi.name
   'Analog Devices Hardware Interfaces'
 
+pyadi-iio supports libiio v0.x and v1.x; the version above is illustrative
+and the library handles both transparently through ``adi.compat``.
+
 When using virtual environments, ``iio`` can be imported from outside but not from inside by default because virtual environments do not inherit system packages.
 Either install the python environment with ``--system-site-packages`` to inherit all system packages or set ``PYTHONPATH`` environment variable to inherit from some paths.
+
+What next
+---------
+
+* :doc:`Concepts <../concepts>` — the rx/tx/attribute/URI mental model.
+* :doc:`Supported devices <../devices/index>` — find your part by family.
+* :doc:`Troubleshooting <troubleshooting>` — common errors during install or first connection.

--- a/doc/source/guides/troubleshooting.rst
+++ b/doc/source/guides/troubleshooting.rst
@@ -1,0 +1,139 @@
+Troubleshooting
+===============
+
+Symptom → cause → fix. Entries are short and pragmatic; if your problem
+isn't here, see :doc:`Support <../support>` or the
+`EngineerZone forum <https://ez.analog.com/sw-interface-tools/f/q-a>`_.
+
+import iio / libiio not found
+-----------------------------
+
+**Symptom:** ``ImportError: No module named iio`` or ``cannot find -liio``.
+
+**Cause:** The libiio Python bindings (``pylibiio``) or the C library
+itself isn't on the path. Common when libiio was built from source and
+installed to ``/usr/local/lib/pythonX.Y/site-packages``, which a virtualenv
+won't see by default.
+
+**Fix:** Either set ``PYTHONPATH`` to include the site-packages dir
+where ``iio.py`` lives, or recreate the venv with
+``--system-site-packages``, or ``pip install pylibiio`` to get the
+PyPI build.
+
+No device found on instantiation
+--------------------------------
+
+**Symptom:** ``Exception: No device found`` when calling
+``adi.<part>(uri=...)``.
+
+**Cause:** The URI doesn't reach a libiio context, or the context
+doesn't contain a device the class is looking for. Common cases:
+firewall blocking the Ethernet backend, USB enumeration delay,
+typo in the IP/hostname, hardware not powered.
+
+**Fix:** Verify with ``iio_info`` directly: ``iio_info -u ip:192.168.2.1``
+should list devices. If that fails, the problem is below pyadi-iio.
+If it succeeds but pyadi-iio still fails, the class is looking for a
+device name that isn't in this context (e.g., wrong HDL profile).
+
+rx() returns an empty array
+---------------------------
+
+**Symptom:** ``sdr.rx()`` returns an array of length 0 or a list of
+empty arrays.
+
+**Cause:** ``rx_buffer_size`` was set to 0, no channels are enabled,
+or the DMA underflowed before the buffer filled.
+
+**Fix:** Confirm ``sdr.rx_buffer_size`` is the sample count you expect.
+Confirm ``sdr.rx_enabled_channels`` is non-empty. If both look right,
+the DMA is underflowing — usually because the upstream HDL isn't
+producing samples (LO not locked, sample rate misconfigured, no clock).
+
+tx() raises after the first call
+--------------------------------
+
+**Symptom:** First ``tx()`` works; second ``tx()`` raises or hangs.
+
+**Cause:** ``tx_cyclic_buffer = True`` was set, and the cyclic buffer
+must be torn down before re-arming.
+
+**Fix:** Call ``sdr.tx_destroy_buffer()`` before the second ``tx()``.
+
+Property read returns a stale value
+-----------------------------------
+
+**Symptom:** ``sdr.foo = X`` followed by ``print(sdr.foo)`` shows the
+old value or a snapped-to-grid value.
+
+**Cause:** Some drivers clamp setpoints to a supported grid; some
+expose the raw last-write rather than the active value. This is
+device-specific.
+
+**Fix:** Check the per-part datasheet for the supported grid. For
+sample rates and LO frequencies, the readback usually reflects what
+the hardware actually programmed, not what you tried to set.
+
+attr not defined in <class>
+---------------------------
+
+**Symptom:** ``AttributeError: <attr> not defined in <class>``.
+
+**Cause:** Either the wrong subclass (e.g., using ``adi.ad9361`` against
+an AD9364, which doesn't have channel-1 properties), or a driver variant
+mismatch (the IIO ``compatible`` string in the kernel is different from
+what pyadi-iio expects).
+
+**Fix:** Confirm the device name reported by ``iio_info -u <uri>`` matches
+what the class binds to. If you're using a multi-class module (e.g.,
+``adi.ad936x``), try the specific subclass (``adi.ad9364``).
+
+Multi-chip / _mc class doesn't find all devices
+-----------------------------------------------
+
+**Symptom:** ``adi.ad9081_mc(uri=..., phy_dev_names=[...])`` fails to
+discover all the chips, or only sees a subset.
+
+**Cause:** The context doesn't expose every expected device, usually
+because the FPGA design is misconfigured or only one chip is up.
+
+**Fix:** ``iio_info -u <uri> | head -50`` to enumerate what the context
+actually contains. The ``_mc`` class names map 1:1 to IIO device names.
+
+libiio v0 vs. v1 behavior differences
+-------------------------------------
+
+**Symptom:** Code that worked on one machine fails on another with
+buffer-mask or channel-find errors.
+
+**Cause:** pyadi-iio supports both libiio v0.x and v1.x via
+``adi/compat.py``, but a few buffer-management behaviors differ —
+v1 uses ``iio.Stream`` and ``iio.ChannelsMask``; v0 uses ``iio.Buffer``.
+
+**Fix:** Check the libiio version both ends are running:
+``python -c "import iio; print(iio.version)"``. For now, prefer libiio
+v0.x for stable behavior; v1.x support is current but its Python
+bindings are not yet on PyPI. See :doc:`../libiio`.
+
+pyadi-iio[jesd] extras vs. base install
+---------------------------------------
+
+**Symptom:** ``ModuleNotFoundError: No module named 'paramiko'`` when
+constructing the JESD debug class.
+
+**Cause:** ``adi.jesd`` requires ``paramiko``, which is optional and
+only installed with the ``[jesd]`` extra.
+
+**Fix:** ``pip install pyadi-iio[jesd]``. The JESD debug class is
+typically only needed for ADRV9009-ZU11EG multi-SOM configurations;
+if you don't use those, you don't need the extra.
+
+Reporting new issues
+--------------------
+
+If your problem isn't covered above, please open an issue at the
+`pyadi-iio GitHub <https://github.com/analogdevicesinc/pyadi-iio/issues>`_
+or post on the
+`EngineerZone <https://ez.analog.com/sw-interface-tools/f/q-a>`_.
+Include the libiio version, pyadi-iio version, OS, and the output of
+``iio_info -u <your-uri>``.

--- a/doc/source/guides/troubleshooting.rst
+++ b/doc/source/guides/troubleshooting.rst
@@ -91,8 +91,8 @@ what the class binds to. If you're using a multi-class module (e.g.,
 Multi-chip / _mc class doesn't find all devices
 -----------------------------------------------
 
-**Symptom:** ``adi.ad9081_mc(uri=..., phy_dev_names=[...])`` fails to
-discover all the chips, or only sees a subset.
+**Symptom:** ``adi.ad9081_mc(uri=..., phy_dev_name="ad9081-phy")`` fails
+to discover all the chips, or only sees a subset.
 
 **Cause:** The context doesn't expose every expected device, usually
 because the FPGA design is misconfigured or only one chip is up.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -77,6 +77,7 @@ Sections
    :maxdepth: 1
 
    guides/quick
+   concepts
    attr/index
    guides/examples
    guides/connectivity

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -80,6 +80,7 @@ Sections
    attr/index
    guides/examples
    guides/connectivity
+   guides/troubleshooting
    buffers/index
    fpga/index
    mcp/index

--- a/doc/update_devs.py
+++ b/doc/update_devs.py
@@ -78,30 +78,19 @@ def update_devs():
         "device_base",
         "mcp_server",
     ]
+    # Remove excluded-class rst files that sphinx-apidoc generated.
+    # Note: we deliberately do NOT regenerate index.rst here — it is
+    # hand-authored as the family landing page. See Task 1 of the
+    # doc-improvements plan.
+    for s in to_skip:
+        excluded = os.path.join(root, "source", "devices", "adi.{}.rst".format(s))
+        if os.path.exists(excluded):
+            os.remove(excluded)
+
+    # Clean up the temporary adi.rst that sphinx-apidoc produced.
     adi_rst_path = os.path.join(root, "source", "devices", "adi.rst")
-    with open(adi_rst_path, "r") as f:
-        lines = f.readlines()
-        for s in to_skip:
-            os.remove(os.path.join(root, "source", "devices", "adi.{}.rst".format(s)))
-            lines = [l for l in lines if s not in l]
-        txt = "".join(lines)
-    with open(adi_rst_path, "w") as f:
-        f.write(txt)
-
-    # Remove extra text
-    with open(adi_rst_path, "r") as f:
-        lines = f.readlines()
-        lines = [l for l in lines if "Module" not in l]
-        lines = [l.replace("adi package", "Supported Devices") for l in lines]
-        lines = [l.replace("Submodules", "") for l in lines]
-        lines = [l.replace("----------", "") for l in lines]
-        lines = [l.replace("===========", "=================") for l in lines]
-        txt = "".join(lines)
-
-    with open(os.path.join(root, "source", "devices", "index.rst"), "w") as f:
-        f.write(txt)
-
-    os.remove(adi_rst_path)
+    if os.path.exists(adi_rst_path):
+        os.remove(adi_rst_path)
 
 
 if __name__ == "__main__":

--- a/doc/update_devs.py
+++ b/doc/update_devs.py
@@ -6,7 +6,17 @@ import os
 
 def update_devs():
     root = os.path.dirname(os.path.abspath(__file__))
+    # Guard: this script only manages per-part adi.*.rst files. It must
+    # never touch the family landing pages or the supported-devices index.
     devices = glob.glob(os.path.join(root, "source", "devices", "adi.*.rst"))
+    forbidden = {
+        os.path.join(root, "source", "devices", "index.rst"),
+    }
+    forbidden.update(
+        glob.glob(os.path.join(root, "source", "devices", "families", "*.rst"))
+    )
+    for d in devices:
+        assert d not in forbidden, f"update_devs would touch family file: {d}"
 
     skip = ["adi.ad9081_mc.rst"]
     devices = [d for d in devices if os.path.basename(d) not in skip]

--- a/tasks.py
+++ b/tasks.py
@@ -1,5 +1,6 @@
 # type:ignore
 # flake8: noqa
+import glob
 import os
 import pathlib
 import sys
@@ -328,7 +329,54 @@ def checkemulation(c):
     sys.exit(count)
 
 
-@task(checkparts)
+@task
+def checkdocs(c):
+    """Check every per-part doc page is referenced from a family page"""
+    print("Running per-part doc coverage check")
+    path = pathlib.Path(__file__).parent.absolute()
+    devices_dir = os.path.join(path, "doc", "source", "devices")
+    families_dir = os.path.join(devices_dir, "families")
+
+    # Every adi.*.rst file in devices/ must be reachable from a family.
+    per_part = sorted(
+        os.path.basename(p).removesuffix(".rst")
+        for p in glob.glob(os.path.join(devices_dir, "adi.*.rst"))
+    )
+
+    # Read all family files; record which per-part refs they mention.
+    referenced = set()
+    family_files = sorted(glob.glob(os.path.join(families_dir, "*.rst")))
+    if not family_files:
+        print("No family files found under doc/source/devices/families/")
+        sys.exit(1)
+    for ff in family_files:
+        with open(ff) as fh:
+            content = fh.read()
+        for name in per_part:
+            # Family pages reference per-part pages via toctree entries
+            # like "../adi.ad9361" — anchor on the "../" prefix so a
+            # substring match in prose can't satisfy coverage.
+            if f"../{name}" in content:
+                referenced.add(name)
+
+    missing = [n for n in per_part if n not in referenced]
+    if missing:
+        print(
+            "The following per-part doc pages are not referenced from "
+            "any family file under doc/source/devices/families/:"
+        )
+        for n in missing:
+            print(f"  {n}")
+        print(
+            "Add each one to the appropriate family page's toctree. "
+            "See doc/source/devices/index.rst for the family list."
+        )
+        sys.exit(len(missing))
+
+    print(f"All {len(per_part)} per-part doc pages are assigned to a family")
+
+
+@task(checkparts, checkemulation, checkdocs)
 def precommit(c):
     """Run precommit checks"""
     c.run("pre-commit run --all-files")

--- a/tasks.py
+++ b/tasks.py
@@ -3,6 +3,7 @@
 import glob
 import os
 import pathlib
+import re
 import sys
 
 import yaml
@@ -339,7 +340,7 @@ def checkdocs(c):
 
     # Every adi.*.rst file in devices/ must be reachable from a family.
     per_part = sorted(
-        os.path.basename(p).removesuffix(".rst")
+        os.path.splitext(os.path.basename(p))[0]
         for p in glob.glob(os.path.join(devices_dir, "adi.*.rst"))
     )
 
@@ -353,10 +354,11 @@ def checkdocs(c):
         with open(ff) as fh:
             content = fh.read()
         for name in per_part:
-            # Family pages reference per-part pages via toctree entries
-            # like "../adi.ad9361" — anchor on the "../" prefix so a
-            # substring match in prose can't satisfy coverage.
-            if f"../{name}" in content:
+            # Anchor on line start + whitespace so a substring match
+            # like "../adi.tdd" inside "../adi.tddn" cannot satisfy
+            # coverage. A toctree entry is a line of the form
+            # "   ../adi.<name>" — match exactly that shape.
+            if re.search(rf"^\s*\.\./{re.escape(name)}\s*$", content, re.M):
                 referenced.add(name)
 
     missing = [n for n in per_part if n not in referenced]


### PR DESCRIPTION
## Summary

End-user documentation refresh on top of the existing Sphinx + `adi_doctools` build.

- **Family taxonomy.** 145 per-part docs are now reachable through 12 hand-authored family pages under `doc/source/devices/families/` (RF Transceivers, JESD ADCs, JESD DACs, Precision ADCs, Precision DACs, IMUs, Clocks/PLLs, RF Front-End, Beamformers, Sensors & Specialty, Eval Systems, Utility). `doc/source/devices/index.rst` becomes a 12-row family landing page. Per-part `adi.<part>.rst` files stay flat on disk so `doc/update_devs.py` keeps working.
- **New concepts page** (`doc/source/concepts.rst`) explains the rx/tx/attribute/URI mental model — bridges quick-start to per-part API reference. Cross-linked from `attr/`, `buffers/`, `connectivity`.
- **Getting-started refresh.** `quick.rst` modernized (Python 3.10, libiio v1.x, `make dev`), `examples.rst` expanded with four end-to-end workflows, new `troubleshooting.rst` with 10 seed FAQ entries.
- **New `invoke checkdocs` gate** (`tasks.py`) asserts every per-part `adi.*.rst` is referenced from at least one family file. Wired into `precommit` and the `CheckParts` CI job. `update_devs.py` now skips overwriting the hand-authored `devices/index.rst`.

## Test plan

- [x] `make html SPHINXOPTS="-W"` passes with zero warnings
- [x] `invoke checkdocs` reports "All 145 per-part doc pages are assigned to a family"
- [x] `make linkcheck` passes
- [ ] Visual review of the rendered docs on the GH Pages preview
- [ ] Confirm CI `CheckParts` job runs `invoke checkdocs` as expected