### PR TITLE
Migrate ADPD RX classes to common parent

### DIFF
--- a/adi/adpd1080.py
+++ b/adi/adpd1080.py
@@ -4,44 +4,40 @@
 
 from adi.attribute import attribute
 from adi.context_manager import context_manager
-from adi.rx_tx import rx
+from adi.device_base import rx_chan_comp
 
 
-class adpd1080(rx, context_manager):
+class adpd1080(rx_chan_comp):
     """ADPD1080 photo-electronic device."""
 
     channel = []  # type: ignore
+    _complex_data = False
     _device_name = ""
+    compatible_parts = ["adpd1080"]
 
     def __init__(self, uri="", device_index=0):
         """ADPD1080 class constructor."""
         context_manager.__init__(self, uri, self._device_name)
+        devices = [device for device in self._ctx.devices if device.name == "adpd1080"]
+        if device_index >= len(devices):
+            raise Exception(
+                f"No device found with name adpd1080 at index {device_index}"
+            )
+        self._rx_channel_names = [ch._id for ch in devices[device_index]._channels]
+        super().__init__(uri=self._ctx, device_index=device_index)
 
-        compatible_parts = ["adpd1080"]
+    def __post_init__(self):
+        """Use the legacy smaller default RX buffer."""
+        self.rx_buffer_size = 16
 
-        self._ctrl = None
-        index = 0
-
-        # Selecting the device_index-th device from the adpd188 family as working device.
-        for device in self._ctx.devices:
-            if device.name in compatible_parts:
-                if index == device_index:
-                    self._ctrl = device
-                    self._rxadc = device
-                    break
-                else:
-                    index += 1
-
-        # dynamically get channels and sorting them after the color
-        # self._ctrl.channels.sort(key=lambda x: str(x.id[14:]))
-        self._rx_channel_names = []
+    def _add_channel_instances(self):
+        """Build wrappers from private IIO channel traversal order."""
         self.channel = []
         for ch in self._ctrl._channels:
             name = ch._id
-            self._rx_channel_names.append(name)
-            self.channel.append(self._channel(self._ctrl, name))
-        rx.__init__(self)
-        self.rx_buffer_size = 16
+            wrapper = self._channel_def(self._ctrl, name)
+            self.channel.append(wrapper)
+            setattr(self, name, wrapper)
 
     def rx(self):
         buff = super().rx()
@@ -61,6 +57,7 @@ class adpd1080(rx, context_manager):
         """ADPD1080 channel."""
 
         def __init__(self, ctrl, channel_name):
+            """Initialize an ADPD1080 channel wrapper."""
             self.name = channel_name
             self._ctrl = ctrl
 
@@ -77,3 +74,5 @@ class adpd1080(rx, context_manager):
         @offset.setter
         def offset(self, value):
             self._set_iio_attr(self.name, "offset", False, value)
+
+    _channel_def = _channel

--- a/adi/adpd188.py
+++ b/adi/adpd188.py
@@ -4,45 +4,41 @@
 
 from adi.attribute import attribute
 from adi.context_manager import context_manager
-from adi.rx_tx import rx
+from adi.device_base import rx_chan_comp
 
 
-class adpd188(rx, context_manager):
+class adpd188(rx_chan_comp):
 
     """ADPD188 photo-electronic device."""
 
     channel = []  # type: ignore
+    _complex_data = False
     _device_name = ""
+    compatible_parts = ["adpd188"]
 
     def __init__(self, uri="", device_index=0):
         """ADPD188 class constructor."""
         context_manager.__init__(self, uri, self._device_name)
+        devices = [device for device in self._ctx.devices if device.name == "adpd188"]
+        if device_index >= len(devices):
+            raise Exception(
+                f"No device found with name adpd188 at index {device_index}"
+            )
+        self._rx_channel_names = [ch._id for ch in devices[device_index]._channels]
+        super().__init__(uri=self._ctx, device_index=device_index)
 
-        compatible_parts = ["adpd188"]
+    def __post_init__(self):
+        """Use the legacy smaller default RX buffer."""
+        self.rx_buffer_size = 16
 
-        self._ctrl = None
-        index = 0
-
-        # Selecting the device_index-th device from the adpd188 family as working device.
-        for device in self._ctx.devices:
-            if device.name in compatible_parts:
-                if index == device_index:
-                    self._ctrl = device
-                    self._rxadc = device
-                    break
-                else:
-                    index += 1
-
-        # dynamically get channels and sorting them after the color
-        # self._ctrl.channels.sort(key=lambda x: str(x.id[14:]))
-        self._rx_channel_names = []
+    def _add_channel_instances(self):
+        """Build wrappers from private IIO channel traversal order."""
         self.channel = []
         for ch in self._ctrl._channels:
             name = ch._id
