### PR TITLE
Migrate AD7746 family to common parent

### DIFF
--- a/adi/ad7746.py
+++ b/adi/ad7746.py
@@ -7,60 +7,49 @@ from collections import OrderedDict
 
 from adi.attribute import attribute
 from adi.context_manager import context_manager
-from adi.rx_tx import rx
+from adi.device_base import rx_chan_comp
 
 
-class ad7746(rx, context_manager):
+class ad7746(rx_chan_comp):
     """ AD7746 CDC """
 
     _complex_data = False
     channel = []  # type: ignore
     _device_name = ""
+    compatible_parts = ["ad7745", "ad7746", "ad7747"]
 
     def __init__(self, uri="", device_name=""):
-
+        """Initialize a requested AD7745/AD7746/AD7747 device."""
         context_manager.__init__(self, uri, self._device_name)
-
-        compatible_parts = [
-            "ad7745",
-            "ad7746",
-            "ad7747",
-        ]
-
-        self._ctrl = None
-
-        if device_name not in compatible_parts:
+        if device_name not in self.compatible_parts:
             raise Exception("Not a compatible device: " + device_name)
+        device = next(
+            (device for device in self._ctx.devices if device.name == device_name), None
+        )
+        if device is None:
+            raise Exception("No device found with name " + device_name)
+        self._rx_channel_names = [ch.id for ch in device.channels]
+        super().__init__(uri=self._ctx, device_name=device_name)
 
-        # Select the device matching device_name as working device
-        for device in self._ctx.devices:
-            print("Found device {}".format(device.name))
-            if device.name == device_name:
-                self._ctrl = device
-                self._rxadc = device
-                break
-        # dynamically get channels
-        _channels = []
-        self._rx_channel_names = []
+    def _add_channel_instances(self):
+        """Build the legacy ordered mapping with channel-specific wrappers."""
+        channels = []
         for ch in self._ctrl.channels:
-            self._rx_channel_names.append(ch.id)
             if "capacitance" in ch.id:
-                _channels.append((ch.id, self._cap_channel(self._ctrl, ch.id)))
+                channels.append((ch.id, self._cap_channel(self._ctrl, ch.id)))
                 continue
             if "temp" in ch.id:
-                _channels.append((ch.id, self._temp_channel(self._ctrl, ch.id)))
+                channels.append((ch.id, self._temp_channel(self._ctrl, ch.id)))
                 continue
             if "voltage" in ch.id:
-                _channels.append((ch.id, self._volt_channel(self._ctrl, ch.id)))
-                continue
-        self.channel = OrderedDict(_channels)
-
-        rx.__init__(self)
+                channels.append((ch.id, self._volt_channel(self._ctrl, ch.id)))
+        self.channel = OrderedDict(channels)
 
     class _temp_channel(attribute):
         """AD7746 temperature channel."""
 
         def __init__(self, ctrl, channel_name):
+            """Initialize an AD7746 temperature channel wrapper."""
             self.name = channel_name
             self._ctrl = ctrl
 
@@ -73,6 +62,7 @@ class ad7746(rx, context_manager):
         """AD7746 voltage channel."""
 
         def __init__(self, ctrl, channel_name):
+            """Initialize an AD7746 voltage channel wrapper."""
             self.name = channel_name
             self._ctrl = ctrl
 

