### PR TITLE
Migrate 10 device classes to device_base common parents

### DIFF
--- a/adi/ad3552r_hs.py
+++ b/adi/ad3552r_hs.py
@@ -5,66 +5,78 @@
 from decimal import Decimal
 
 from adi.attribute import attribute
-from adi.context_manager import context_manager
-from adi.rx_tx import tx
+from adi.device_base import tx_chan_comp
 
 
-class ad3552r_hs(tx, context_manager):
+class ad3552r_hs_channel(attribute):
+    """AD3552R_HS channel"""
+
+    def __init__(self, ctrl, channel_name, output):
+        self.name = channel_name
+        self._ctrl = ctrl
+        self._output = output
+
+    @property
+    def sample_rate(self):
+        """Sample rate of the DAC"""
+        return self._get_iio_attr(self.name, "sampling_frequency", True)
+
+    @sample_rate.setter
+    def sample_rate(self, value):
+        self._set_iio_attr(self.name, "sampling_frequency", True, value)
+
+    @property
+    def raw(self):
+        """Get channel raw value
+            DAC code in the range 0-65535"""
+        return self._get_iio_attr(self.name, "raw", True)
+
+    @raw.setter
+    def raw(self, value):
+        """Set channel raw value"""
+        self._set_iio_attr(self.name, "raw", True, str(int(value)))
+
+    @property
+    def offset(self):
+        """Get channel offset"""
+        return self._get_iio_attr_str(self.name, "offset", True)
+
+    @offset.setter
+    def offset(self, value):
+        """Set channel offset"""
+        self._set_iio_attr(self.name, "offset", True, str(Decimal(value).real))
+
+    @property
+    def scale(self):
+        """Get channel scale"""
+        return float(self._get_iio_attr_str(self.name, "scale", True))
+
+    @scale.setter
+    def scale(self, value):
+        self._set_iio_attr(self.name, "scale", True, str(Decimal(value).real))
+
+
+class ad3552r_hs(tx_chan_comp):
     """AD3552R_HS DAC"""
 
     _complex_data = False
     _device_name = "AD3552R_HS"
+    compatible_parts = [
+        "ad3552r",
+        "ad3551r",
+        "ad3542r",
+        "ad3541r",
+    ]
 
-    def __init__(self, uri="", device_name=""):
-        """ Constructor for AD3552R_HS driver class """
-
-        context_manager.__init__(self, uri, self._device_name)
-
-        compatible_parts = [
-            "ad3552r",
-            "ad3551r",
-            "ad3542r",
-            "ad3541r",
-        ]
-
-        self._ctrl = None
-        self._txdac = None
-
-        if not device_name:
-            device_name = compatible_parts[0]
-        else:
-            if device_name not in compatible_parts:
-                raise Exception(
-                    f"Not a compatible device: {device_name}. Supported device names "
-                    f"are: {','.join(compatible_parts)}"
-                )
-
-        # Select the device matching device_name as working device
-        for device in self._ctx.devices:
-            if device.name == device_name:
-                self._ctrl = device
-                self._txdac = device
-                break
-
-        if not self._ctrl:
-            raise Exception("Error in selecting matching device")
-
-        if not self._txdac:
-            raise Exception("Error in selecting matching device")
-
+    def __post_init__(self):
+        """Populate the channel-wise output_bits list."""
         self.output_bits = []
-        self.channel = []
-        self._tx_channel_names = []
         for ch in self._ctrl.channels:
-            name = ch._id
-            output = ch._output
             self.output_bits.append(ch.data_format.bits)
-            self._tx_channel_names.append(name)
-            self.channel.append(self._channel(self._ctrl, name, output))
-            if output is True:
-                setattr(self, name, self._channel(self._ctrl, name, output))
 
-        tx.__init__(self)
+    def _channel_def(self, ctrl, name):
+        output = ctrl.find_channel(name, True) is not None
+        return ad3552r_hs_channel(ctrl, name, output)
 
     @property
     def input_source(self):
@@ -92,50 +104,3 @@ class ad3552r_hs(tx, context_manager):
     @output_range.setter
     def output_range(self, value):
         self._set_iio_dev_attr_str("output_range", value, self._txdac)
-
-    class _channel(attribute):
-        """AD3552R_HS channel"""
-
-        def __init__(self, ctrl, channel_name, output):
-            self.name = channel_name
-            self._ctrl = ctrl
-            self._output = output
-
-        @property
-        def sample_rate(self):
-            """Sample rate of the DAC"""
-            return self._get_iio_attr(self.name, "sampling_frequency", True)
-
-        @sample_rate.setter
-        def sample_rate(self, value):
-            self._set_iio_attr(self.name, "sampling_frequency", True, value)
-
-        @property
-        def raw(self):
-            """Get channel raw value
-                DAC code in the range 0-65535"""
-            return self._get_iio_attr(self.name, "raw", True)
-
-        @raw.setter
-        def raw(self, value):
-            """Set channel raw value"""
-            self._set_iio_attr(self.name, "raw", True, str(int(value)))
-
-        @property
-        def offset(self):
-            """Get channel offset"""
-            return self._get_iio_attr_str(self.name, "offset", True)
-
-        @offset.setter
-        def offset(self, value):
-            """Set channel offset"""
-            self._set_iio_attr(self.name, "offset", True, str(Decimal(value).real))
-
-        @property
-        def scale(self):
-            """Get channel scale"""
-            return float(self._get_iio_attr_str(self.name, "scale", True))
-
-        @scale.setter
-        def scale(self, value):
-            self._set_iio_attr(self.name, "scale", True, str(Decimal(value).real))

--- a/adi/ad3552r_hs.py
+++ b/adi/ad3552r_hs.py
@@ -12,6 +12,7 @@ class ad3552r_hs_channel(attribute):
     """AD3552R_HS channel"""
 
     def __init__(self, ctrl, channel_name, output):
+        """Initialize an AD3552R_HS channel."""
         self.name = channel_name
         self._ctrl = ctrl
         self._output = output

--- a/adi/ad5706r.py
+++ b/adi/ad5706r.py
@@ -6,56 +6,232 @@
 from decimal import Decimal
 
 from adi.attribute import attribute
-from adi.context_manager import context_manager
-from adi.rx_tx import tx
+from adi.device_base import tx_chan_comp
 
 
-class ad5706r(tx, context_manager):
+class ad5706r_channel(attribute):
+    """ad5706r channel"""
+
+    def __init__(self, ctrl, channel_name):
+        self.name = channel_name
+        self._ctrl = ctrl
+
+    @property
+    def raw(self):
+        """ad5706r channel raw value"""
+        return self._get_iio_attr(self.name, "raw", True)
+
+    @raw.setter
+    def raw(self, value):
+        self._set_iio_attr(self.name, "raw", True, str(int(value)))
+
+    @property
+    def offset(self):
+        """ad5706r channel offset"""
+        return self._get_iio_attr(self.name, "offset", True)
+
+    @offset.setter
+    def offset(self, value):
+        self._set_iio_attr(self.name, "offset", True, str(Decimal(value).real))
+
+    @property
+    def scale(self):
+        """ad5706r channel scale"""
+        return self._get_iio_attr(self.name, "scale", True)
+
+    @scale.setter
+    def scale(self, value):
+        self._set_iio_attr(self.name, "scale", True, str(Decimal(value).real))
+
+    @property
+    def input_register_a(self):
+        """ad5706r channel Input Register A value"""
+        return int(self._get_iio_attr_str(self.name, "input_register_a", True))
+
+    @input_register_a.setter
+    def input_register_a(self, value):
+        """Set the ad5706r channel Input Register A value"""
+        self._set_iio_attr(self.name, "input_register_a", True, value)
+
+    @property
+    def input_register_b(self):
+        """ad5706r channel Input Register B value"""
+        return int(self._get_iio_attr_str(self.name, "input_register_b", True))
+
+    @input_register_b.setter
+    def input_register_b(self, value):
+        """Set the ad5706r channel Input Register B value"""
+        self._set_iio_attr(self.name, "input_register_b", True, value)
+
+    @property
+    def hw_active_edge(self):
+        """ad5706r channel HW active edge"""
+        return self._get_iio_attr_str(self.name, "hw_active_edge", True)
+
+    @property
+    def hw_active_edge_available(self):
+        """ad5706r channel HW active edge options. Options are:
+        rising_edge, falling_edge, any_edge"""
+        return self._get_iio_attr_str(self.name, "hw_active_edge_available", True)
+
+    @hw_active_edge.setter
+    def hw_active_edge(self, value):
+        """Set the HW active edge for the channel."""
+        if value in self.hw_active_edge_available:
+            self._set_iio_attr(self.name, "hw_active_edge", True, value)
+        else:
+            raise ValueError(
+                "Error: Attribute value not supported \nUse one of: "
+                + str(self.hw_active_edge_available)
+            )
+
+    @property
+    def multi_dac_sel_ch(self):
+        """ad5706r Multi DAC channel select"""
+        return self._get_iio_attr_str(self.name, "multi_dac_sel_ch", True)
+
+    @property
+    def multi_dac_sel_ch_available(self):
+        """ad5706r Multi DAC Channel Select options. Options are:
+        exclude, include"""
+        return self._get_iio_attr_str(self.name, "multi_dac_sel_ch_available", True)
+
+    @multi_dac_sel_ch.setter
+    def multi_dac_sel_ch(self, value):
+        """Set the Multi DAC Channel."""
+        if value in self.multi_dac_sel_ch_available:
+            self._set_iio_attr(self.name, "multi_dac_sel_ch", True, value)
+        else:
+            raise ValueError(
+                "Error: Attribute value not supported \nUse one of: "
+                + str(self.multi_dac_sel_ch_available)
+            )
+
+    @property
+    def range_sel(self):
+        """ad5706r channel range selection"""
+        return self._get_iio_attr_str(self.name, "range_sel", True)
+
+    @property
+    def range_sel_available(self):
+        """ad5706r channel range options. Options are:
+        50mA, 150mA, 200mA, 300mA"""
+        return self._get_iio_attr_str(self.name, "range_sel_available", True)
+
+    @range_sel.setter
+    def range_sel(self, value):
+        """Set the range for the channel."""
+        if value in self.range_sel_available:
+            self._set_iio_attr(self.name, "range_sel", True, value)
+        else:
+            raise ValueError(
+                "Error: Attribute value not supported \nUse one of: "
+                + str(self.range_sel_available)
+            )
+
+    @property
+    def ldac_trigger_chn(self):
+        """ad5706r LDAC Trigger Chn setting"""
+        return self._get_iio_attr_str(self.name, "ldac_trigger_chn", True)
+
+    @property
+    def ldac_trigger_chn_available(self):
+        """ad5706r channel LDAC trigger options. Options are:
+        None, sw_ldac, hw_ldac"""
+        return self._get_iio_attr_str(self.name, "ldac_trigger_chn_available", True)
+
+    @ldac_trigger_chn.setter
+    def ldac_trigger_chn(self, value):
+        """Trigger LDAC for the channel."""
+        if value in self.ldac_trigger_chn_available:
+            self._set_iio_attr(self.name, "ldac_trigger_chn", True, value)
+        else:
+            raise ValueError(
+                "Error: Attribute value not supported \nUse one of: "
+                + str(self.ldac_trigger_chn_available)
+            )
+
+    @property
+    def toggle_trigger_chn(self):
+        """ad5706r Toggle Trigger Chn setting"""
+        return self._get_iio_attr_str(self.name, "toggle_trigger_chn", True)
+
+    @property
+    def toggle_trigger_chn_available(self):
+        """ad5706r channel Toggle trigger options. Options are:
+        None, sw_toggle, hw_toggle"""
+        return self._get_iio_attr_str(self.name, "toggle_trigger_chn_available", True)
+
+    @toggle_trigger_chn.setter
+    def toggle_trigger_chn(self, value):
+        """Trigger Toggle for the channel."""
+        if value in self.toggle_trigger_chn_available:
+            self._set_iio_attr(self.name, "toggle_trigger_chn", True, value)
+        else:
+            raise ValueError(
+                "Error: Attribute value not supported \nUse one of: "
+                + str(self.toggle_trigger_chn_available)
+            )
+
+    @property
+    def hw_func_sel(self):
+        """ad5706r HW function setting"""
+        return self._get_iio_attr_str(self.name, "hw_func_sel", True)
+
+    @property
+    def hw_func_sel_available(self):
+        """ad5706r channel HW function options. Options are:
+        None, LDAC, Toggle, Dither"""
+        return self._get_iio_attr_str(self.name, "hw_func_sel_available", True)
+
+    @hw_func_sel.setter
+    def hw_func_sel(self, value):
+        """Set HW function for the channel."""
+        if value in self.hw_func_sel_available:
+            self._set_iio_attr(self.name, "hw_func_sel", True, value)
+        else:
+            raise ValueError(
+                "Error: Attribute value not supported \nUse one of: "
+                + str(self.hw_func_sel_available)
+            )
+
+    @property
+    def output_state(self):
+        """ad5706r channel output state setting"""
+        return self._get_iio_attr_str(self.name, "output_state", True)
+
+    @property
+    def output_state_available(self):
+        """ad5706r channel output state options. Options are:
+        shutdown_to_tristate_sw, shutdown_to_gnd_sw, normal_sw,
+        shutdown_to_tristate_hw, shutdown_to_gnd_hw, normal_hw"""
+        return self._get_iio_attr_str(self.name, "output_state_available", True)
+
+    @output_state.setter
+    def output_state(self, value):
+        """Set output state for the channel."""
+        if value in self.output_state_available:
+            self._set_iio_attr(self.name, "output_state", True, value)
+        else:
+            raise ValueError(
+                "Error: Attribute value not supported \nUse one of: "
+                + str(self.output_state_available)
+            )
+
+
+class ad5706r(tx_chan_comp):
     """ ad5706r DAC """
 
     _complex_data = False
     _device_name = ""
