### PR TITLE
Migrate temperature RX classes to common parents

### DIFF
--- a/adi/ltc2983.py
+++ b/adi/ltc2983.py
@@ -8,38 +8,39 @@ from collections.abc import Iterable
 import numpy as np
 
 from adi.attribute import attribute
-from adi.context_manager import context_manager
-from adi.rx_tx import rx
+from adi.device_base import rx_chan_comp
 
 
-class ltc2983(rx, context_manager):
+class ltc2983(rx_chan_comp):
     """ LTC2983 Multi-Sensor Temperature Measurement System """
 
     channel: OrderedDict = None
+    _complex_data = False
     _device_name = "ltc2983"
     _rx_unbuffered_data = True
     _rx_data_type = np.int32
     _rx_data_si_type = float
+    compatible_parts = ["ltc2983"]
 
     def __init__(self, uri=""):
-        context_manager.__init__(self, uri, self._device_name)
-        self._ctrl = self._ctx.find_device("ltc2983")
-        self._rxadc = self._ctx.find_device("ltc2983")
+        """Initialize the LTC2983 while preserving its URI-only API."""
+        super().__init__(uri=uri)
 
-        # dynamically get channels
-        _channels = []
-        self._rx_channel_names = []
-        for ch in self._ctrl.channels:
-            self._rx_channel_names.append(ch.id)
-            _channels.append((ch.id, self._channel(self._ctrl, ch.id)))
-        self.channel = OrderedDict(_channels)
+    def __post_init__(self):
+        """Preserve all-channel traversal rather than scan-only discovery."""
+        self._rx_channel_names = [ch.id for ch in self._ctrl.channels]
 
-        rx.__init__(self)
+    def _add_channel_instances(self):
+        """Preserve the public OrderedDict channel container."""
+        self.channel = OrderedDict(
+            (ch.id, self._channel_def(self._ctrl, ch.id)) for ch in self._ctrl.channels
+        )
 
     class _channel(attribute):
         """ LTC2983 channel """
 
         def __init__(self, ctrl, channel_name):
+            """Initialize an LTC2983 channel wrapper."""
             self._ctrl = ctrl
             self.name = channel_name
 
@@ -72,3 +73,5 @@ class ltc2983(rx, context_manager):
                 val = np.fromiter(val, np.int32)
 
         return val * self.channel[channel_name].scale
+
+    _channel_def = _channel

--- a/adi/max31855.py
+++ b/adi/max31855.py
@@ -5,34 +5,33 @@
 import numpy as np
 
 from adi.attribute import attribute
-from adi.context_manager import context_manager
-from adi.rx_tx import rx
+from adi.device_base import rx_chan_comp
 
 
-class max31855(rx, context_manager, attribute):
+class max31855(rx_chan_comp, attribute):
     """MAX31855 thermocouple device"""
 
+    _complex_data = False
     _device_name = "max31855"
     _rx_data_type = np.int16
     _rx_unbuffered_data = True
     _rx_data_si_type = float
+    _control_device_name = "maxim_thermocouple"
+    _rx_data_device_name = "maxim_thermocouple"
+    _rx_channel_names = ["t_temp", "i_temp"]
+    compatible_parts = ["max31855"]
 
     def __init__(self, uri=""):
-        context_manager.__init__(self, uri, self._device_name)
-        self._ctrl = self._ctx.find_device("maxim_thermocouple")
-
-        if self._ctrl is None:
-            raise Exception("No device found")
-
-        self.temp_i = self._channel(self._ctrl, "i_temp")
-        self.temp_t = self._channel(self._ctrl, "t_temp")
-        self._rx_channel_names = ["t_temp", "i_temp"]
-        rx.__init__(self)
+        """Initialize the MAX31855 and retain its public temperature aliases."""
+        super().__init__(uri=uri)
+        self.temp_t = self.t_temp
+        self.temp_i = self.i_temp
 
     class _channel(attribute):
         """MAX31855 channel"""
 
         def __init__(self, ctrl, channel_name):