--- a/test/test_refactored_devices_unit.py
+++ b/test/test_refactored_devices_unit.py
@@ -234,6 +234,33 @@ def test_adpd_common_parent_rejects_missing_device_index(
         device_class(uri="local:", device_index=2)
 
 
+@pytest.mark.parametrize("device_name", ["ad7745", "ad7746", "ad7747"])
+def test_ad7746_common_parent_preserves_order_and_wrapper_subtypes(
+    monkeypatch, device_name
+):
+    """AD7746 family keeps ordered mapping and ID-specific wrapper types."""
+    names = ["voltage1", "capacitance1", "temp0", "status"]
+    _mock_context(monkeypatch, device_name, names, [True, True, True, False])
+
+    with adi.ad7746(uri="local:", device_name=device_name) as dev:
+        assert dev._ctrl is dev._rxadc
+        assert dev._rx_channel_names == names
+        assert dev.rx_enabled_channels == [0, 1, 2, 3]
+        assert isinstance(dev.channel, OrderedDict)
+        assert list(dev.channel) == names[:3]
+        assert isinstance(dev.channel["voltage1"], adi.ad7746._volt_channel)
+        assert isinstance(dev.channel["capacitance1"], adi.ad7746._cap_channel)
+        assert isinstance(dev.channel["temp0"], adi.ad7746._temp_channel)
+
+
+def test_ad7746_common_parent_preserves_empty_name_rejection(monkeypatch):
+    """The legacy constructor does not silently default an empty device name."""
+    _mock_context(monkeypatch, "ad7746", ["voltage0"])
+
+    with pytest.raises(Exception, match="Not a compatible device: $"):
+        adi.ad7746(uri="local:")
+
+
 def test_adis16460_common_parent_preserves_rx_contract(monkeypatch):
     """ADIS16460 keeps channel order and its smaller default RX buffer."""
     names = [

--- a/test/test_refactored_devices_unit.py
+++ b/test/test_refactored_devices_unit.py
@@ -261,6 +261,44 @@ def test_ad7746_common_parent_preserves_empty_name_rejection(monkeypatch):
         adi.ad7746(uri="local:")
 
 
+def test_ad7746_channel_subtypes_preserve_attribute_forwarding():
+    """Channel-specific wrappers retain their public attribute contracts."""
+    ctrl = MagicMock()
+    temp = adi.ad7746._temp_channel(ctrl, "temp0")
+    temp._get_iio_attr = Mock(return_value=23)
+    assert temp.input == 23
+
+    voltage = adi.ad7746._volt_channel(ctrl, "voltage0")
+    voltage._get_iio_attr = Mock(return_value=11)
+    voltage._get_iio_attr_str = Mock(
+        side_effect=lambda _name, attr, _output: {
+            "scale": "2.5",
+            "sampling_frequency": "50",
+            "sampling_frequency_available": "50 31 16 8",
+        }[attr]
+    )
+    voltage._set_iio_attr = Mock()
+    assert voltage.raw == 11
+    assert voltage.scale == 2.5
+    assert voltage.sampling_frequency == "50"
+    assert voltage.sampling_frequency_available == [50, 31, 16, 8]
+    voltage.sampling_frequency = 31
+    voltage.calibscale_calibration()
+
+    capacitance = adi.ad7746._cap_channel(ctrl, "capacitance0")
+    capacitance._get_iio_attr = Mock(side_effect=lambda _name, attr, _output: attr)
+    capacitance._get_iio_attr_str = Mock(return_value="100")
+    capacitance._set_iio_attr = Mock()
+    capacitance._set_iio_attr_float = Mock()
+    assert capacitance.offset == "100"
+    assert capacitance.calibscale == "calibscale"
+    assert capacitance.calibbias == "calibbias"
+    capacitance.offset = 101
+    capacitance.calibscale = 1.5
+    capacitance.calibbias = 2
+    capacitance.calibbias_calibration()
+
+
 def test_adis16460_common_parent_preserves_rx_contract(monkeypatch):
     """ADIS16460 keeps channel order and its smaller default RX buffer."""
     names = [


### PR DESCRIPTION
## Summary
- migrate the AD7745/AD7746/AD7747 family to the shared `rx_chan_comp` parent
- preserve the explicit device-name requirement and exact compatible-part set
- populate all channel names before RX initialization because these devices expose no scan elements
- retain the public `OrderedDict` mapping and capacitance, voltage, and temperature wrapper subtypes
- add regression coverage for every compatible part, channel order, enabled channels, wrapper dispatch, and empty-name rejection

## Testing
- `pytest -q --emu test/test_refactored_devices_unit.py test/test_ad7746.py` (94 passed, 9 skipped)
- `pytest -q` (64 passed, 2050 skipped)
- pre-commit, compile, and diff checks (passed)