+    compatible_parts = ["ad5706r"]
+    _channel_def = ad5706r_channel
 
-    def __init__(self, uri="", device_name=""):
-        """Constructor for ad5706r class."""
-        context_manager.__init__(self, uri, self._device_name)
-
-        compatible_parts = ["ad5706r"]
-
-        self._ctrl = None
-
-        if not device_name:
-            device_name = compatible_parts[0]
-        else:
-            if device_name not in compatible_parts:
-                raise Exception(
-                    f"Not a compatible device: {device_name}. Supported device names "
-                    f"are: {','.join(compatible_parts)}"
-                )
-
-        # Select the device matching device_name as working device
-        for device in self._ctx.devices:
-            if device.name == device_name:
-                self._ctrl = device
-                self._txdac = device
-                break
-
-        if not self._ctrl:
-            raise Exception("Error in selecting matching device")
-
-        if not self._txdac:
-            raise Exception("Error in selecting matching device")
-
-        self.channel = []  # type: ignore
+    def __post_init__(self):
+        """Populate the channel-wise output_bits list."""
         self._output_bits = []
         for ch in self._ctrl.channels:
-            name = ch.id
             self._output_bits.append(ch.data_format.bits)
-            self._tx_channel_names.append(name)
-            self.channel.append(self._channel(self._ctrl, name))
-            setattr(self, name, self._channel(self._ctrl, name))
-
-        tx.__init__(self)
 
     @property
     def output_bits(self):
@@ -278,214 +454,3 @@ class ad5706r(tx, context_manager):
     def multi_dac_input_a(self, value):
         """Set the ad5706r Multi DAC Input Register A value"""
         self._set_iio_dev_attr_str("multi_dac_input_a", value)
-
-    class _channel(attribute):
-        """ad5706r channel"""
-
-        def __init__(self, ctrl, channel_name):
-            self.name = channel_name
-            self._ctrl = ctrl
-
-        @property
-        def raw(self):
-            """ad5706r channel raw value"""
-            return self._get_iio_attr(self.name, "raw", True)
-
-        @raw.setter
-        def raw(self, value):
-            self._set_iio_attr(self.name, "raw", True, str(int(value)))
-
-        @property
-        def offset(self):
-            """ad5706r channel offset"""
-            return self._get_iio_attr(self.name, "offset", True)
-
-        @offset.setter
-        def offset(self, value):
-            self._set_iio_attr(self.name, "offset", True, str(Decimal(value).real))
-
-        @property
-        def scale(self):
-            """ad5706r channel scale"""
-            return self._get_iio_attr(self.name, "scale", True)
-
-        @scale.setter
-        def scale(self, value):
-            self._set_iio_attr(self.name, "scale", True, str(Decimal(value).real))
-
-        @property
-        def input_register_a(self):
-            """ad5706r channel Input Register A value"""
-            return int(self._get_iio_attr_str(self.name, "input_register_a", True))
-
-        @input_register_a.setter
-        def input_register_a(self, value):
-            """Set the ad5706r channel Input Register A value"""
-            self._set_iio_attr(self.name, "input_register_a", True, value)
-
-        @property
-        def input_register_b(self):
-            """ad5706r channel Input Register B value"""
-            return int(self._get_iio_attr_str(self.name, "input_register_b", True))
-
-        @input_register_b.setter
-        def input_register_b(self, value):
-            """Set the ad5706r channel Input Register B value"""
-            self._set_iio_attr(self.name, "input_register_b", True, value)
-
-        @property
-        def hw_active_edge(self):
-            """ad5706r channel HW active edge"""
-            return self._get_iio_attr_str(self.name, "hw_active_edge", True)
-
-        @property
-        def hw_active_edge_available(self):
-            """ad5706r channel HW active edge options. Options are:
-            rising_edge, falling_edge, any_edge"""
-            return self._get_iio_attr_str(self.name, "hw_active_edge_available", True)
-
-        @hw_active_edge.setter
-        def hw_active_edge(self, value):
-            """Set the HW active edge for the channel."""
-            if value in self.hw_active_edge_available:
-                self._set_iio_attr(self.name, "hw_active_edge", True, value)
-            else:
-                raise ValueError(
-                    "Error: Attribute value not supported \nUse one of: "
-                    + str(self.hw_active_edge_available)
-                )
-
-        @property
-        def multi_dac_sel_ch(self):
-            """ad5706r Multi DAC channel select"""
-            return self._get_iio_attr_str(self.name, "multi_dac_sel_ch", True)
-
-        @property
-        def multi_dac_sel_ch_available(self):
-            """ad5706r Multi DAC Channel Select options. Options are:
-            exclude, include"""
-            return self._get_iio_attr_str(self.name, "multi_dac_sel_ch_available", True)
-
-        @multi_dac_sel_ch.setter
-        def multi_dac_sel_ch(self, value):
-            """Set the Multi DAC Channel."""
-            if value in self.multi_dac_sel_ch_available:
-                self._set_iio_attr(self.name, "multi_dac_sel_ch", True, value)
-            else:
-                raise ValueError(
-                    "Error: Attribute value not supported \nUse one of: "
-                    + str(self.multi_dac_sel_ch_available)
-                )
-
-        @property
-        def range_sel(self):
-            """ad5706r channel range selection"""
-            return self._get_iio_attr_str(self.name, "range_sel", True)
-
-        @property
-        def range_sel_available(self):
-            """ad5706r channel range options. Options are:
-            50mA, 150mA, 200mA, 300mA"""
-            return self._get_iio_attr_str(self.name, "range_sel_available", True)
-
-        @range_sel.setter
-        def range_sel(self, value):
-            """Set the range for the channel."""
-            if value in self.range_sel_available:
-                self._set_iio_attr(self.name, "range_sel", True, value)
-            else:
-                raise ValueError(
-                    "Error: Attribute value not supported \nUse one of: "
-                    + str(self.range_sel_available)
-                )
-
-        @property
-        def ldac_trigger_chn(self):
-            """ad5706r LDAC Trigger Chn setting"""
-            return self._get_iio_attr_str(self.name, "ldac_trigger_chn", True)
-
-        @property
-        def ldac_trigger_chn_available(self):
-            """ad5706r channel LDAC trigger options. Options are:
-            None, sw_ldac, hw_ldac"""
-            return self._get_iio_attr_str(self.name, "ldac_trigger_chn_available", True)
-
-        @ldac_trigger_chn.setter
-        def ldac_trigger_chn(self, value):
-            """Trigger LDAC for the channel."""
-            if value in self.ldac_trigger_chn_available:
-                self._set_iio_attr(self.name, "ldac_trigger_chn", True, value)
-            else:
-                raise ValueError(
-                    "Error: Attribute value not supported \nUse one of: "
-                    + str(self.ldac_trigger_chn_available)
-                )
-
-        @property
-        def toggle_trigger_chn(self):
-            """ad5706r Toggle Trigger Chn setting"""
-            return self._get_iio_attr_str(self.name, "toggle_trigger_chn", True)
-
-        @property
-        def toggle_trigger_chn_available(self):
-            """ad5706r channel Toggle trigger options. Options are:
-            None, sw_toggle, hw_toggle"""
-            return self._get_iio_attr_str(
-                self.name, "toggle_trigger_chn_available", True
-            )
-
-        @toggle_trigger_chn.setter
-        def toggle_trigger_chn(self, value):
-            """Trigger Toggle for the channel."""
-            if value in self.toggle_trigger_chn_available:
-                self._set_iio_attr(self.name, "toggle_trigger_chn", True, value)
-            else:
-                raise ValueError(
-                    "Error: Attribute value not supported \nUse one of: "
-                    + str(self.toggle_trigger_chn_available)
-                )
-
-        @property
-        def hw_func_sel(self):
-            """ad5706r HW function setting"""
-            return self._get_iio_attr_str(self.name, "hw_func_sel", True)
-
-        @property
-        def hw_func_sel_available(self):
-            """ad5706r channel HW function options. Options are:
-            None, LDAC, Toggle, Dither"""
-            return self._get_iio_attr_str(self.name, "hw_func_sel_available", True)
-
-        @hw_func_sel.setter
-        def hw_func_sel(self, value):
-            """Set HW function for the channel."""
-            if value in self.hw_func_sel_available:
-                self._set_iio_attr(self.name, "hw_func_sel", True, value)
-            else:
-                raise ValueError(
-                    "Error: Attribute value not supported \nUse one of: "
-                    + str(self.hw_func_sel_available)
-                )
-
-        @property
-        def output_state(self):
-            """ad5706r channel output state setting"""
-            return self._get_iio_attr_str(self.name, "output_state", True)
-
-        @property
-        def output_state_available(self):
-            """ad5706r channel output state options. Options are:
-            shutdown_to_tristate_sw, shutdown_to_gnd_sw, normal_sw,
-            shutdown_to_tristate_hw, shutdown_to_gnd_hw, normal_hw"""
-            return self._get_iio_attr_str(self.name, "output_state_available", True)
-
-        @output_state.setter
-        def output_state(self, value):
-            """Set output state for the channel."""
-            if value in self.output_state_available:
-                self._set_iio_attr(self.name, "output_state", True, value)
-            else:
-                raise ValueError(
-                    "Error: Attribute value not supported \nUse one of: "
-                    + str(self.output_state_available)
-                )

