### PR TITLE
Migrate LTC2499 to common parent

### DIFF
--- a/adi/ltc2499.py
+++ b/adi/ltc2499.py
@@ -6,35 +6,35 @@ from collections import OrderedDict
 import numpy as np
 
 from adi.attribute import attribute
-from adi.context_manager import context_manager
-from adi.rx_tx import rx
+from adi.device_base import rx_chan_comp
 
 
-class ltc2499(rx, context_manager):
+class ltc2499(rx_chan_comp):
 
     channel: OrderedDict = None
+    _complex_data = False
     _device_name = "ltc2499"
     _rx_unbuffered_data = True
     _rx_data_si_type = float
+    compatible_parts = ["ltc2499"]
 
     def __init__(self, uri=""):
-        context_manager.__init__(self, uri, self._device_name)
-        self._ctrl = self._ctx.find_device("ltc2499")
+        """Initialize the LTC2499 while preserving its URI-only API."""
+        super().__init__(uri=uri)
 
-        if not self._ctrl:
-            raise Exception("No device found")
+    def __post_init__(self):
+        """Preserve all-channel traversal rather than scan-only discovery."""
+        self._rx_channel_names = [ch.id for ch in self._ctrl.channels]
 
-        _channels = []
-        self._rx_channel_names = []
-        for ch in self._ctrl.channels:
-            self._rx_channel_names.append(ch.id)
-            _channels.append((ch.id, self._channel(self._ctrl, ch.id)))
-        self.channel = OrderedDict(_channels)
-
-        rx.__init__(self)
+    def _add_channel_instances(self):
+        """Preserve the public OrderedDict channel container."""
+        self.channel = OrderedDict(
+            (ch.id, self._channel_def(self._ctrl, ch.id)) for ch in self._ctrl.channels
+        )
 
     class _channel(attribute):
         def __init__(self, ctrl, channel_name):
+            """Initialize an LTC2499 channel wrapper."""
             self._ctrl = ctrl
             self.name = channel_name
 
@@ -49,3 +49,5 @@ class ltc2499(rx, context_manager):
         @property
         def value(self):
             return self.raw * self.scale
+
+    _channel_def = _channel

--- a/test/test_refactored_devices_unit.py
+++ b/test/test_refactored_devices_unit.py
@@ -148,6 +148,24 @@ def test_ltc2983_common_parent_preserves_ordered_all_channel_api(monkeypatch):
         assert [channel.name for channel in dev.channel.values()] == list(dev.channel)
 
 
+def test_ltc2499_common_parent_preserves_ordered_all_channel_api(monkeypatch):
+    """LTC2499 retains OrderedDict access and includes non-scan channels."""
+    _mock_context(
+        monkeypatch,
+        "ltc2499",
+        ["voltage0", "voltage1", "timestamp"],
+        [True, True, False],
+    )
+
+    with adi.ltc2499(uri="local:") as dev:
+        assert dev._ctrl is dev._rxadc
+        assert dev._rx_channel_names == ["voltage0", "voltage1", "timestamp"]
+        assert dev.rx_enabled_channels == [0, 1]
+        assert isinstance(dev.channel, OrderedDict)
+        assert list(dev.channel) == ["voltage0", "voltage1", "timestamp"]
+        assert [channel.name for channel in dev.channel.values()] == list(dev.channel)
+
+
 def test_adis16460_common_parent_preserves_rx_contract(monkeypatch):
     """ADIS16460 keeps channel order and its smaller default RX buffer."""
     names = [


### PR DESCRIPTION
## Summary
- migrate `ltc2499` to the shared `rx_chan_comp` parent
- preserve its URI-only constructor and unbuffered RX behavior
- retain the public `OrderedDict` channel API in IIO traversal order
- continue exposing non-scan channels in the mapping while enabling only scan-element RX channels
- add mock-context regression coverage for ordering, container type, control/RX identity, and enabled channels

## Testing
- `pytest -q test/test_refactored_devices_unit.py test/test_ltc2499.py` (18 passed, 31 skipped)
- `pytest -q` (56 passed, 2050 skipped)
- pre-commit and compile checks for changed files (passed)