### PR TITLE
Migrate additional RX classes to common parents

### DIFF
--- a/adi/adis16460.py
+++ b/adi/adis16460.py
@@ -4,11 +4,10 @@
 
 import numpy as np
 
-from adi.context_manager import context_manager
-from adi.rx_tx import rx
+from adi.device_base import rx_def
 
 
-class adis16460(rx, context_manager):
+class adis16460(rx_def):
     """ ADIS16460 Compact, Precision, Six Degrees of Freedom Inertial Sensor """
 
     _complex_data = False
@@ -21,15 +20,17 @@ class adis16460(rx, context_manager):
         "accel_z",
     ]
     _device_name = ""
+    _control_device_name = "adis16460"
+    _rx_data_device_name = "adis16460"
+    compatible_parts = ["adis16460"]
 
     def __init__(self, uri=""):
+        """Initialize the ADIS16460 while preserving its URI-only API."""
+        super().__init__(uri=uri)
 
-        context_manager.__init__(self, uri, self._device_name)
-
-        self._ctrl = self._ctx.find_device("adis16460")
-        self._rxadc = self._ctx.find_device("adis16460")
-        rx.__init__(self)
-        self.rx_buffer_size = 16  # Make default buffer smaller
+    def __post_init__(self):
+        """Use the legacy smaller default RX buffer."""
+        self.rx_buffer_size = 16
 
     @property
     def sample_rate(self):

--- a/adi/max11205.py
+++ b/adi/max11205.py
@@ -6,62 +6,41 @@
 import numpy as np
 
 from adi.attribute import attribute
-from adi.context_manager import context_manager
-from adi.rx_tx import rx
+from adi.device_base import rx_chan_comp
 
 
-class max11205(rx, context_manager):
+class max11205(rx_chan_comp):
 
     """MAX11205 ADC"""
 
     _complex_data = False
     channel = []  # type: ignore
     _device_name = ""
+    compatible_parts = ["max11205a", "max11205b"]
 
     def __init__(self, uri="", device_name=""):
         """Constructor for MAX11205 class."""
-        context_manager.__init__(self, uri, self._device_name)
+        super().__init__(uri=uri, device_name=device_name)
 
-        compatible_parts = [
-            "max11205a",
-            "max11205b",
-        ]
+    def __post_init__(self):
+        """Preserve channel traversal and the legacy private-ID lookup."""
+        self._rx_channel_names = [ch._id for ch in self._ctrl.channels]
 
-        self._ctrl = None
-
-        if not device_name:
-            device_name = compatible_parts[0]
-        else:
-            if device_name not in compatible_parts:
-                raise Exception(f"Not a compatible device: {device_name}")
-
-        # Select the device matching device_name as working device
-        for device in self._ctx.devices:
-            if device.name == device_name:
-                self._ctrl = device
-                self._rxadc = device
-                break
-
-        if not self._ctrl:
-            raise Exception("Error in selecting matching device")
-
-        if not self._rxadc:
-            raise Exception("Error in selecting matching device")
-
-        self._rx_channel_names = []
+    def _add_channel_instances(self):
+        """Build wrappers from the same private channel IDs as the legacy class."""
         self.channel = []
         for ch in self._ctrl.channels:
             name = ch._id
-            self._rx_channel_names.append(name)
-            self.channel.append(self._channel(self._ctrl, name))
-
-        rx.__init__(self)
+            wrapper = self._channel_def(self._ctrl, name)
+            self.channel.append(wrapper)
+            setattr(self, name, wrapper)
 
     class _channel(attribute):
 
         """MAX11205 channel"""
 
         def __init__(self, ctrl, channel_name):
+            """Initialize a MAX11205 channel wrapper."""
             self.name = channel_name
             self._ctrl = ctrl
 
@@ -91,3 +70,5 @@ class max11205(rx, context_manager):
             raise Exception("Error in converting to actual voltage")
 
         return ret
+
+    _channel_def = _channel

--- a/test/test_refactored_devices_unit.py
+++ b/test/test_refactored_devices_unit.py
@@ -97,6 +97,7 @@ def _mock_context(monkeypatch, device_name, channel_names, scan_elements=None):
     for name, scan_element in zip(channel_names, scan_elements):
         channel = MagicMock()
         channel.id = name
+        channel._id = name
         channel.scan_element = scan_element
         channels.append(channel)
     device = MagicMock()
@@ -140,6 +141,47 @@ def test_ltc2983_common_parent_preserves_ordered_all_channel_api(monkeypatch):
         assert isinstance(dev.channel, OrderedDict)
         assert list(dev.channel) == ["voltage0", "temp1", "status"]
         assert [channel.name for channel in dev.channel.values()] == list(dev.channel)
+
+
+def test_adis16460_common_parent_preserves_rx_contract(monkeypatch):
+    """ADIS16460 keeps channel order and its smaller default RX buffer."""
+    names = [
+        "anglvel_x",
+        "anglvel_y",
+        "anglvel_z",
+        "accel_x",
+        "accel_y",
+        "accel_z",
+    ]
+    _mock_context(monkeypatch, "adis16460", names)
+
+    with adi.adis16460(uri="local:") as dev:
+        assert dev._ctrl is dev._rxadc
+        assert dev._rx_channel_names == names
+        assert dev.rx_enabled_channels == list(range(6))
+        assert dev.rx_buffer_size == 16
+
+
+@pytest.mark.parametrize("device_name", ["max11205a", "max11205b"])
+def test_max11205_common_parent_preserves_exact_selection(monkeypatch, device_name):
+    """MAX11205 keeps explicit model selection and private-ID channel ordering."""
+    _mock_context(monkeypatch, device_name, ["voltage0", "voltage1"])
+
+    with adi.max11205(uri="local:", device_name=device_name) as dev:
+        assert dev._ctrl is dev._rxadc
+        assert dev._rx_channel_names == ["voltage0", "voltage1"]
+        assert dev.rx_enabled_channels == [0, 1]
+        assert [channel.name for channel in dev.channel] == ["voltage0", "voltage1"]
+        assert dev.voltage0 is dev.channel[0]
+        assert dev.voltage1 is dev.channel[1]
+
+
+def test_max11205_default_does_not_fallback_to_variant_b(monkeypatch):
+    """The default remains max11205a rather than probing compatible variants."""
+    _mock_context(monkeypatch, "max11205b", ["voltage0"])
+
+    with pytest.raises(Exception, match="max11205a"):
+        adi.max11205(uri="local:")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- migrate `adis16460` to the shared `rx_def` parent
- migrate `max11205` to the shared `rx_chan_comp` parent
- preserve URI-only ADIS16460 construction, fixed channel order, and 16-sample default buffer
- preserve exact MAX11205 variant selection, private-ID channel traversal, wrappers, and conversion behavior
- add mock-context regression tests for parent-chain initialization and variant behavior

## Testing
- `pytest -q test/test_refactored_devices_unit.py test/test_adis16460_p.py test/test_max11205.py` (12 passed, 37 skipped)
- `pytest -q` (50 passed, 2050 skipped)
- pre-commit hooks for changed files (all passed)