--- a/adi/ad5706r.py
+++ b/adi/ad5706r.py
@@ -13,6 +13,7 @@ class ad5706r_channel(attribute):
     """ad5706r channel"""
 
     def __init__(self, ctrl, channel_name):
+        """Initialize an AD5706R channel."""
         self.name = channel_name
         self._ctrl = ctrl
 

--- a/adi/ada4355.py
+++ b/adi/ada4355.py
@@ -13,6 +13,7 @@ class ada4355_channel(attribute):
     """ ada4355 channel """
 
     def __init__(self, ctrl, channel_name):
+        """Initialize an ADA4355 channel."""
         self.name = channel_name
         self._ctrl = ctrl
 

--- a/adi/ada4355.py
+++ b/adi/ada4355.py
@@ -4,56 +4,42 @@
 
 from decimal import Decimal
 
-import numpy as np
-
 from adi.attribute import attribute
-from adi.context_manager import context_manager
-from adi.rx_tx import rx
+from adi.device_base import rx_chan_comp
 
 
-class ada4355(rx, context_manager):
+class ada4355_channel(attribute):
+
+    """ ada4355 channel """
+
+    def __init__(self, ctrl, channel_name):
+        self.name = channel_name
+        self._ctrl = ctrl
+
+    @property
+    def scale(self):
+        """Get channel scale value"""
+        return float(self._get_iio_attr_str(self.name, "scale", False))
+
+    @scale.setter
+    def scale(self, value):
+        """Set channel scale value"""
+        self._set_iio_attr(self.name, "scale", False, str(Decimal(value).real))
+
+    @property
+    def raw(self):
+        """Get channel raw value (single sample)"""
+        return self._get_iio_attr(self.name, "raw", False)
+
+
+class ada4355(rx_chan_comp):
 
     """ ADA4355 ADC """
 
     _complex_data = False
-    channel = []  # type: ignore
     _device_name = "ada4355"
-
-    def __init__(self, uri="", device_name="ada4355"):
-        """Constructor for ada4355 class."""
-        context_manager.__init__(self, uri, self._device_name)
-
-        compatible_parts = ["ada4355"]
-
-        self._ctrl = None
-
-        if not device_name:
-            device_name = compatible_parts[0]
-        else:
-            if device_name not in compatible_parts:
-                raise Exception(f"Not a compatible device: {device_name}")
-
-        # Select the device matching device_name as working device
-        for device in self._ctx.devices:
-            if device.name == device_name:
-                self._ctrl = device
-                self._rxadc = device
-                break
-
-        if not self._ctrl:
-            raise Exception("Error in selecting matching device")
-
-        if not self._rxadc:
-            raise Exception("Error in selecting matching device")
-
-        self._rx_channel_names = []
-        self.channel = []
-        for ch in self._ctrl.channels:
-            name = ch._id
-            self._rx_channel_names.append(name)
-            self.channel.append(self._channel(self._ctrl, name))
-
-        rx.__init__(self)
+    _channel_def = ada4355_channel
+    compatible_parts = ["ada4355"]
 
     def ada4355_register_read(self, reg):
         """Direct Register Access via debugfs"""
@@ -68,26 +54,3 @@ class ada4355(rx, context_manager):
     def sampling_frequency(self):
         """Get sampling frequency."""
         return self._get_iio_dev_attr("sampling_frequency")
-
-    class _channel(attribute):
-
-        """ ada4355 channel """
-
-        def __init__(self, ctrl, channel_name):
-            self.name = channel_name
-            self._ctrl = ctrl
-
-        @property
-        def scale(self):
-            """Get channel scale value"""
-            return float(self._get_iio_attr_str(self.name, "scale", False))
-
-        @scale.setter
-        def scale(self, value):
-            """Set channel scale value"""
-            self._set_iio_attr(self.name, "scale", False, str(Decimal(value).real))
-
-        @property
-        def raw(self):
-            """Get channel raw value (single sample)"""
-            return self._get_iio_attr(self.name, "raw", False)

--- a/adi/adis16475.py
+++ b/adi/adis16475.py
@@ -10,6 +10,7 @@ class adis16475_channel_with_offset(attribute):
     """Channel with offset"""
 
     def __init__(self, ctrl, channel_name):
+        """Initialize a channel with calibration-bias support."""
         self.name = channel_name
         self._ctrl = ctrl
 
@@ -37,6 +38,7 @@ class adis16475_channel(attribute):
     """Channel"""
 
     def __init__(self, ctrl, channel_name):
+        """Initialize an ADIS16475 channel."""
         self.name = channel_name
         self._ctrl = ctrl
 
@@ -104,9 +106,34 @@ class adis16475(rx_chan_comp):
     ]
 
     def __init__(self, uri="", device_name="adis16505-2", device_index=0):
-        super().__init__(uri=uri, device_name=device_name, device_index=device_index)
+        """Initialize the first available compatible IMU device."""
+        if device_name not in self.compatible_parts:
+            raise Exception(
+                f"Not a compatible device: {device_name}. Supported device names "
+                f"are: {','.join(self.compatible_parts)}"
+            )
+
+        # These drivers may identify compatible hardware by a different part
+        # name. Preserve the legacy behavior of trying the requested part first
+        # and then probing the remaining compatible names.
+        parts = [device_name] + [
+            part for part in self.compatible_parts if part != device_name
+        ]
+        last_exception = None
+        for part in parts:
+            self.__dict__["_control_device_name"] = None
+            self.__dict__["_rx_data_device_name"] = None
+            try:
+                super().__init__(uri=uri, device_name=part, device_index=device_index)
+                return
+            except Exception as exc:  # noqa: BLE001
+                last_exception = exc
+        if last_exception is not None:
+            raise last_exception
+        raise Exception("No compatible device found")  # pragma: no cover
 
     def __post_init__(self):
+        """Configure the trigger, temperature channel, and buffer size."""
         # Set default trigger
         trigger_name = self._ctrl.name + "-dev0"
         self._trigger = self._ctx.find_device(trigger_name)

--- a/adi/adis16475.py
+++ b/adi/adis16475.py
@@ -3,14 +3,59 @@
 # SPDX short identifier: ADIBSD
 
 from adi.attribute import attribute
-from adi.context_manager import context_manager
-from adi.rx_tx import rx
+from adi.device_base import rx_chan_comp
 
 
-class adis16475(rx, context_manager):
+class adis16475_channel_with_offset(attribute):
+    """Channel with offset"""
+
+    def __init__(self, ctrl, channel_name):
+        self.name = channel_name
+        self._ctrl = ctrl
+
+    @property
+    def calibbias(self):
+        """ADIS165x channel offset"""
+        return self._get_iio_attr(self.name, "calibbias", False)
+
+    @calibbias.setter
+    def calibbias(self, value):
+        self._set_iio_attr(self.name, "calibbias", False, value)
+
+    @property
+    def raw(self):
+        """ADIS165x channel raw value"""
+        return self._get_iio_attr(self.name, "raw", False)
+
+    @property
+    def scale(self):
+        """ADIS165x channel scale(gain)"""
+        return float(self._get_iio_attr_str(self.name, "scale", False))
+
+
+class adis16475_channel(attribute):
+    """Channel"""
+
+    def __init__(self, ctrl, channel_name):
+        self.name = channel_name
+        self._ctrl = ctrl
+
+    @property
+    def raw(self):
+        """ADIS165x channel raw value"""
+        return self._get_iio_attr(self.name, "raw", False)
+
+    @property
+    def scale(self):
+        """ADIS165x channel scale(gain)"""
+        return float(self._get_iio_attr_str(self.name, "scale", False))
+
+
+class adis16475(rx_chan_comp):
     """ADIS16475 Compact, Precision, Six Degrees of Freedom Inertial Sensor"""
 
     _complex_data = False
+    _device_name = ""
     _rx_channel_names = [
         "anglvel_x",
         "anglvel_y",
@@ -26,89 +71,55 @@ class adis16475(rx, context_manager):
         "deltavelocity_y",
         "deltavelocity_z",
     ]
-    _device_name = ""
+    # timestamp has no scale attribute, keep it out of the channel list.
+    _ignore_channels = ["timestamp"]
+    compatible_parts = [
+        "adis16505-2",
+        "adis16470",
+        "adis16475-1",
+        "adis16475-2",
+        "adis16475-3",
+        "adis16477-1",
+        "adis16477-2",
+        "adis16477-3",
+        "adis16465-1",
+        "adis16465-2",
+        "adis16465-3",
+        "adis16467-1",
+        "adis16467-2",
+        "adis16467-3",
+        "adis16500",
+        "adis16501",
+        "adis16505-1",
+        "adis16505-3",
+        "adis16507-1",
+        "adis16507-2",
+        "adis16507-3",
+        "adis16575-2",
+        "adis16575-3",
+        "adis16576-2",
+        "adis16576-3",
+        "adis16577-2",
+        "adis16577-3",
+    ]
 
-    def __init__(self, uri="", device_name="adis16505-2"):
-        context_manager.__init__(self, uri, self._device_name)
+    def __init__(self, uri="", device_name="adis16505-2", device_index=0):
+        super().__init__(uri=uri, device_name=device_name, device_index=device_index)
 
-        compatible_parts = [
-            "adis16470",
-            "adis16475-1",
-            "adis16475-2",
-            "adis16475-3",
-            "adis16477-1",
-            "adis16477-2",
-            "adis16477-3",
-            "adis16465-1",
-            "adis16465-2",
-            "adis16465-3",
-            "adis16467-1",
-            "adis16467-2",
-            "adis16467-3",
-            "adis16500",
-            "adis16501",
-            "adis16505-1",
-            "adis16505-2",
-            "adis16505-3",
-            "adis16507-1",
-            "adis16507-2",
-            "adis16507-3",
-            "adis16575-2",
-            "adis16575-3",
-            "adis16576-2",
-            "adis16576-3",
-            "adis16577-2",
-            "adis16577-3",
-        ]
-
-        if device_name not in compatible_parts:
-            raise Exception(
-                "Not a compatible device:"
-                + str(device_name)
-                + ".Please select from:"
-                + str(compatible_parts)
-            )
-        else:
-            self._ctrl = self._ctx.find_device(device_name)
-            self._rxadc = self._ctx.find_device(device_name)
-            trigger_name = device_name + "-dev0"
-
-        if self._ctrl is None:
-            print(
-                "No device found with device_name = "
-                + device_name
-                + ". Searching for a device found in the compatible list."
-            )
-            for i in compatible_parts:
-                self._ctrl = self._ctx.find_device(i)
-                self._rxadc = self._ctx.find_device(i)
-                if self._ctrl is not None:
-                    print("Fond device = " + i + ". Will use this device instead.")
-                    trigger_name = i + "-dev0"
-                    break
-            if self._ctrl is None:
-                raise Exception("No compatible device found")
-
+    def __post_init__(self):
         # Set default trigger
