### PR TITLE
Migrate additional TX classes to common parents

### DIFF
--- a/adi/ad552xr.py
+++ b/adi/ad552xr.py
@@ -5,56 +5,20 @@
 """AD552XR DAC driver."""
 
 from adi.attribute import attribute
-from adi.context_manager import context_manager
-from adi.rx_tx import tx
+from adi.device_base import tx_chan_comp
 
 
-class ad552xr(tx, context_manager):
+class ad552xr(tx_chan_comp):
     """ad552xr DAC."""
 
     _complex_data = False
     _device_name = ""
 
-    def __init__(self, uri="", device_name=""):
-        """Initialize ad552xr class."""
-        context_manager.__init__(self, uri, self._device_name)
+    compatible_parts = ["ad5529r"]
 
-        compatible_parts = ["ad5529r"]
-
-        self._ctrl = None
-
-        if not device_name:
-            device_name = compatible_parts[0]
-        else:
-            if device_name not in compatible_parts:
-                raise Exception(
-                    f"Not a compatible device: {device_name}. Supported device names "
-                    f"are: {','.join(compatible_parts)}"
-                )
-
-        # Select the device matching device_name as working device
-        for device in self._ctx.devices:
-            if device.name == device_name:
-                self._ctrl = device
-                self._txdac = device
-                break
-
-        if not self._ctrl:
-            raise Exception("Error in selecting matching device")
-
-        if not self._txdac:
-            raise Exception("Error in selecting matching device")
-
-        self._output_bits = []
-        self.channel = []
-        for ch in self._ctrl.channels:
-            name = ch.id
-            self._output_bits.append(ch.data_format.bits)
-            self._tx_channel_names.append(name)
-            self.channel.append(self._channel(self._ctrl, name))
-            setattr(self, name, self._channel(self._ctrl, name))
-
-        tx.__init__(self)
+    def __post_init__(self):
+        """Populate the channel-wise output-bit widths."""
+        self._output_bits = [ch.data_format.bits for ch in self._ctrl.channels]
 
     @property
     def output_bits(self):
@@ -74,6 +38,7 @@ class ad552xr(tx, context_manager):
         """ad552xr channel."""
 
         def __init__(self, ctrl, channel_name):
+            """Initialize a channel wrapper."""
             self.name = channel_name
             self._ctrl = ctrl
 
@@ -328,3 +293,5 @@ class ad552xr(tx, context_manager):
                     "Error: Attribute value not supported \nUse one of: "
                     + str(self.range_sel_available)
                 )
+
+    _channel_def = _channel

--- a/adi/ad5710r.py
+++ b/adi/ad5710r.py
@@ -3,56 +3,20 @@
 # SPDX short identifier: ADIBSD
 
 from adi.attribute import attribute
-from adi.context_manager import context_manager
-from adi.rx_tx import tx
+from adi.device_base import tx_chan_comp
 
 
-class ad5710r(tx, context_manager):
+class ad5710r(tx_chan_comp):
     """ AD5710r DAC """
 
     _complex_data = False
     _device_name = ""
 
-    def __init__(self, uri="", device_name=""):
-        """Constructor for AD5710r class."""
-        context_manager.__init__(self, uri, self._device_name)
+    compatible_parts = ["ad5710r"]
 
-        compatible_parts = ["ad5710r"]
-
-        self._ctrl = None
-
-        if not device_name:
-            device_name = compatible_parts[0]
-        else:
-            if device_name not in compatible_parts:
-                raise Exception(
-                    f"Not a compatible device: {device_name}. Supported device names "
-                    f"are: {','.join(compatible_parts)}"
-                )
-
-        # Select the device matching device_name as working device
-        for device in self._ctx.devices:
-            if device.name == device_name:
-                self._ctrl = device
-                self._txdac = device
-                break
-
-        if not self._ctrl:
-            raise Exception("Error in selecting matching device")
-
-        if not self._txdac:
-            raise Exception("Error in selecting matching device")
-
-        self.channel = []  # type: ignore
-        self._output_bits = []
-        for ch in self._ctrl.channels:
-            name = ch.id
-            self._output_bits.append(ch.data_format.bits)
-            self._tx_channel_names.append(name)
-            self.channel.append(self._channel(self._ctrl, name))
-            setattr(self, name, self._channel(self._ctrl, name))
-
-        tx.__init__(self)
+    def __post_init__(self):
+        """Populate the channel-wise output-bit widths."""
+        self._output_bits = [ch.data_format.bits for ch in self._ctrl.channels]
 
     @property
     def output_bits(self):
