### PR TITLE
Update paramiko dependency to more secure version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,8 @@ pyadi-iio-mcp = "adi.mcp_server:main"
 
 [project.optional-dependencies]
 jesd = [
-    "paramiko"
+    "paramiko",
+    "cryptography>=48.0.0", # paramiko dependency
 ]
 mcp = [
     "fastmcp",


### PR DESCRIPTION
Limit paramiko (SSH dependency for JESD) version