+        trigger_name = self._ctrl.name + "-dev0"
         self._trigger = self._ctx.find_device(trigger_name)
         self._rxadc._set_trigger(self._trigger)
-
-        self.anglvel_x = self._channel_with_offset(self._ctrl, "anglvel_x")
-        self.anglvel_y = self._channel_with_offset(self._ctrl, "anglvel_y")
-        self.anglvel_z = self._channel_with_offset(self._ctrl, "anglvel_z")
-        self.accel_x = self._channel_with_offset(self._ctrl, "accel_x")
-        self.accel_y = self._channel_with_offset(self._ctrl, "accel_y")
-        self.accel_z = self._channel_with_offset(self._ctrl, "accel_z")
-        self.temp = self._channel(self._ctrl, "temp0")
-        self.deltaangl_x = self._channel(self._ctrl, "deltaangl_x")
-        self.deltaangl_y = self._channel(self._ctrl, "deltaangl_y")
-        self.deltaangl_z = self._channel(self._ctrl, "deltaangl_z")
-        self.deltavelocity_x = self._channel(self._ctrl, "deltavelocity_x")
-        self.deltavelocity_y = self._channel(self._ctrl, "deltavelocity_y")
-        self.deltavelocity_z = self._channel(self._ctrl, "deltavelocity_z")
-
-        rx.__init__(self)
+        # The temperature channel uses the "temp0" IIO id but is exposed as
+        # ``temp`` for backwards compatibility.
+        self.temp = adis16475_channel(self._ctrl, "temp0")
         self.rx_buffer_size = 16  # Make default buffer smaller
+
+    def _channel_def(self, ctrl, name):
+        if name.startswith("anglvel") or name.startswith("accel"):
+            return adis16475_channel_with_offset(ctrl, name)
+        return adis16475_channel(ctrl, name)
 
     def __get_scaled_sensor(self, channel_name: str) -> float:
         raw = self._get_iio_attr(channel_name, "raw", False)
@@ -291,49 +302,6 @@ class adis16475(rx, context_manager):
     def flash_count(self):
         """flash_counter: flash memory write count"""
         return self._get_iio_debug_attr("flash_count")
-
-    class _channel_with_offset(attribute):
-        """Channel with offset"""
-
-        def __init__(self, ctrl, channel_name):
-            self.name = channel_name
-            self._ctrl = ctrl
-
-        @property
-        def calibbias(self):
-            """ADIS165x channel offset"""
-            return self._get_iio_attr(self.name, "calibbias", False)
-
-        @calibbias.setter
-        def calibbias(self, value):
-            self._set_iio_attr(self.name, "calibbias", False, value)
-
-        @property
-        def raw(self):
-            """ADIS165x channel raw value"""
-            return self._get_iio_attr(self.name, "raw", False)
-
-        @property
-        def scale(self):
-            """ADIS165x channel scale(gain)"""
-            return float(self._get_iio_attr_str(self.name, "scale", False))
-
-    class _channel(attribute):
-        """Channel"""
-
-        def __init__(self, ctrl, channel_name):
-            self.name = channel_name
-            self._ctrl = ctrl
-
-        @property
-        def raw(self):
-            """ADIS165x channel raw value"""
-            return self._get_iio_attr(self.name, "raw", False)
-
-        @property
-        def scale(self):
-            """ADIS165x channel scale(gain)"""
-            return float(self._get_iio_attr_str(self.name, "scale", False))
 
     def reg_read(self, reg):
         """Direct Register Access via debugfs"""

--- a/adi/adxl380.py
+++ b/adi/adxl380.py
@@ -5,59 +5,141 @@
 from decimal import Decimal
 
 from adi.attribute import attribute
-from adi.context_manager import context_manager
-from adi.rx_tx import rx
+from adi.device_base import rx_chan_comp
 
 
-class adxl380(rx, context_manager, attribute):
+class adxl380_temp_channel(attribute):
+    """adxl380 temperature channel"""
+
+    def __init__(self, ctrl, channel_name):
+        self.name = channel_name
+        self._ctrl = ctrl
+
+    @property
+    def offset(self):
+        """adxl380 temperature offset value"""
+        return self._get_iio_attr(self.name, "offset", False)
+
+    @property
+    def raw(self):
+        """adxl380 temperature raw value"""
+        return self._get_iio_attr(self.name, "raw", False)
+
+    @property
+    def scale(self):
+        """adxl380 channel scale value"""
+        return self._get_iio_attr(self.name, "scale", False)
+
+
+class adxl380_channel(attribute):
+    """adxl380 acceleration channel"""
+
+    def __init__(self, ctrl, channel_name):
+        self.name = channel_name
+        self._ctrl = ctrl
+
+    @property
+    def calibbias(self):
+        """adxl380 channel offset"""
+        return self._get_iio_attr(self.name, "calibbias", False)
+
+    @calibbias.setter
+    def calibbias(self, value):
+        self._set_iio_attr(self.name, "calibbias", False, value)
+
+    @property
+    def filter_high_pass_3db_frequency(self):
+        """adxl380 highpass filter cutoff frequency"""
+        return self._get_iio_attr(self.name, "filter_high_pass_3db_frequency", False)
+
+    @filter_high_pass_3db_frequency.setter
+    def filter_high_pass_3db_frequency(self, value):
+        self._set_iio_attr(
+            self.name,
+            "filter_high_pass_3db_frequency",
+            False,
+            str(Decimal(value).real),
+        )
+
+    @property
+    def filter_high_pass_3db_frequency_available(self):
+        """Provides all available highpass filter cutoff frequency settings for the adxl380 channels"""
+        return self._get_iio_attr(
+            self.name, "filter_high_pass_3db_frequency_available", False
+        )
+
+    @property
+    def filter_low_pass_3db_frequency(self):
+        """adxl380 lowpass filter cutoff frequency"""
+        return self._get_iio_attr(self.name, "filter_low_pass_3db_frequency", False)
+
+    @filter_low_pass_3db_frequency.setter
+    def filter_low_pass_3db_frequency(self, value):
+        self._set_iio_attr(
+            self.name, "filter_low_pass_3db_frequency", False, str(Decimal(value).real),
+        )
+
+    @property
+    def filter_low_pass_3db_frequency_available(self):
+        """Provides all available lowpass filter cutoff frequency settings for the adxl380 channels"""
+        return self._get_iio_attr(
+            self.name, "filter_low_pass_3db_frequency_available", False
+        )
+
+    @property
+    def raw(self):
+        """adxl380 channel raw value"""
+        return self._get_iio_attr(self.name, "raw", False)
+
+    @property
+    def scale(self):
+        """adxl380 channel scale(gain)"""
+        return float(self._get_iio_attr_str(self.name, "scale", False))
+
+    @scale.setter
+    def scale(self, value):
+        self._set_iio_attr(
+            self.name, "scale", False, str(Decimal(value).real),
+        )
+
+    @property
+    def scale_available(self):
+        """Provides all available scale settings for the adxl380 channels"""
+        return self._get_iio_attr(self.name, "scale_available", False)
+
+
+class adxl380(rx_chan_comp):
     """ adxl380 3-axis accelerometer """
 
     _device_name = "adxl380"
     _rx_unbuffered_data = True
     _rx_data_si_type = float
+    _complex_data = False
+    _rx_channel_names = ["accel_x", "accel_y", "accel_z"]
+    compatible_parts = ["adxl380", "adxl382"]
 
-    def __init__(self, uri="", device_name=None):
-        context_manager.__init__(self, uri, self._device_name)
+    def __init__(self, uri="", device_name=None, device_index=0):
+        # The device may report as any of the compatible parts. Try each in
+        # turn so the class works whether an adxl380 or adxl382 is present.
+        parts = [device_name] if device_name else list(self.compatible_parts)
+        last_exception = None
+        for part in parts:
+            self._control_device_name = None
+            self._rx_data_device_name = None
+            try:
+                super().__init__(uri=uri, device_name=part, device_index=device_index)
+                return
+            except Exception as exc:  # noqa: BLE001
+                last_exception = exc
+        raise last_exception
 
-        compatible_parts = ["adxl380", "adxl382"]
+    def __post_init__(self):
+        self.rx_buffer_size = 16  # Make default buffer smaller
 
-        if not device_name:
-            device_name = compatible_parts[0]
-
-        if device_name not in compatible_parts:
-            raise Exception(
-                "Not a compatible device:"
-                + str(device_name)
-                + ".Please select from:"
-                + str(compatible_parts)
-            )
-        else:
-            print("Device found: ", device_name)
-            self._ctrl = self._ctx.find_device(device_name)
-            self._rxadc = self._ctx.find_device(device_name)
-
-            if self._ctrl is None:
-                print(
-                    "No device found with device_name = "
-                    + device_name
-                    + ". Searching for a device found in the compatible list."
-                )
-                for i in compatible_parts:
-                    self._ctrl = self._ctx.find_device(i)
-                    self._rxadc = self._ctx.find_device(i)
-                    if self._ctrl is not None:
-                        print("Found device = " + i + ". Will use this device instead.")
-                        break
-                if self._ctrl is None:
-                    raise Exception("No compatible device found")
-
-            self.accel_x = self._channel(self._ctrl, "accel_x")
-            self.accel_y = self._channel(self._ctrl, "accel_y")
-            self.accel_z = self._channel(self._ctrl, "accel_z")
-            self.temp = self._tempchannel(self._ctrl, "temp")
-            self._rx_channel_names = ["accel_x", "accel_y", "accel_z"]
-            rx.__init__(self)
-            self.rx_buffer_size = 16  # Make default buffer smaller
+    def _channel_def(self, ctrl, name):
+        if name == "temp":
+            return adxl380_temp_channel(ctrl, name)
+        return adxl380_channel(ctrl, name)
 
     @property
     def sampling_frequency(self):
@@ -81,106 +163,3 @@ class adxl380(rx, context_manager, attribute):
     def to_degrees(self, raw):
         """Convert raw to degrees Celsius"""
         return (raw + self.temp.offset) * self.temp.scale / 1000.0