@@ -214,6 +178,7 @@ class ad5710r(tx, context_manager):
         """AD5710r channel"""
 
         def __init__(self, ctrl, channel_name):
+            """Initialize a channel wrapper."""
             self.name = channel_name
             self._ctrl = ctrl
 
@@ -287,3 +252,5 @@ class ad5710r(tx, context_manager):
                 )
 
         #####################################################################
+
+    _channel_def = _channel

--- a/test/test_refactored_devices_unit.py
+++ b/test/test_refactored_devices_unit.py
@@ -2,7 +2,7 @@
 Unit tests for refactored device classes using device_base pattern.
 These tests verify the refactoring maintains correct structure and interfaces.
 """
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, call, patch
 
 import pytest
 
@@ -60,6 +60,32 @@ def test_ltc2378_preserves_all_compatible_parts():
 def test_max9611_preserves_legacy_rx_channel_order():
     """Integer RX indices and returned array order remain backwards compatible."""
     assert adi.max9611._rx_channel_names == ["temp", "voltage1"]
+
+
+def test_ad5710r_preserved_device_properties():
+    """Exercise preserved AD5710R device-level getter and setter contracts."""
+    dev = object.__new__(adi.ad5710r)
+    dev._get_iio_dev_attr_str = Mock(return_value="value")
+    dev._set_iio_dev_attr_str = Mock()
+
+    assert dev.sampling_frequency == "value"
+    assert dev.all_ch_input_registers == "value"
+    assert dev.all_ch_raw == "value"
+
+    dev.sampling_frequency = 1000
+    dev.all_ch_input_registers = 42
+    dev.all_ch_raw = 7
+
+    assert dev._get_iio_dev_attr_str.call_args_list == [
+        call("sampling_frequency"),
+        call("all_ch_input_registers"),
+        call("all_ch_raw"),
+    ]
+    assert dev._set_iio_dev_attr_str.call_args_list == [
+        call("sampling_frequency", 1000),
+        call("all_ch_input_registers", 42),
+        call("all_ch_raw", 7),
+    ]
 
 
 @pytest.mark.parametrize(

--- a/test/test_refactored_devices_unit.py
+++ b/test/test_refactored_devices_unit.py
@@ -280,3 +280,35 @@ def test_max9611_channel_definitions(test_channel_definitions, iio_uri, device_c
 @pytest.mark.parametrize("device_class", ["adis16475"])
 def test_adis16475_channel_definitions(test_channel_definitions, iio_uri, device_class):
     test_channel_definitions(device_class, iio_uri)
+
+
+@pytest.mark.iio_hardware("ad5710r")
+@pytest.mark.parametrize("device_class", ["ad5710r"])
+def test_ad5710r_channel_definitions(test_channel_definitions, iio_uri, device_class):
+    test_channel_definitions(device_class, iio_uri)
+    with adi.ad5710r(uri=iio_uri) as dev:
+        expected_names = [ch.id for ch in dev._ctrl.channels]
+        assert dev.tx_enabled_channels == list(range(8))
+        assert dev._tx_channel_names == expected_names
+        assert dev.output_bits == [16] * 8
+        assert [ch.name for ch in dev.channel] == expected_names
+        assert all(
+            getattr(dev, name) is dev.channel[i]
+            for i, name in enumerate(expected_names)
+        )
+
+
+@pytest.mark.iio_hardware("ad5529r")
+@pytest.mark.parametrize("device_class", ["ad552xr"])
+def test_ad552xr_channel_definitions(test_channel_definitions, iio_uri, device_class):
+    test_channel_definitions(device_class, iio_uri)
+    with adi.ad552xr(uri=iio_uri) as dev:
+        expected_names = [ch.id for ch in dev._ctrl.channels]
+        assert dev.tx_enabled_channels == list(range(16))
+        assert dev._tx_channel_names == expected_names
+        assert dev.output_bits == [16] * 16
+        assert [ch.name for ch in dev.channel] == expected_names
+        assert all(
+            getattr(dev, name) is dev.channel[i]
+            for i, name in enumerate(expected_names)
+        )


### PR DESCRIPTION
## Summary
- migrate `ad5710r` and `ad552xr` to the shared `tx_chan_comp` parent
- preserve compatible-device selection, buffered TX behavior, channel ordering, named wrappers, and output-bit metadata
- add emulation-backed structural regression coverage for both classes

## Testing
- `pytest -q --emu test/test_refactored_devices_unit.py test/test_ad5710r.py test/test_ad5529r.py` (258 passed, 9 skipped)
- `pytest -q` (43 passed, 2050 skipped)
- pre-commit hooks for changed files (all passed)