-            self._rx_channel_names.append(name)
-            self.channel.append(self._channel(self._ctrl, name))
-        rx.__init__(self)
-        self.rx_buffer_size = 16
+            wrapper = self._channel_def(self._ctrl, name)
+            self.channel.append(wrapper)
+            setattr(self, name, wrapper)
 
     @property
     def mode(self):
@@ -67,6 +63,7 @@ class adpd188(rx, context_manager):
         """ADPD188 channel."""
 
         def __init__(self, ctrl, channel_name):
+            """Initialize an ADPD188 channel wrapper."""
             self.name = channel_name
             self._ctrl = ctrl
 
@@ -90,3 +87,5 @@ class adpd188(rx, context_manager):
             return self._get_iio_attr_str(
                 self.name, "mode_available", False, self._rxadc
             )
+
+    _channel_def = _channel

--- a/test/test_refactored_devices_unit.py
+++ b/test/test_refactored_devices_unit.py
@@ -103,6 +103,7 @@ def _mock_context(monkeypatch, device_name, channel_names, scan_elements=None):
     device = MagicMock()
     device.name = device_name
     device.channels = channels
+    device._channels = channels
 
     class FakeContext:
         def __init__(self):
@@ -164,6 +165,73 @@ def test_ltc2499_common_parent_preserves_ordered_all_channel_api(monkeypatch):
         assert isinstance(dev.channel, OrderedDict)
         assert list(dev.channel) == ["voltage0", "voltage1", "timestamp"]
         assert [channel.name for channel in dev.channel.values()] == list(dev.channel)
+
+
+def _mock_indexed_context(monkeypatch, device_name, channel_names):
+    """Install a context containing two same-name devices."""
+    devices = []
+    for suffix in ("first", "second"):
+        channels = []
+        for name in channel_names:
+            channel = MagicMock()
+            channel.id = name
+            channel._id = f"{name}_{suffix}"
+            channel.scan_element = True
+            channels.append(channel)
+        device = MagicMock()
+        device.name = device_name
+        device.channels = channels
+        device._channels = channels
+        devices.append(device)
+
+    class FakeContext:
+        def __init__(self):
+            self.devices = devices
+
+        def find_device(self, name):
+            return next((device for device in devices if device.name == name), None)
+
+    context = FakeContext()
+    monkeypatch.setattr("adi.rx_tx.iio.Context", FakeContext)
+
+    def init_context(self, uri="", device_name=""):
+        self._ctx = context
+        self.uri = uri
+
+    monkeypatch.setattr("adi.rx_tx.context_manager.__init__", init_context)
+    return devices
+
+
+@pytest.mark.parametrize(
+    "device_class,device_name", [(adi.adpd188, "adpd188"), (adi.adpd1080, "adpd1080")],
+)
+def test_adpd_common_parent_preserves_index_and_private_channel_order(
+    monkeypatch, device_class, device_name
+):
+    """ADPD migrations retain indexed discovery and private channel traversal."""
+    devices = _mock_indexed_context(monkeypatch, device_name, ["red", "blue"])
+
+    with device_class(uri="local:", device_index=1) as dev:
+        assert dev._ctrl is dev._rxadc is devices[1]
+        assert dev._rx_channel_names == ["red_second", "blue_second"]
+        assert dev.rx_enabled_channels == [0, 1]
+        assert dev.rx_buffer_size == 16
+        assert [channel.name for channel in dev.channel] == dev._rx_channel_names
+        assert dev.red_second is dev.channel[0]
+        assert dev.blue_second is dev.channel[1]
+
+
+@pytest.mark.parametrize(
+    "device_class,device_name", [(adi.adpd188, "adpd188"), (adi.adpd1080, "adpd1080")],
+)
+def test_adpd_common_parent_rejects_missing_device_index(
+    monkeypatch, device_class, device_name
+):
+    """Out-of-range indexed discovery raises a deterministic error."""
+    _mock_indexed_context(monkeypatch, device_name, ["red"])
+
+    with pytest.raises(Exception, match=f"{device_name} at index 2"):
+        device_class(uri="local:", device_index=2)
 
 
 def test_adis16460_common_parent_preserves_rx_contract(monkeypatch):


### PR DESCRIPTION
## Summary
- migrate `adpd188` and `adpd1080` to the shared `rx_chan_comp` parent
- preserve indexed selection among duplicate same-name devices
- retain private IIO channel traversal order, channel wrappers, and named aliases
- preserve the 16-sample default RX buffer and ADPD1080 buffer-release override
- add mock-context regression coverage for second-device selection and out-of-range indices

## Testing
- `pytest -q test/test_refactored_devices_unit.py` (22 passed, 29 skipped)
- `pytest -q` (60 passed, 2050 skipped)
- pre-commit and compile checks for changed files (passed)