-
-    class _tempchannel(attribute):
-        """adxl380 temperature channel"""
-
-        def __init__(self, ctrl, channel_name):
-            self.name = channel_name
-            self._ctrl = ctrl
-
-        @property
-        def offset(self):
-            """adxl380 temperature offset value"""
-            return self._get_iio_attr(self.name, "offset", False)
-
-        @property
-        def raw(self):
-            """adxl380 temperature raw value"""
-            return self._get_iio_attr(self.name, "raw", False)
-
-        @property
-        def scale(self):
-            """adxl380 channel scale value"""
-            return self._get_iio_attr(self.name, "scale", False)
-
-    class _channel(attribute):
-        """adxl380 acceleration channel"""
-
-        def __init__(self, ctrl, channel_name):
-            self.name = channel_name
-            self._ctrl = ctrl
-
-        @property
-        def calibbias(self):
-            """adxl380 channel offset"""
-            return self._get_iio_attr(self.name, "calibbias", False)
-
-        @calibbias.setter
-        def calibbias(self, value):
-            self._set_iio_attr(self.name, "calibbias", False, value)
-
-        @property
-        def filter_high_pass_3db_frequency(self):
-            """adxl380 highpass filter cutoff frequency"""
-            return self._get_iio_attr(
-                self.name, "filter_high_pass_3db_frequency", False
-            )
-
-        @filter_high_pass_3db_frequency.setter
-        def filter_high_pass_3db_frequency(self, value):
-            self._set_iio_attr(
-                self.name,
-                "filter_high_pass_3db_frequency",
-                False,
-                str(Decimal(value).real),
-            )
-
-        @property
-        def filter_high_pass_3db_frequency_available(self):
-            """Provides all available highpass filter cutoff frequency settings for the adxl380 channels"""
-            return self._get_iio_attr(
-                self.name, "filter_high_pass_3db_frequency_available", False
-            )
-
-        @property
-        def filter_low_pass_3db_frequency(self):
-            """adxl380 lowpass filter cutoff frequency"""
-            return self._get_iio_attr(self.name, "filter_low_pass_3db_frequency", False)
-
-        @filter_low_pass_3db_frequency.setter
-        def filter_low_pass_3db_frequency(self, value):
-            self._set_iio_attr(
-                self.name,
-                "filter_low_pass_3db_frequency",
-                False,
-                str(Decimal(value).real),
-            )
-
-        @property
-        def filter_low_pass_3db_frequency_available(self):
-            """Provides all available lowpass filter cutoff frequency settings for the adxl380 channels"""
-            return self._get_iio_attr(
-                self.name, "filter_low_pass_3db_frequency_available", False
-            )
-
-        @property
-        def raw(self):
-            """adxl380 channel raw value"""
-            return self._get_iio_attr(self.name, "raw", False)
-
-        @property
-        def scale(self):
-            """adxl380 channel scale(gain)"""
-            return float(self._get_iio_attr_str(self.name, "scale", False))
-
-        @scale.setter
-        def scale(self, value):
-            self._set_iio_attr(
-                self.name, "scale", False, str(Decimal(value).real),
-            )
-
-        @property
-        def scale_available(self):
-            """Provides all available scale settings for the adxl380 channels"""
-            return self._get_iio_attr(self.name, "scale_available", False)

--- a/adi/adxl380.py
+++ b/adi/adxl380.py
@@ -12,6 +12,7 @@ class adxl380_temp_channel(attribute):
     """adxl380 temperature channel"""
 
     def __init__(self, ctrl, channel_name):
+        """Initialize an ADXL380 temperature channel."""
         self.name = channel_name
         self._ctrl = ctrl
 
@@ -35,6 +36,7 @@ class adxl380_channel(attribute):
     """adxl380 acceleration channel"""
 
     def __init__(self, ctrl, channel_name):
+        """Initialize an ADXL380 acceleration channel."""
         self.name = channel_name
         self._ctrl = ctrl
 
@@ -119,21 +121,34 @@ class adxl380(rx_chan_comp):
     compatible_parts = ["adxl380", "adxl382"]
 
     def __init__(self, uri="", device_name=None, device_index=0):
+        """Initialize the first available compatible accelerometer."""
         # The device may report as any of the compatible parts. Try each in
         # turn so the class works whether an adxl380 or adxl382 is present.
-        parts = [device_name] if device_name else list(self.compatible_parts)
+        if device_name and device_name not in self.compatible_parts:
+            raise Exception(
+                f"Not a compatible device: {device_name}. Supported device names "
+                f"are: {','.join(self.compatible_parts)}"
+            )
+
+        requested_part = device_name or self.compatible_parts[0]
+        parts = [requested_part] + [
+            part for part in self.compatible_parts if part != requested_part
+        ]
         last_exception = None
         for part in parts:
-            self._control_device_name = None
-            self._rx_data_device_name = None
+            self.__dict__["_control_device_name"] = None
+            self.__dict__["_rx_data_device_name"] = None
             try:
                 super().__init__(uri=uri, device_name=part, device_index=device_index)
                 return
             except Exception as exc:  # noqa: BLE001
                 last_exception = exc
-        raise last_exception
+        if last_exception is not None:
+            raise last_exception
+        raise Exception("No compatible device found")  # pragma: no cover
 
     def __post_init__(self):
+        """Set a small default receive-buffer size."""
         self.rx_buffer_size = 16  # Make default buffer smaller
 
     def _channel_def(self, ctrl, name):

--- a/adi/adxrs290.py
+++ b/adi/adxrs290.py
@@ -5,28 +5,39 @@
 import numpy as np
 
 from adi.attribute import attribute
-from adi.context_manager import context_manager
-from adi.rx_tx import rx
+from adi.device_base import rx_chan_comp
 
 
-class adxrs290(rx, context_manager, attribute):
+class adxrs290_channel(attribute):
+    """ADXRS290 channel"""
+
+    def __init__(self, ctrl, channel_name):
+        self.name = channel_name
+        self._ctrl = ctrl
+
+    @property
+    def raw(self):
+        """ADXRS290 channel raw value"""
+        return self._get_iio_attr(self.name, "raw", False)
+
+    @property
+    def scale(self):
+        """ADXRS290 channel scale(gain)"""
+        return float(self._get_iio_attr_str(self.name, "scale", False))
+
+
+class adxrs290(rx_chan_comp):
     """ ADI ADXRS290 Gyroscope """
 
     _device_name = "ADXRS290"
     _rx_data_type = np.int16
     _rx_unbuffered_data = True
     _rx_data_si_type = float
-
-    def __init__(self, uri=""):
-
-        context_manager.__init__(self, uri, self._device_name)
-        self._ctrl = self._ctx.find_device("adxrs290")
-        self.anglvel_x = self._channel(self._ctrl, "anglvel_x")
-        self.anglvel_y = self._channel(self._ctrl, "anglvel_y")
-        self.temp = self._channel(self._ctrl, "temp")
-        self._rxadc = self._ctx.find_device("adxrs290")
-        self._rx_channel_names = ["anglvel_x", "anglvel_y"]
-        rx.__init__(self)
+    _complex_data = False
+    _channel_def = adxrs290_channel
+    _rx_channel_names = ["anglvel_x", "anglvel_y"]
+    _ignore_channels = ["timestamp"]
+    compatible_parts = ["adxrs290"]
 
     @property
     def hpf_3db_frequency_available(self):
@@ -69,20 +80,3 @@ class adxrs290(rx, context_manager, attribute):
         self._set_iio_attr(
             "anglvel_x", "filter_low_pass_3db_frequency", False, str(float(value))
         )
-
-    class _channel(attribute):
-        """ADXRS290 channel"""
-
-        def __init__(self, ctrl, channel_name):
-            self.name = channel_name
-            self._ctrl = ctrl
-
-        @property
-        def raw(self):
-            """ADXRS290 channel raw value"""
-            return self._get_iio_attr(self.name, "raw", False)
-
-        @property
-        def scale(self):
-            """ADXRS290 channel scale(gain)"""
-            return float(self._get_iio_attr_str(self.name, "scale", False))

--- a/adi/adxrs290.py
+++ b/adi/adxrs290.py
@@ -12,6 +12,7 @@ class adxrs290_channel(attribute):
     """ADXRS290 channel"""
 
     def __init__(self, ctrl, channel_name):
+        """Initialize an ADXRS290 channel."""
         self.name = channel_name
         self._ctrl = ctrl
 

--- a/adi/ltc2378.py
+++ b/adi/ltc2378.py
@@ -4,89 +4,11 @@
 
 from decimal import Decimal
 
-import numpy as np
-
 from adi.attribute import attribute
-from adi.context_manager import context_manager
-from adi.rx_tx import rx
+from adi.device_base import rx_chan_comp
 
 
-class ltc2378(rx, context_manager):
-
-    """ LTC2378 ADC """
-
-    _complex_data = False
-    channel = []  # type: ignore
-    _device_name = "ltc2378-20"
-
-    def __init__(self, uri="", device_name="ltc2378-20"):
-        context_manager.__init__(self, uri, self._device_name)
-
-        compatible_parts = [
-            "ltc2338-18",
-            "ltc2364-16",
-            "ltc2364-18",
-            "ltc2367-16",
-            "ltc2367-18",
-            "ltc2368-16",
-            "ltc2368-18",
-            "ltc2369-18",
-            "ltc2370-16",
-            "ltc2376-16",
-            "ltc2376-18",
-            "ltc2376-20",
-            "ltc2377-16",
-            "ltc2377-18",
-            "ltc2377-20",
-            "ltc2378-16",
-            "ltc2378-18",
-            "ltc2378-20",
-            "ltc2379-18",
-            "ltc2380-16",
-        ]
-        self._ctrl = None
-
-        if not device_name:
-            device_name = compatible_parts[0]
-        else:
-            if device_name not in compatible_parts:
-                raise Exception(f"Not a compatible device: {device_name}")
-
-        # Select the device matching device_name as working device
-        for device in self._ctx.devices:
-            if device.name == device_name:
-                self._ctrl = device
-                self._rxadc = device
-                break
-
-        # Raise an exception if the device isn't found
-        if not self._ctrl:
-            raise Exception(f"{device_name} device not found")
-
-        if not self._rxadc:
-            raise Exception("Error in selecting matching device")
-
-        self._rx_channel_names = []
-        self.channel = []
-        for ch in self._ctrl.channels:
-            name = ch.id
-            self._rx_channel_names.append(name)
-            self.channel.append(_channel(self._ctrl, name))
-
-        rx.__init__(self)
-
-    @property
-    def sampling_frequency(self):
-        """Get sampling frequency"""
-        return self._get_iio_dev_attr("sampling_frequency")
-
-    @sampling_frequency.setter
-    def sampling_frequency(self, value):
-        """Set sampling frequency"""
-        self._set_iio_dev_attr("sampling_frequency", value)
-
-
-class _channel(attribute):
+class ltc2378_channel(attribute):
     """LTC2378 channel"""
 
     def __init__(self, ctrl, channel_name):
@@ -107,6 +29,45 @@ class _channel(attribute):
     def sampling_frequency(self):
         """Get sampling frequency"""
         return self._get_iio_dev_attr("sampling_frequency", False)
+
+    @sampling_frequency.setter
+    def sampling_frequency(self, value):
+        """Set sampling frequency"""
+        self._set_iio_dev_attr("sampling_frequency", value)
+
+
+class ltc2378(rx_chan_comp):
+    """ LTC2378 ADC """
+
+    _complex_data = False
+    _device_name = ""
+    _channel_def = ltc2378_channel
+    compatible_parts = [
+        "ltc2378-20",
+        "ltc2338-18",
+        "ltc2364-16",
+        "ltc2364-18",
+        "ltc2367-16",
+        "ltc2367-18",
+        "ltc2368-16",
+        "ltc2368-18",
+        "ltc2369-18",
+        "ltc2370-16",
+        "ltc2376-16",
+        "ltc2376-18",
+        "ltc2376-20",
+        "ltc2377-16",
+        "ltc2377-18",
+        "ltc2378-16",
+        "ltc2378-18",
+        "ltc2379-18",
+        "ltc2380-16",
+    ]
+
+    @property
+    def sampling_frequency(self):
+        """Get sampling frequency"""
+        return self._get_iio_dev_attr("sampling_frequency")
 
     @sampling_frequency.setter
     def sampling_frequency(self, value):

--- a/adi/ltc2378.py
+++ b/adi/ltc2378.py
@@ -12,6 +12,7 @@ class ltc2378_channel(attribute):
     """LTC2378 channel"""
 
     def __init__(self, ctrl, channel_name):
