### PR TITLE
compat: stop double-swapping big-endian RX channel data (fixes #760)

### DIFF
--- a/adi/compat.py
+++ b/adi/compat.py
@@ -60,7 +60,6 @@ class compat_libiio_v1_rx:
             # create format strings
             df = chan.data_format
             fmt = ("i" if df.is_signed is True else "u") + str(df.length // 8)
-            fmt = ">" + fmt if df.is_be else fmt
             data_channel_interleaved.append(np.frombuffer(bytearray_data, dtype=fmt))
 
         return data_channel_interleaved
@@ -186,7 +185,6 @@ class compat_libiio_v0_rx:
             # create format strings
             df = chan.data_format
             fmt = ("i" if df.is_signed is True else "u") + str(df.length // 8)
-            fmt = ">" + fmt if df.is_be else fmt
             data_channel_interleaved.append(np.frombuffer(bytearray_data, dtype=fmt))
 
         return data_channel_interleaved


### PR DESCRIPTION
## Summary

Fixes #760 — big-endian RX channel data was being byteswapped twice, corrupting every sample on real big-endian channels (e.g. the accel channels of an ADIS16470 on a little-endian host).

## Root cause

`#647` added, in both the libiio v0 and v1 `_rx_buffered_data` paths:

```python
fmt = ">" + fmt if df.is_be else fmt
```

This forces `np.frombuffer` to interpret the bytes as big-endian whenever the channel's hardware layout is big-endian. The problem is that the bytes handed to `np.frombuffer` are **not raw** — `Channel.read()` (called just above, with the default `raw=False`) runs libiio's `iio_channel_convert()`, which already normalizes raw sample bytes to **host-native** byte order. The `# Do local type conversion` comment on that `read()` call documents exactly this.

So on a little-endian host with a big-endian channel:

1. libiio converts BE hardware bytes → LE host order (correct, native).
2. `dtype=">u2"` then tells numpy to byteswap *again* → wrong value.

`df.is_be` describes the channel's **silicon** layout, not the layout of the buffer you're actually handed after conversion — conflating the two is the bug.

## Why revert is the right fix

Per the discussion in #760, pyadi-iio handled channel endianness correctly **before** #647. The case #647 was written for (PQMON) turned out to be a firmware bug — the firmware reported the wrong channel endianness (analogdevicesinc/no-OS#3150) — not something pyadi should compensate for. Compensating in pyadi breaks every correctly-behaving big-endian device.

This PR reverts the two added lines, restoring native-endian interpretation of the already-converted buffer.

## Validation

- Data-path verified: `Channel.read()` → `iio_channel_convert()` → host-native, so the numpy dtype must be native for all channels (the reporter's mixed timestamp-LE / accel-BE set all come back native).
- The change is a literal 2-line revert of #647; no other behavior is touched.
- Hardware confirmation on the reporter's ADIS16470 setup would be the final sign-off — happy to iterate if any device path still needs the BE flag.
