### PR TITLE
Migrate ADPD410x to common parent

### DIFF
--- a/adi/adpd410x.py
+++ b/adi/adpd410x.py
@@ -3,7 +3,6 @@
 # SPDX short identifier: ADIBSD
 
 from adi.attribute import attribute
-from adi.context_manager import context_manager
 from adi.device_base import rx_chan_comp_no_buff
 
 
@@ -24,11 +23,6 @@ class adpd410x(rx_chan_comp_no_buff):
     ]
     _device_name = ""
     compatible_parts = ["adpd410x"]
-
-    def __init__(self, uri=""):
-        """Initialize without adding RX state absent from the legacy driver."""
-        context_manager.__init__(self, uri, self._device_name)
-        super().__init__(uri=self._ctx)
 
     @property
     def sampling_frequency(self):

--- a/adi/adpd410x.py
+++ b/adi/adpd410x.py
@@ -4,10 +4,10 @@
 
 from adi.attribute import attribute
 from adi.context_manager import context_manager
-from adi.rx_tx import rx
+from adi.device_base import rx_chan_comp_no_buff
 
 
-class adpd410x(rx, context_manager):
+class adpd410x(rx_chan_comp_no_buff):
     """ adpd410x Multimodal Sensor Front End """
 
     _complex_data = False
@@ -23,16 +23,12 @@ class adpd410x(rx, context_manager):
         "channel7",
     ]
     _device_name = ""
+    compatible_parts = ["adpd410x"]
 
     def __init__(self, uri=""):
-
+        """Initialize without adding RX state absent from the legacy driver."""
         context_manager.__init__(self, uri, self._device_name)
-
-        self._rxadc = self._ctx.find_device("adpd410x")
-
-        self.channel = []
-        for name in self._rx_channel_names:
-            self.channel.append(self._channel(self._rxadc, name))
+        super().__init__(uri=self._ctx)
 
     @property
     def sampling_frequency(self):
@@ -68,6 +64,7 @@ class adpd410x(rx, context_manager):
         """adpd410x channel"""
 
         def __init__(self, ctrl, channel_name):
+            """Initialize an ADPD410x channel wrapper."""
             self.name = channel_name
             self._ctrl = ctrl
 
@@ -75,3 +72,5 @@ class adpd410x(rx, context_manager):
         def raw(self):
             """ adpd410x channel raw value"""
             return self._get_iio_attr(self.name, "raw", False, self._ctrl)
+
+    _channel_def = _channel

--- a/test/test_refactored_devices_unit.py
+++ b/test/test_refactored_devices_unit.py
@@ -235,12 +235,13 @@ def test_adpd_common_parent_rejects_missing_device_index(
         device_class(uri="local:", device_index=2)
 
 
-def test_adpd410x_no_buffer_parent_preserves_legacy_constructor_state(monkeypatch):
-    """ADPD410x gains shared discovery without implicitly initializing RX state."""
+def test_adpd410x_inherited_constructor_preserves_no_buffer_state(monkeypatch):
+    """The inherited constructor discovers the device without initializing RX state."""
     names = [f"channel{index}" for index in range(8)]
     device = _mock_context(monkeypatch, "adpd410x", names)
 
     with adi.adpd410x(uri="local:") as dev:
+        assert "__init__" not in adi.adpd410x.__dict__
         assert dev._ctrl is dev._rxadc is device
         assert dev._rx_channel_names == names
         assert [channel.name for channel in dev.channel] == names

--- a/test/test_refactored_devices_unit.py
+++ b/test/test_refactored_devices_unit.py
@@ -235,6 +235,41 @@ def test_adpd_common_parent_rejects_missing_device_index(
         device_class(uri="local:", device_index=2)
 
 
+def test_adpd410x_no_buffer_parent_preserves_legacy_constructor_state(monkeypatch):
+    """ADPD410x gains shared discovery without implicitly initializing RX state."""
+    names = [f"channel{index}" for index in range(8)]
+    device = _mock_context(monkeypatch, "adpd410x", names)
+
+    with adi.adpd410x(uri="local:") as dev:
+        assert dev._ctrl is dev._rxadc is device
+        assert dev._rx_channel_names == names
+        assert [channel.name for channel in dev.channel] == names
+        assert all(
+            getattr(dev, name) is dev.channel[index] for index, name in enumerate(names)
+        )
+        assert "_rx_enabled_channels" not in dev.__dict__
+        assert "_rx__rxbuf" not in dev.__dict__
+
+
+def test_adpd410x_preserves_device_and_channel_attribute_forwarding():
+    """ADPD410x properties continue forwarding to the selected IIO device."""
+    dev = object.__new__(adi.adpd410x)
+    dev._rxadc = MagicMock()
+    dev._get_iio_dev_attr_str = Mock(return_value="value")
+    dev._set_iio_dev_attr_str = Mock()
+
+    assert dev.sampling_frequency == "value"
+    assert dev.last_timeslot == "value"
+    assert dev.operation_mode == "value"
+    dev.sampling_frequency = 100
+    dev.last_timeslot = 3
+    dev.operation_mode = "go"
+
+    channel = adi.adpd410x._channel(dev._rxadc, "channel0")
+    channel._get_iio_attr = Mock(return_value=17)
+    assert channel.raw == 17
+
+
 @pytest.mark.parametrize("device_name", ["ad7745", "ad7746", "ad7747"])
 def test_ad7746_common_parent_preserves_order_and_wrapper_subtypes(
     monkeypatch, device_name


### PR DESCRIPTION
## Summary
- migrate `adpd410x` to the shared `rx_chan_comp_no_buff` parent
- preserve the URI-only constructor and exact eight-channel order
- retain the legacy constructor state, which did not initialize RX buffering or enabled-channel state
- use shared device discovery and channel-wrapper construction without silently changing buffering behavior
- add regression coverage for control/data identity, wrapper aliases, uninitialized RX state, and attribute forwarding

## Testing
- `pytest -q test/test_refactored_devices_unit.py test/test_adpd410x.py` (36 passed, 37 skipped)
- `pytest -q` (74 passed, 2050 skipped)
- pre-commit, compile, and diff checks (passed)