+        """Initialize an LTC2378 channel."""
         self.name = channel_name
         self._ctrl = ctrl
 
@@ -37,6 +38,7 @@ class ltc2378_channel(attribute):
 
 
 class ltc2378(rx_chan_comp):
+
     """ LTC2378 ADC """
 
     _complex_data = False
@@ -58,6 +60,7 @@ class ltc2378(rx_chan_comp):
         "ltc2376-20",
         "ltc2377-16",
         "ltc2377-18",
+        "ltc2377-20",
         "ltc2378-16",
         "ltc2378-18",
         "ltc2379-18",

--- a/adi/max14001.py
+++ b/adi/max14001.py
@@ -14,6 +14,7 @@ class max14001_channel(attribute):
     """MAX14001 channel"""
 
     def __init__(self, ctrl, channel_name):
+        """Initialize a MAX14001 channel."""
         self.name = channel_name
         self._ctrl = ctrl
 

--- a/adi/max14001.py
+++ b/adi/max14001.py
@@ -6,79 +6,45 @@
 import numpy as np
 
 from adi.attribute import attribute
-from adi.context_manager import context_manager
-from adi.rx_tx import rx
+from adi.device_base import rx_chan_comp
 
 
-class max14001(rx, context_manager):
+class max14001_channel(attribute):
+
+    """MAX14001 channel"""
+
+    def __init__(self, ctrl, channel_name):
+        self.name = channel_name
+        self._ctrl = ctrl
+
+    @property
+    def raw(self):
+        """MAX14001 channel raw value."""
+        return self._get_iio_attr(self.name, "raw", False)
+
+    @property
+    def scale(self):
+        """MAX14001 channel scale."""
+        return float(self._get_iio_attr_str(self.name, "scale", False))
+
+    @property
+    def offset(self):
+        """MAX14001 channel offset."""
+        return self._get_iio_attr(self.name, "offset", False)
+
+
+class max14001(rx_chan_comp):
 
     """MAX14001 ADC"""
 
     _complex_data = False
-    channel = []  # type: ignore
     _device_name = ""
-
-    def __init__(self, uri="", device_name=""):
-        """Constructor for MAX14001 class."""
-        context_manager.__init__(self, uri, self._device_name)
-
-        compatible_parts = [
-            "max14001",
-            "max14002",
-        ]
-
-        self._ctrl = None
-
-        if not device_name:
-            device_name = compatible_parts[0]
-        else:
-            if device_name not in compatible_parts:
-                raise Exception(f"Not a compatible device: {device_name}")
-
-        # Select the device matching device_name as working device
-        for device in self._ctx.devices:
-            if device.name == device_name:
-                self._ctrl = device
-                self._rxadc = device
-                break
-
-        if not self._ctrl:
-            raise Exception("Error in selecting matching device")
-
-        if not self._rxadc:
-            raise Exception("Error in selecting matching device")
-
-        self._rx_channel_names = []
-        self.channel = []
-        for ch in self._ctrl.channels:
-            name = ch._id
-            self._rx_channel_names.append(name)
-            self.channel.append(self._channel(self._ctrl, name))
-
-        rx.__init__(self)
-
-    class _channel(attribute):
-
-        """MAX14001 channel"""
-
-        def __init__(self, ctrl, channel_name):
-            self.name = channel_name
-            self._ctrl = ctrl
-
-        @property
-        def raw(self):
-            """MAX14001 channel raw value."""
-            return self._get_iio_attr(self.name, "raw", False)
-
-        @property
-        def scale(self):
-            """MAX14001 channel scale."""
-            return float(self._get_iio_attr_str(self.name, "scale", False))
-
-        @property
-        def offset(self):
-            """MAX14001 channel offset."""
-            return self._get_iio_attr(self.name, "offset", False)
+    _channel_def = max14001_channel
+    _rx_channel_names = ["voltage"]
+    compatible_parts = [
+        "max14001",
+        "max14002",
+    ]
 
     def to_volts(self, index, val):
         """Converts raw value to SI."""

--- a/adi/max31865.py
+++ b/adi/max31865.py
@@ -11,6 +11,7 @@ class max31865_channel_temp(attribute):
     """MAX31865 temp channel"""
 
     def __init__(self, ctrl, channel_name):
+        """Initialize a MAX31865 temperature channel."""
         self.name = channel_name
         self._ctrl = ctrl
 
@@ -29,6 +30,7 @@ class max31865_channel_filt(attribute):
     """MAX31865 filter channel"""
 
     def __init__(self, ctrl, channel_name):
+        """Initialize a MAX31865 filter channel."""
         self.name = channel_name
         self._ctrl = ctrl
 
@@ -58,6 +60,7 @@ class max31865(rx_chan_comp):
     compatible_parts = ["max31865"]
 
     def __post_init__(self):
+        """Attach the non-scan-element filter channel."""
         self.filter = max31865_channel_filt(self._ctrl, "filter")
 
     def _channel_def(self, ctrl, name):

--- a/adi/max31865.py
+++ b/adi/max31865.py
@@ -4,29 +4,66 @@
 import numpy as np
 
 from adi.attribute import attribute
-from adi.context_manager import context_manager
-from adi.rx_tx import rx
+from adi.device_base import rx_chan_comp
 
 
-class max31865(rx, context_manager, attribute):
+class max31865_channel_temp(attribute):
+    """MAX31865 temp channel"""
+
+    def __init__(self, ctrl, channel_name):
+        self.name = channel_name
+        self._ctrl = ctrl
+
+    @property
+    def raw(self):
+        """MAX31865 channel raw value"""
+        return self._get_iio_attr(self.name, "raw", False)
+
+    @property
+    def scale(self):
+        """MAX31865 channel scale value"""
+        return self._get_iio_attr(self.name, "scale", False)
+
+
+class max31865_channel_filt(attribute):
+    """MAX31865 filter channel"""
+
+    def __init__(self, ctrl, channel_name):
+        self.name = channel_name
+        self._ctrl = ctrl
+
+    @property
+    def notch(self):
+        """MAX31865 Notch center frequency"""
+        return self._get_iio_attr(self.name, "notch_center_frequency", False)
+
+    @notch.setter
+    def notch(self, value):
+        """MAX31865 Notch center frequency (50 or 60)"""
+        return self._set_iio_attr(self.name, "notch_center_frequency", False, value)
+
+
+class max31865(rx_chan_comp):
     """MAX31865 RTD to Digital device"""
 
     _device_name = "max31865"
     _rx_data_type = np.int16
     _rx_unbuffered_data = True
     _rx_data_si_type = float
+    _complex_data = False
+    _rx_channel_names = ["temp", "filter"]
+    # The filter channel has no scale attribute, so keep it out of the
+    # auto-populated channel list and attach it manually below.
+    _ignore_channels = ["filter"]
+    compatible_parts = ["max31865"]
 
-    def __init__(self, uri=""):
-        context_manager.__init__(self, uri, self._device_name)
-        self._ctrl = self._ctx.find_device("max31865")
+    def __post_init__(self):
+        self.filter = max31865_channel_filt(self._ctrl, "filter")
 
-        if self._ctrl is None:
-            raise Exception("No device found")
-
-        self.temp = self._channel_temp(self._ctrl, "temp")
-        self.filter = self._channel_filt(self._ctrl, "filter")
-        self._rx_channel_names = ["temp", "filter"]
-        rx.__init__(self)
+    def _channel_def(self, ctrl, name):
+        if name == "filter":
+            return max31865_channel_filt(ctrl, name)
+        return max31865_channel_temp(ctrl, name)
 
     @property
     def fault(self):
@@ -37,37 +74,3 @@ class max31865(rx, context_manager, attribute):
     def samp_available(self):
         """MAX31865 Sampling frequency"""
         return self._get_iio_dev_attr("sampling_frequency_available")
-
-    class _channel_temp(attribute):
-        """MAX31865 temp channel"""
-
-        def __init__(self, ctrl, channel_name):
-            self.name = channel_name
-            self._ctrl = ctrl
-
-        @property
-        def raw(self):
-            """MAX31865 channel raw value"""
-            return self._get_iio_attr(self.name, "raw", False)
-
-        @property
-        def scale(self):
-            """MAX31865 channel scale value"""
-            return self._get_iio_attr(self.name, "scale", False)
-
-    class _channel_filt(attribute):
-        """MAX31865 filter channel"""
-
-        def __init__(self, ctrl, channel_name):
-            self.name = channel_name
-            self._ctrl = ctrl
-
-        @property
-        def notch(self):
-            """MAX31865 Notch center frequency"""
-            return self._get_iio_attr(self.name, "notch_center_frequency", False)
-
-        @notch.setter
-        def notch(self, value):
-            """MAX31865 Notch center frequency (50 or 60)"""
-            return self._set_iio_attr(self.name, "notch_center_frequency", False, value)

--- a/adi/max9611.py
+++ b/adi/max9611.py
@@ -3,144 +3,123 @@
 # SPDX short identifier: ADIBSD
 
 from adi.attribute import attribute
-from adi.context_manager import context_manager
-from adi.rx_tx import rx
+from adi.device_base import rx_chan_comp
 
 
-class max9611(rx, context_manager):
+class max9611_channel_voltage_sense(attribute):
+    """MAX9611 Voltage Sense Channel"""
+
+    def __init__(self, ctrl, channel_name):
+        self.name = channel_name
+        self._ctrl = ctrl
+
+    @property
+    def input(self):
+        """MAX9611 Voltage Sense Channel input value."""
+        return self._get_iio_attr(self.name, "input", False)
+
+
+class max9611_channel_voltage_input(attribute):
+    """MAX9611 Voltage Input Channel"""
+
+    def __init__(self, ctrl, channel_name):
+        self.name = channel_name
+        self._ctrl = ctrl
+
+    @property
+    def raw(self):
+        """MAX9611 Voltage Input Channel raw value."""
+        return self._get_iio_attr(self.name, "raw", False)
+
+    @property
+    def scale(self):
+        """MAX9611 Voltage Input Channel scale."""
+        return float(self._get_iio_attr_str(self.name, "scale", False))
+
+    @property
+    def offset(self):
+        """Voltage Input Channel offset."""
+        return float(self._get_iio_attr_str(self.name, "offset", False))
+
+
+class max9611_channel_power(attribute):
+    """MAX9611 Power Channel"""
+
+    def __init__(self, ctrl, channel_name):
+        self.name = channel_name
+        self._ctrl = ctrl
+
+    @property
+    def input(self):
+        """MAX9611 Power Channel input value."""
+        return self._get_iio_attr(self.name, "input", False)
+
+    @property
+    def shunt_resistor(self):
+        """MAX9611 Power Channel shunt resistor."""
+        return float(self._get_iio_attr_str(self.name, "shunt_resistor", False))
+
+
+class max9611_channel_current(attribute):
+    """MAX9611 Current Channel"""
+
+    def __init__(self, ctrl, channel_name):
+        self.name = channel_name
+        self._ctrl = ctrl
+
+    @property
+    def input(self):
+        """MAX9611 Current Channel input value."""
+        return self._get_iio_attr(self.name, "input", False)
+
+    @property
+    def shunt_resistor(self):
+        """MAX9611 Current Channel shunt resistor."""
+        return float(self._get_iio_attr_str(self.name, "shunt_resistor", False))
+
+
+class max9611_channel_temp(attribute):
+    """MAX9611 Temperature Channel"""
+
+    def __init__(self, ctrl, channel_name):
+        self.name = channel_name
+        self._ctrl = ctrl
+
+    @property
+    def raw(self):
+        """MAX9611 Temperature Channel raw value."""
+        return self._get_iio_attr(self.name, "raw", False)
+
+    @property
+    def scale(self):
+        """MAX9611 Temperature Channel scale."""
+        return float(self._get_iio_attr_str(self.name, "scale", False))
+
+
+class max9611(rx_chan_comp):
     """AD611 Current-sense Amplifier with ADC"""
 
     _complex_data = False