+            """Initialize a MAX31855 channel wrapper."""
             self.name = channel_name
             self._ctrl = ctrl
 
@@ -45,3 +44,5 @@ class max31855(rx, context_manager, attribute):
         def scale(self):
             """MAX31855 channel scale value"""
             return self._get_iio_attr(self.name, "scale", False)
+
+    _channel_def = _channel

--- a/test/test_refactored_devices_unit.py
+++ b/test/test_refactored_devices_unit.py
@@ -2,6 +2,7 @@
 Unit tests for refactored device classes using device_base pattern.
 These tests verify the refactoring maintains correct structure and interfaces.
 """
+from collections import OrderedDict
 from unittest.mock import MagicMock, Mock, call, patch
 
 import pytest
@@ -86,6 +87,59 @@ def test_ad5710r_preserved_device_properties():
         call("all_ch_input_registers", 42),
         call("all_ch_raw", 7),
     ]
+
+
+def _mock_context(monkeypatch, device_name, channel_names, scan_elements=None):
+    """Install a minimal IIO context for common-parent unit tests."""
+    if scan_elements is None:
+        scan_elements = [True] * len(channel_names)
+    channels = []
+    for name, scan_element in zip(channel_names, scan_elements):
+        channel = MagicMock()
+        channel.id = name
+        channel.scan_element = scan_element
+        channels.append(channel)
+    device = MagicMock()
+    device.name = device_name
+    device.channels = channels
+    context = MagicMock()
+    context.devices = [device]
+    context.find_device.side_effect = (
+        lambda name: device if name == device_name else None
+    )
+
+    def init_context(self, uri="", device_name=""):
+        self._ctx = context
+        self.uri = uri
+
+    monkeypatch.setattr("adi.rx_tx.context_manager.__init__", init_context)
+    return device
+
+
+def test_max31855_common_parent_preserves_aliases_and_order(monkeypatch):
+    """MAX31855 keeps its driver-name mapping and public temperature aliases."""
+    _mock_context(monkeypatch, "maxim_thermocouple", ["t_temp", "i_temp"])
+
+    with adi.max31855(uri="local:") as dev:
+        assert dev._ctrl is dev._rxadc
+        assert dev._rx_channel_names == ["t_temp", "i_temp"]
+        assert [channel.name for channel in dev.channel] == ["t_temp", "i_temp"]
+        assert dev.temp_t is dev.t_temp is dev.channel[0]
+        assert dev.temp_i is dev.i_temp is dev.channel[1]
+
+
+def test_ltc2983_common_parent_preserves_ordered_all_channel_api(monkeypatch):
+    """LTC2983 retains OrderedDict access and includes non-scan channels."""
+    _mock_context(
+        monkeypatch, "ltc2983", ["voltage0", "temp1", "status"], [True, True, False],
+    )
+
+    with adi.ltc2983(uri="local:") as dev:
+        assert dev._ctrl is dev._rxadc
+        assert dev._rx_channel_names == ["voltage0", "temp1", "status"]
+        assert isinstance(dev.channel, OrderedDict)
+        assert list(dev.channel) == ["voltage0", "temp1", "status"]
+        assert [channel.name for channel in dev.channel.values()] == list(dev.channel)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- migrate `max31855` and `ltc2983` to the shared `rx_chan_comp` parent
- preserve URI-only constructors, unbuffered RX behavior, channel order, and compatible-part selection
- retain MAX31855 public temperature aliases and the LTC2983 `OrderedDict` all-channel API
- add mock-context regression tests for driver-name mapping, aliases, non-scan channels, and container ordering

## Testing
- `pytest -q test/test_refactored_devices_unit.py test/test_max31855.py` (8 passed, 31 skipped)
- `pytest -q` (46 passed, 2050 skipped)
- pre-commit hooks for changed files (all passed)