### PR TITLE
Revert "adi: add support for big endian rx buffers"

### DIFF
--- a/adi/compat.py
+++ b/adi/compat.py
@@ -60,7 +60,6 @@ class compat_libiio_v1_rx:
             # create format strings
             df = chan.data_format
             fmt = ("i" if df.is_signed is True else "u") + str(df.length // 8)
-            fmt = ">" + fmt if df.is_be else fmt
             data_channel_interleaved.append(np.frombuffer(bytearray_data, dtype=fmt))
 
         return data_channel_interleaved
@@ -186,7 +185,6 @@ class compat_libiio_v0_rx:
             # create format strings
             df = chan.data_format
             fmt = ("i" if df.is_signed is True else "u") + str(df.length // 8)
-            fmt = ">" + fmt if df.is_be else fmt
             data_channel_interleaved.append(np.frombuffer(bytearray_data, dtype=fmt))
 
         return data_channel_interleaved


### PR DESCRIPTION
# Description

Fixes #760

This reverts commit 932ece74d2573009a09ef773c5aab1e040f60df4.

Byte order swaps are already handled by libiio in `iio_channel_read`, `iio_channel_convert`, so the output of `libiio.Channel.read()` already comes in native byte order. An extra endianness correction is not needed.

This behaviour was originally added to comply with the PQMON board, but it is actually the PQMON that claims the wrong endianness, not pyadi-iio that doesn't account for it. (see analogdevicesinc/no-OS#3150)

## Type of change

- [x] Bug fix
- [ ] New device class interface
- [ ] New feature on an existing class
- [ ] Breaking change
- [ ] Documentation only
- [ ] Test or CI only

# How has this been tested?

Tested on **real hardware**.
- Hardware: Raspberry Pi 5 + EVAL-ADISIMU1-RPIZ + ADIS16470
- OS: Kuiper Linux (Debian Trixie), kernel 6.12.41-v8-16k+ from analogdevicesinc rpi-6.12.y branch
- libiio 0.26

```python
import adi

adis = adi.adis16475("local:", device_name="adis16470")

adis.rx_output_type = "SI"
adis.rx_buffer_size = 1
adis.rx_enabled_channels = ["accel_x", "accel_y", "accel_z"] # accel_* are big endian
adis.rx_annotated = True

for i in range(5):
    sample_set = adis.rx()

    accel_x = sample_set["accel_x"][0]
    accel_y = sample_set["accel_y"][0]
    accel_z = sample_set["accel_z"][0]

    accel = (accel_x*accel_x + accel_y*accel_y + accel_z*accel_z)**.5

    print(accel, accel_x, accel_y, accel_z)
```

Expected output: The first number on each line should be close to the gravitational acceleration 9.81.

Output (before fix):

```
$ python3 imu_test.py
WARNING: High-speed mode not enabled
0.012119530986198971 0.004835072 0.000383163 0.011106678
0.012119914338305738 0.004595712 0.000526779 0.011202422
0.012239960077477253 0.0047872 0.000574651 0.011250294
0.01210212259097176 0.0047872 0.00043103499999999997 0.011106678
0.01223405861101135 0.0047872 0.00043103499999999997 0.011250294
```

Output (after fix):

```
$ python3 imu_test.py
WARNING: High-speed mode not enabled
9.804652819587297 1.213267968 3.259891712 9.166913536
9.806176872981872 1.2255232 3.259891712 9.166913536
9.759389964458899 1.250033664 3.2476364799999997 9.117892608
9.794560518255112 1.250033664 3.284402176 9.142403072
9.793747777554627 1.250033664 3.2476364799999997 9.154658304
```

# Documentation

- [x] No documentation change needed
- [ ] Updated existing docs under `doc/source/`
- [ ] Added a new device page and linked it from the relevant toctree

# Checklist

- [x] `invoke precommit` passes locally
- [x] All commits are signed off (`Signed-off-by: Name <email>`)
- [x] No new warnings from the build or doc generation
- [x] Dependent changes in libiio, kernel, or HDL are merged and referenced