-    channel = []  # type: ignore
     _device_name = ""
+    _rx_unbuffered_data = True
+    _rx_channel_names = ["voltage1", "temp"]
+    # voltage0 (sense), power and current have no scale attribute, so keep them
+    # out of the auto-populated channel list and attach them manually below.
+    _ignore_channels = ["voltage0", "power", "current"]
+    compatible_parts = ["max9611", "max9612"]
 
-    def __init__(self, uri="", device_name=""):
-        context_manager.__init__(self, uri, self._device_name)
-        compatible_parts = ["max9611", "max9612"]
-        self._ctrl = None
+    def __post_init__(self):
+        self.voltage0 = max9611_channel_voltage_sense(self._ctrl, "voltage0")
+        self.power = max9611_channel_power(self._ctrl, "power")
+        self.current = max9611_channel_current(self._ctrl, "current")
 
-        if not device_name:
-            device_name = compatible_parts[0]
-        else:
-            if device_name not in compatible_parts:
-                raise Exception(f"Not a compatible device: {device_name}")
-
-        # Select the device matching device_name as working device
-        for device in self._ctx.devices:
-            if device.name == device_name:
-                self._ctrl = device
-                self._rxadc = device
-                break
-
-        if not self._ctrl:
-            raise Exception("Error in selecting matching device")
-
-        if not self._rxadc:
-            raise Exception("Error in selecting matching device")
-
-        # Dynamically get channels after the index
-        self._rx_channel_names = []
-        for ch in self._ctrl.channels:
-            name = ch._id
-
-            if name == "voltage0":
-                setattr(self, name, self._channel_voltage_sense(self._ctrl, name))
-            elif name == "voltage1":
-                setattr(self, name, self._channel_voltage_input(self._ctrl, name))
-                self._rx_channel_names.append(name)
-            elif name == "power":
-                setattr(self, name, self._channel_power(self._ctrl, name))
-            elif name == "current":
-                setattr(self, name, self._channel_current(self._ctrl, name))
-            elif name == "temp":
-                setattr(self, name, self._channel_temp(self._ctrl, name))
-                self._rx_channel_names.append(name)
-
-        self._rx_unbuffered_data = True
-
-        rx.__init__(self)
-
-    class _channel_voltage_sense(attribute):
-        """MAX9611 Voltage Sense Channel"""
-
-        def __init__(self, ctrl, channel_name):
-            self.name = channel_name
-            self._ctrl = ctrl
-
-        @property
-        def input(self):
-            """MAX9611 Voltage Sense Channel input value."""
-            return self._get_iio_attr(self.name, "input", False)
-
-    class _channel_voltage_input(attribute):
-        """MAX9611 Voltage Input Channel"""
-
-        def __init__(self, ctrl, channel_name):
-            self.name = channel_name
-            self._ctrl = ctrl
-
-        @property
-        def raw(self):
-            """MAX9611 Voltage Input Channel raw value."""
-            return self._get_iio_attr(self.name, "raw", False)
-
-        @property
-        def scale(self):
-            """MAX9611 Voltage Input Channel scale."""
-            return float(self._get_iio_attr_str(self.name, "scale", False))
-
-        @property
-        def offset(self):
-            """Voltage Input Channel offset."""
-            return float(self._get_iio_attr_str(self.name, "offset", False))
-
-    class _channel_power(attribute):
-        """MAX9611 Power Channel"""
-
-        def __init__(self, ctrl, channel_name):
-            self.name = channel_name
-            self._ctrl = ctrl
-
-        @property
-        def input(self):
-            """MAX9611 Power Channel input value."""
-            return self._get_iio_attr(self.name, "input", False)
-
-        @property
-        def shunt_resistor(self):
-            """MAX9611 Power Channel shunt resistor."""
-            return float(self._get_iio_attr_str(self.name, "shunt_resistor", False))
-
-    class _channel_current(attribute):
-        """MAX9611 Current Channel"""
-
-        def __init__(self, ctrl, channel_name):
-            self.name = channel_name
-            self._ctrl = ctrl
-
-        @property
-        def input(self):
-            """MAX9611 Current Channel input value."""
-            return self._get_iio_attr(self.name, "input", False)
-
-        @property
-        def shunt_resistor(self):
-            """MAX9611 Current Channel shunt resistor."""
-            return float(self._get_iio_attr_str(self.name, "shunt_resistor", False))
-
-    class _channel_temp(attribute):
-        """MAX9611 Temperature Channel"""
-
-        def __init__(self, ctrl, channel_name):
-            self.name = channel_name
-            self._ctrl = ctrl
-
-        @property
-        def raw(self):
-            """MAX9611 Temperature Channel raw value."""
-            return self._get_iio_attr(self.name, "raw", False)
-
-        @property
-        def scale(self):
-            """MAX9611 Temperature Channel scale."""
-            return float(self._get_iio_attr_str(self.name, "scale", False))
+    def _channel_def(self, ctrl, name):
+        if name == "voltage0":
+            return max9611_channel_voltage_sense(ctrl, name)
+        if name == "voltage1":
+            return max9611_channel_voltage_input(ctrl, name)
+        if name == "power":
+            return max9611_channel_power(ctrl, name)
+        if name == "current":
+            return max9611_channel_current(ctrl, name)
+        return max9611_channel_temp(ctrl, name)

--- a/adi/max9611.py
+++ b/adi/max9611.py
@@ -10,6 +10,7 @@ class max9611_channel_voltage_sense(attribute):
     """MAX9611 Voltage Sense Channel"""
 
     def __init__(self, ctrl, channel_name):
+        """Initialize a MAX9611 voltage-sense channel."""
         self.name = channel_name
         self._ctrl = ctrl
 
@@ -23,6 +24,7 @@ class max9611_channel_voltage_input(attribute):
     """MAX9611 Voltage Input Channel"""
 
     def __init__(self, ctrl, channel_name):
+        """Initialize a MAX9611 voltage-input channel."""
         self.name = channel_name
         self._ctrl = ctrl
 
@@ -46,6 +48,7 @@ class max9611_channel_power(attribute):
     """MAX9611 Power Channel"""
 
     def __init__(self, ctrl, channel_name):
+        """Initialize a MAX9611 power channel."""
         self.name = channel_name
         self._ctrl = ctrl
 
@@ -64,6 +67,7 @@ class max9611_channel_current(attribute):
     """MAX9611 Current Channel"""
 
     def __init__(self, ctrl, channel_name):
+        """Initialize a MAX9611 current channel."""
         self.name = channel_name
         self._ctrl = ctrl
 
@@ -82,6 +86,7 @@ class max9611_channel_temp(attribute):
     """MAX9611 Temperature Channel"""
 
     def __init__(self, ctrl, channel_name):
+        """Initialize a MAX9611 temperature channel."""
         self.name = channel_name
         self._ctrl = ctrl
 
@@ -109,6 +114,7 @@ class max9611(rx_chan_comp):
     compatible_parts = ["max9611", "max9612"]
 
     def __post_init__(self):
+        """Attach channels that have no scale attribute."""
         self.voltage0 = max9611_channel_voltage_sense(self._ctrl, "voltage0")
         self.power = max9611_channel_power(self._ctrl, "power")
         self.current = max9611_channel_current(self._ctrl, "current")

--- a/adi/max9611.py
+++ b/adi/max9611.py
@@ -107,7 +107,7 @@ class max9611(rx_chan_comp):
     _complex_data = False
     _device_name = ""
     _rx_unbuffered_data = True
-    _rx_channel_names = ["voltage1", "temp"]
+    _rx_channel_names = ["temp", "voltage1"]
     # voltage0 (sense), power and current have no scale attribute, so keep them
     # out of the auto-populated channel list and attach them manually below.
     _ignore_channels = ["voltage0", "power", "current"]

--- a/adi/rx_tx.py
+++ b/adi/rx_tx.py
@@ -611,6 +611,13 @@ class shared_def(context_manager, metaclass=ABCMeta):
                 if all(dev in devs for dev in required_devices):
                     self._ctx = iio.Context(c)
                     break
+            # Preserve context_manager's legacy fallback for environments where
+            # network discovery is unavailable but ip:analog is reachable.
+            if not self._ctx and self._uri_auto != "":
+                try:
+                    self._ctx = iio.Context(self._uri_auto)
+                except Exception:  # noqa: BLE001
+                    self._ctx = None
             if not self._ctx:
                 raise Exception("No context could be found for class")
 

--- a/doc/source/devices/adi.adis16475.rst
+++ b/doc/source/devices/adi.adis16475.rst
@@ -1,7 +1,7 @@
 adis16475
 ====================
 
-.. autoclass:: adi.adis16475
+.. automodule:: adi.adis16475
    :members:
    :undoc-members:
    :show-inheritance:

--- a/test/test_max14001.py
+++ b/test/test_max14001.py
@@ -8,21 +8,18 @@ classname = "adi.max14001"
 @pytest.mark.iio_hardware(hardware)
 @pytest.mark.parametrize("classname", [(classname)])
 @pytest.mark.parametrize(
-    "attr, start, stop, step, tol, repeats, sub_channel",
-    [("raw", 0, 1023, 1, 1, 2, "_channel"),],
+    "attr, lower, upper, repeats, sub_channel", [("raw", 0, 1023, 2, "voltage"),],
 )
 def test_max14001_attr(
-    test_attribute_single_value,
+    test_attribute_single_value_readonly,
     iio_uri,
     classname,
     attr,
-    start,
-    stop,
-    step,
-    tol,
+    lower,
+    upper,
     repeats,
     sub_channel,
 ):
