### PR TITLE
Migrate ADXL313 family to common parent

### DIFF
--- a/adi/adxl313.py
+++ b/adi/adxl313.py
@@ -6,53 +6,43 @@ import numpy as np
 
 from adi.attribute import attribute
 from adi.context_manager import context_manager
-from adi.rx_tx import rx
+from adi.device_base import rx_chan_comp
 
 
-class adxl313(rx, context_manager, attribute):
+class adxl313(rx_chan_comp, attribute):
 
     """ADXL313 3-axis accelerometer"""
 
+    _complex_data = False
     _device_name = ""
     _rx_data_type = np.int32
     _rx_unbuffered_data = True
     _rx_data_si_type = float
+    _rx_channel_names = ["accel_x", "accel_y", "accel_z"]
+    compatible_parts = ["ADXL312", "ADXL313", "ADXL314"]
 
     def __init__(self, uri=""):
         """adxl313 class constructor."""
         context_manager.__init__(self, uri)
-
-        compatible_parts = [
-            "ADXL312",
-            "ADXL313",
-            "ADXL314",
-        ]
-
-        self._ctrl = None
-
-        # Select the device matching device_name as working device
-        for device in self._ctx.devices:
-            if device.name in compatible_parts:
-                print("Found device {}".format(device.name))
-                self._ctrl = device
-                self._rxadc = device
-                self._device_name = device.name
-                break
-
-        if self._ctrl is None:
+        device_name = next(
+            (
+                device.name
+                for device in self._ctx.devices
+                if device.name in self.compatible_parts
+            ),
+            None,
+        )
+        if device_name is None:
             raise Exception("No compatible device found")
-
-        self.accel_x = self._channel(self._ctrl, "accel_x")
-        self.accel_y = self._channel(self._ctrl, "accel_y")
-        self.accel_z = self._channel(self._ctrl, "accel_z")
-        self._rx_channel_names = ["accel_x", "accel_y", "accel_z"]
-        rx.__init__(self)
+        self._device_name = device_name
+        super().__init__(uri=self._ctx, device_name=device_name)
 
     class _channel(attribute):
 
         """ADXL313 acceleration channel"""
 
         def __init__(self, ctrl, channel_name):
+            """Initialize an ADXL313-family channel wrapper."""
             self.name = channel_name
             self._ctrl = ctrl
 
@@ -111,3 +101,5 @@ class adxl313(rx, context_manager, attribute):
         def scale_available(self):
             """Provides all available scale settings for the ADXL313 channels."""
             return self._get_iio_attr(self.name, "scale_available", False)
+
+    _channel_def = _channel

--- a/test/test_refactored_devices_unit.py
+++ b/test/test_refactored_devices_unit.py
@@ -103,11 +103,16 @@ def _mock_context(monkeypatch, device_name, channel_names, scan_elements=None):
     device = MagicMock()
     device.name = device_name
     device.channels = channels
-    context = MagicMock()
-    context.devices = [device]
-    context.find_device.side_effect = (
-        lambda name: device if name == device_name else None
-    )
+
+    class FakeContext:
+        def __init__(self):
+            self.devices = [device]
+            self.find_device = MagicMock(
+                side_effect=lambda name: device if name == device_name else None
+            )
+
+    context = FakeContext()
+    monkeypatch.setattr("adi.rx_tx.iio.Context", FakeContext)
 
     def init_context(self, uri="", device_name=""):
         self._ctx = context
@@ -182,6 +187,63 @@ def test_max11205_default_does_not_fallback_to_variant_b(monkeypatch):
 
     with pytest.raises(Exception, match="max11205a"):
         adi.max11205(uri="local:")
+
+
+@pytest.mark.parametrize("selected_name", ["ADXL312", "ADXL313", "ADXL314"])
+def test_adxl313_common_parent_preserves_family_discovery(monkeypatch, selected_name):
+    """ADXL313 selects any supported family member and retains channel aliases."""
+    _mock_context(monkeypatch, selected_name, ["accel_x", "accel_y", "accel_z"])
+
+    with adi.adxl313(uri="local:") as dev:
+        assert dev._device_name == selected_name
+        assert dev._ctrl is dev._rxadc
+        assert dev._rx_channel_names == ["accel_x", "accel_y", "accel_z"]
+        assert dev.rx_enabled_channels == [0, 1, 2]
+        assert [channel.name for channel in dev.channel] == dev._rx_channel_names
+        assert dev.accel_x is dev.channel[0]
+        assert dev.accel_y is dev.channel[1]
+        assert dev.accel_z is dev.channel[2]
+
+
+def test_adxl313_preserves_first_compatible_context_order(monkeypatch):
+    """Family discovery remains context-ordered rather than model-prioritized."""
+    channels = ["accel_x", "accel_y", "accel_z"]
+    first = _mock_context(monkeypatch, "ADXL314", channels)
+    second = MagicMock()
+    second.name = "ADXL312"
+    second.channels = first.channels
+
+    # Expose a second compatible device in the same context.
+    with patch("adi.rx_tx.context_manager.__init__") as init:
+
+        class FakeContext:
+            def __init__(self):
+                self.devices = [first, second]
+
+            def find_device(self, name):
+                return next(
+                    (device for device in self.devices if device.name == name), None
+                )
+
+        context = FakeContext()
+        monkeypatch.setattr("adi.rx_tx.iio.Context", FakeContext)
+
+        def set_context(instance, uri="", device_name=""):
+            instance._ctx = context
+            instance.uri = uri
+
+        init.side_effect = set_context
+        with adi.adxl313(uri="local:") as dev:
+            assert dev._device_name == "ADXL314"
+            assert dev._ctrl is first
+
+
+def test_adxl313_rejects_context_without_compatible_device(monkeypatch):
+    """Contexts without an ADXL312/313/314 retain the legacy error."""
+    _mock_context(monkeypatch, "other-device", ["accel_x"])
+
+    with pytest.raises(Exception, match="No compatible device found"):
+        adi.adxl313(uri="local:")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- migrate `adxl313` to the shared `rx_chan_comp` parent
- preserve URI-only construction and exact ADXL312/ADXL313/ADXL314 compatibility
- retain first-compatible-device selection in IIO context order
- preserve RX channel order, enabled channels, wrapper aliases, data types, and attribute behavior
- add mock-context regression tests for every family member, context ordering, and incompatible contexts

## Testing
- `pytest -q test/test_refactored_devices_unit.py test/test_adxl313.py` (17 passed, 40 skipped)
- `pytest -q` (55 passed, 2050 skipped)
- pre-commit hooks for changed files (all passed)