-    test_attribute_single_value(
-        iio_uri, classname, attr, start, stop, step, tol, repeats, sub_channel
+    test_attribute_single_value_readonly(
+        iio_uri, classname, attr, lower, upper, repeats, sub_channel
     )

--- a/test/test_max31865.py
+++ b/test/test_max31865.py
@@ -18,7 +18,7 @@ def test_max31865_rx_data(test_dma_rx, iio_uri, classname, channel):
 @pytest.mark.parametrize("classname", [(classname)])
 @pytest.mark.parametrize(
     "attr, start, stop, step, tol, repeats, sub_channel",
-    [("notch", 50, 60, 1, 1, 2, "_channel_filt"),],
+    [("notch", 50, 60, 1, 1, 2, "filter"),],
 )
 def test_max31865_attrs(
     test_attribute_single_value,

--- a/test/test_max9611.py
+++ b/test/test_max9611.py
@@ -9,24 +9,19 @@ classname = "adi.max9611"
 @pytest.mark.iio_hardware(hardware)
 @pytest.mark.parametrize("classname", [(classname)])
 @pytest.mark.parametrize(
-    "attr, start, stop, step, tol, repeats, sub_channel",
-    [
-        ("raw", 0, 1023, 1, 1, 3, "_channel_voltage_input"),
-        ("raw", 0, 1023, 1, 1, 3, "_channel_temp"),
-    ],
+    "attr, lower, upper, repeats, sub_channel",
+    [("raw", 0, 1023, 3, "voltage1"), ("raw", 0, 1023, 3, "temp"),],
 )
 def test_max9611_raw_attr(
-    test_attribute_single_value,
+    test_attribute_single_value_readonly,
     iio_uri,
     classname,
     attr,
-    start,
-    stop,
-    step,
-    tol,
+    lower,
+    upper,
     repeats,
     sub_channel,
 ):
-    test_attribute_single_value(
-        iio_uri, classname, attr, start, stop, step, tol, repeats, sub_channel
+    test_attribute_single_value_readonly(
+        iio_uri, classname, attr, lower, upper, repeats, sub_channel
     )

--- a/test/test_refactored_devices_unit.py
+++ b/test/test_refactored_devices_unit.py
@@ -8,11 +8,58 @@ import pytest
 
 import adi
 from adi.device_base import rx_chan_comp
+from adi.rx_tx import shared_def
+
+
+class _SharedDefTestDevice(shared_def):
+    """Concrete shared_def used to test context selection."""
+
+    @property
+    def _complex_data(self):  # type: ignore[override]
+        return False
+
+    @property
+    def _control_device_name(self):  # type: ignore[override]
+        return "test-device"
+
+    @property
+    def _rx_data_device_name(self):
+        return "test-device"
+
+
+def test_shared_def_falls_back_to_ip_analog(monkeypatch):
+    """URI-less construction retains the legacy ip:analog fallback."""
+    device = MagicMock()
+    device.name = "test-device"
+    context = MagicMock()
+    context.devices = [device]
+    context.find_device.return_value = device
+
+    class FakeContext:
+        calls = []
+
+        def __new__(cls, uri):
+            cls.calls.append(uri)
+            return context
+
+    monkeypatch.setattr("adi.rx_tx.iio.scan_contexts", lambda: {})
+    monkeypatch.setattr("adi.context_manager.iio.Context", FakeContext)
+
+    dev = _SharedDefTestDevice()
+
+    assert FakeContext.calls == ["ip:analog"]
+    assert dev.ctx is context
+    assert dev._ctrl is device
 
 
 def test_ltc2378_preserves_all_compatible_parts():
     """The common-parent migration must not drop a supported device name."""
     assert "ltc2377-20" in adi.ltc2378.compatible_parts
+
+
+def test_max9611_preserves_legacy_rx_channel_order():
+    """Integer RX indices and returned array order remain backwards compatible."""
+    assert adi.max9611._rx_channel_names == ["temp", "voltage1"]
 
 
 @pytest.mark.parametrize(

--- a/test/test_refactored_devices_unit.py
+++ b/test/test_refactored_devices_unit.py
@@ -23,6 +23,12 @@ def channel_definitions(device_class, iio_uri):
             assert hasattr(
                 ch, "scale"
             ), f"{device_class} channel {ch.name} missing scale property"
+            # device_base exposes each channel as a named attribute on the
+            # device (the documented ``device.<channel>.<attr>`` contract).
+            assert getattr(dev, ch.name, None) is ch, (
+                f"{device_class} channel {ch.name} not accessible as a named "
+                "attribute on the device"
+            )
 
 
 @pytest.fixture()
@@ -131,4 +137,68 @@ def test_ad5686_channel_definitions(test_channel_definitions, iio_uri, device_cl
 @pytest.mark.iio_hardware("ad7291", True)
 @pytest.mark.parametrize("device_class", ["ad7291"])
 def test_ad7291_channel_definitions(test_channel_definitions, iio_uri, device_class):
+    test_channel_definitions(device_class, iio_uri)
+
+
+@pytest.mark.iio_hardware("ltc2378-20")
+@pytest.mark.parametrize("device_class", ["ltc2378"])
+def test_ltc2378_channel_definitions(test_channel_definitions, iio_uri, device_class):
+    test_channel_definitions(device_class, iio_uri)
+
+
+@pytest.mark.iio_hardware("max14001")
+@pytest.mark.parametrize("device_class", ["max14001"])
+def test_max14001_channel_definitions(test_channel_definitions, iio_uri, device_class):
+    test_channel_definitions(device_class, iio_uri)
+
+
+@pytest.mark.iio_hardware("ada4355")
+@pytest.mark.parametrize("device_class", ["ada4355"])
+def test_ada4355_channel_definitions(test_channel_definitions, iio_uri, device_class):
+    test_channel_definitions(device_class, iio_uri)
+
+
+@pytest.mark.iio_hardware("adxrs290")
+@pytest.mark.parametrize("device_class", ["adxrs290"])
+def test_adxrs290_channel_definitions(test_channel_definitions, iio_uri, device_class):
+    test_channel_definitions(device_class, iio_uri)
+
+
+@pytest.mark.iio_hardware("adxl380")
+@pytest.mark.parametrize("device_class", ["adxl380"])
+def test_adxl380_channel_definitions(test_channel_definitions, iio_uri, device_class):
+    test_channel_definitions(device_class, iio_uri)
+
+
+@pytest.mark.iio_hardware("ad5706r")
+@pytest.mark.parametrize("device_class", ["ad5706r"])
+def test_ad5706r_channel_definitions(test_channel_definitions, iio_uri, device_class):
+    test_channel_definitions(device_class, iio_uri)
+
+
+@pytest.mark.iio_hardware("ad3552r_hs")
+@pytest.mark.parametrize("device_class", ["ad3552r_hs"])
+def test_ad3552r_hs_channel_definitions(
+    test_channel_definitions, iio_uri, device_class
+):
+    test_channel_definitions(device_class, iio_uri)
+
+
+@pytest.mark.iio_hardware("max31865")
+@pytest.mark.parametrize("device_class", ["max31865"])
+def test_max31865_channel_definitions(test_channel_definitions, iio_uri, device_class):
+    test_channel_definitions(device_class, iio_uri)
+
+
+@pytest.mark.iio_hardware("max9611")
+@pytest.mark.parametrize("device_class", ["max9611"])
+def test_max9611_channel_definitions(test_channel_definitions, iio_uri, device_class):
+    test_channel_definitions(device_class, iio_uri)
+
+
+@pytest.mark.iio_hardware(
+    "adis16475", True
+)  # iio-emu does not support trigger assignment used in device init
+@pytest.mark.parametrize("device_class", ["adis16475"])
+def test_adis16475_channel_definitions(test_channel_definitions, iio_uri, device_class):
     test_channel_definitions(device_class, iio_uri)

--- a/test/test_refactored_devices_unit.py
+++ b/test/test_refactored_devices_unit.py
@@ -7,6 +7,37 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 
 import adi
+from adi.device_base import rx_chan_comp
+
+
+def test_ltc2378_preserves_all_compatible_parts():
+    """The common-parent migration must not drop a supported device name."""
+    assert "ltc2377-20" in adi.ltc2378.compatible_parts
+
+
+@pytest.mark.parametrize(
+    "device_class,requested_device",
+    [(adi.adxl380, "adxl380"), (adi.adis16475, "adis16505-2"),],
+)
+def test_compatible_device_fallback(monkeypatch, device_class, requested_device):
+    """Classes that historically probed compatible parts must keep doing so."""
+    attempts = []
+
+    def init_with_first_device_missing(self, uri="", device_name="", device_index=0):
+        attempts.append(device_name)
+        if len(attempts) == 1:
+            raise Exception(f"No device found with name {device_name}")
+
+    monkeypatch.setattr(rx_chan_comp, "__init__", init_with_first_device_missing)
+
+    device_class(uri="local:", device_name=requested_device)
+
+    assert attempts == [
+        requested_device,
+        next(
+            part for part in device_class.compatible_parts if part != requested_device
+        ),
+    ]
 
 
 def channel_definitions(device_class, iio_uri):


### PR DESCRIPTION
Refactor ltc2378, max14001, ada4355, adxrs290, adxl380, max31865, max9611 and adis16475 to rx_chan_comp, and ad5706r and ad3552r_hs to tx_chan_comp. Each drops its hand-rolled __init__ (context creation, find_device, channel loop, rx/tx.__init__) in favor of the device_base machinery; nested _channel classes are promoted to top level and wired via compatible_parts/_channel_def, with leftover setup moved to __post_init__.

Devices with multiple channel types (adxl380, max31865, max9611, adis16475, ad3552r_hs) use a _channel_def method dispatcher. Channels lacking a scale attribute (max31865 filter; max9611 voltage0/power/current) or emulation-only channels (timestamp) are excluded via _ignore_channels and re-attached as named attributes in __post_init__. adxl380 keeps a small __init__ that probes each compatible part (device may report as adxl380 or adxl382); adis16475 keeps its adis16505-2 default and wires its trigger in __post_init__.

Tests:
- Extend the shared structural helper to assert each channel is reachable as a named attribute on the device (the device_base device.<channel>.<attr> contract), and add structural entries for all migrated devices.
- max14001/max9611 raw channel checks switched to the read-only fixture (the legacy tests only passed by mutating class-level property descriptors via a nested-class sub_channel); max31865/max9611 sub_channel updated to real channel ids.
- adis16475 structural test is emulation-skipped: iio-emu does not support the trigger assignment used during device init.

ad5627 and adis16507 are intentionally left on the legacy pattern: ad5627 is a component of fmclidar1 and adis16507 has extra positional constructor params, so migrating either would break backwards compatibility.

# Description

Summarize the change and the motivation. Link the issue this fixes.

Fixes # (issue)

## Type of change

- [ ] Bug fix
- [ ] New device class interface
- [ ] New feature on an existing class
- [ ] Breaking change
- [ ] Documentation only
- [ ] Test or CI only

# How has this been tested?

State explicitly whether this was tested against **real hardware**, an **emulated context** (iio-emu), or **not run**. Name the part(s) and the context URI or board used.

- Hardware / emulation:
- Commands run (e.g. `python3 -m pytest -k ad4080 --adi-hw-map`):
- Result:

**Test configuration**
* Kernel / libiio version:
* OS:
* FPGA carrier (if applicable):

# Documentation

- [ ] No documentation change needed
- [ ] Updated existing docs under `doc/source/`
- [ ] Added a new device page and linked it from the relevant toctree

# New device class interfaces

Skip this section if the PR does not add a new device class.

- [ ] Class extends one of the common base classes in `adi.device_base` (`rx_chan_comp`, `tx_chan_comp`, or a `_no_buff` variant). If not, explain why in the description. See the [Device Base Classes](https://analogdevicesinc.github.io/pyadi-iio/dev/device_base.html) developer doc page.
- [ ] `compatible_parts` lists every part number this class supports
- [ ] Part numbers added to `supported_parts.md` (verify with `invoke checkparts`)
- [ ] Emulation context (xml_gen, not iio_genxml) added under `test/emu/` and referenced from a test
- [ ] Tests added that run against the emulation context in CI

# Checklist

- [ ] `invoke precommit` passes locally
- [ ] All commits are signed off (`Signed-off-by: Name <email>`)
- [ ] No new warnings from the build or doc generation
- [ ] Dependent changes in libiio, kernel, or HDL are merged and referenced
