### PR TITLE
Migrate AD5940 to common RX parent

### DIFF
--- a/adi/ad5940.py
+++ b/adi/ad5940.py
@@ -8,40 +8,49 @@ from collections import OrderedDict
 
 from adi.attribute import attribute
 from adi.context_manager import context_manager
-from adi.rx_tx import rx
+from adi.device_base import rx_chan_comp
 
 
-class ad5940(rx, context_manager):
+class ad5940(rx_chan_comp):
     """ ad5940 CDC """
 
     _complex_data = False
     channel = []  # type: ignore
     _device_name = ""
+    compatible_parts = ["ad5940"]
 
     def __init__(self, uri=""):
 
-        device_name = "ad5940"
+        device_name = self.compatible_parts[0]
         context_manager.__init__(self, uri, self._device_name)
 
-        self._ctrl = None
+        selected_device = None
 
         # Select the device matching device_name as working device
         for device in self._ctx.devices:
             if device.name == device_name:
-                self._ctrl = device
-                self._rxadc = device
+                selected_device = device
                 break
-        # dynamically get channels
-        _channels = []
-        self._rx_channel_names = []
-        for ch in self._ctrl.channels:
-            self._rx_channel_names.append(ch.id)
-            if ch.name == "bia":
-                _channels.append((ch.id, self._bia_channel(self, self._ctrl, ch.id)))
-                continue
-        self.channel = OrderedDict(_channels)
+        if selected_device is None:
+            raise Exception(device_name + " device not found")
 
-        rx.__init__(self)
+        # The no-OS device has no scan elements. Preserve the legacy behavior
+        # of enabling every IIO channel before the common RX initializer runs.
+        self._rx_channel_names = [ch.id for ch in selected_device.channels]
+        rx_chan_comp.__init__(self, uri=self._ctx, device_name=device_name)
+
+        # libiio may return a new Python wrapper from find_device(). Restore the
+        # exact context-traversal object used by the legacy implementation.
+        self._ctrl = self._rxadc = selected_device
+        self._add_channel_instances()
+
+    def _add_channel_instances(self):
+        """Preserve the public BIA-only OrderedDict channel container."""
+        self.channel = OrderedDict(
+            (ch.id, self._bia_channel(self, self._ctrl, ch.id),)
+            for ch in self._ctrl.channels
+            if ch.name == "bia"
+        )
 
     @property
     def impedance_mode(self):

--- a/adi/adg2128.py
+++ b/adi/adg2128.py
@@ -27,7 +27,7 @@ class yline(object):
         self._line[y] = value
 
 
-class adg2128(attribute, context_manager):
+class adg2128(context_manager, attribute):
     """ADG2128 cross point switch."""
 
     def __init__(self, uri=""):

--- a/adi/cn0565.py
+++ b/adi/cn0565.py
@@ -10,7 +10,7 @@ from adi.adg2128 import adg2128
 from adi.context_manager import context_manager
 
 
-class cn0565(ad5940, adg2128, context_manager):
+class cn0565(ad5940, adg2128):
 
     """The CN0565 class inherits features from both the AD5940 (providing high
     precision in impedance and electrochemical frontend) and the ADG2128

--- a/test/test_cn0565.py
+++ b/test/test_cn0565.py
@@ -1,5 +1,7 @@
 import pytest
 
+import adi
+
 hardware = ["cn0565"]
 classname = "adi.cn0565"
 
@@ -29,3 +31,13 @@ def test_cn0565_attrs(
     test_attribute_single_value(
         iio_uri, classname, attr, start, stop, step, tol, repeats
     )
+
+
+@pytest.mark.iio_hardware(hardware)
+def test_cn0565_preserves_ad5940_channel_binding(iio_uri):
+    """The BIA wrapper remains bound to AD5940 after ADG2128 initialization."""
+    with adi.cn0565(uri=iio_uri) as dev:
+        assert dev._rxadc.name == "ad5940"
+        assert dev._ctrl.name == "adg2128"
+        assert list(dev.channel) == ["voltage0"]
+        assert dev.channel["voltage0"]._ctrl is dev._rxadc

--- a/test/test_refactored_devices_unit.py
+++ b/test/test_refactored_devices_unit.py
@@ -271,6 +271,44 @@ def test_adpd410x_preserves_device_and_channel_attribute_forwarding():
     assert channel.raw == 17
 
 
+def test_ad5940_common_parent_preserves_bia_ordered_mapping(monkeypatch):
+    """AD5940 keeps all RX names but exposes only BIA wrappers in its mapping."""
+    device = _mock_context(
+        monkeypatch, "ad5940", ["voltage0", "timestamp"], scan_elements=[False, False],
+    )
+    device.channels[0].name = "bia"
+    device.channels[1].name = "timestamp"
+
+    with adi.ad5940(uri="local:") as dev:
+        assert isinstance(dev, rx_chan_comp)
+        assert dev._ctrl is dev._rxadc is device
+        assert dev._rx_channel_names == ["voltage0", "timestamp"]
+        assert dev.rx_enabled_channels == [0, 1]
+        assert isinstance(dev.channel, OrderedDict)
+        assert list(dev.channel) == ["voltage0"]
+        assert isinstance(dev.channel["voltage0"], adi.ad5940._bia_channel)
+        assert dev.channel["voltage0"]._parent is dev
+        assert dev.channel["voltage0"]._ctrl is device
+
+
+def test_ad5940_bia_wrapper_preserves_raw_conversions():
+    """BIA raw reads retain magnitude, complex-float, and integer conversion."""
+    parent = Mock()
+    channel = adi.ad5940._bia_channel(parent, Mock(), "voltage0")
+
+    channel._get_iio_attr = Mock(return_value=1069547520)
+    parent.impedance_mode = True
+    parent.magnitude_mode = True
+    assert channel.raw == 1.5
+
+    channel._get_iio_attr = Mock(return_value=[1065353216, 1073741824])
+    parent.magnitude_mode = False
+    assert channel.raw == complex(1.0, 2.0)
+
+    parent.impedance_mode = False
+    assert channel.raw == complex(1065353216, 1073741824)
+
+
 @pytest.mark.parametrize("device_name", ["ad7745", "ad7746", "ad7747"])
 def test_ad7746_common_parent_preserves_order_and_wrapper_subtypes(
     monkeypatch, device_name


### PR DESCRIPTION
## Summary
- migrate AD5940 to the shared `rx_chan_comp` parent
- preserve its all-channel RX setup and BIA-only `OrderedDict` API
- align ADG2128/CN0565 inheritance ordering for the composite device
- preserve exact AD5940 wrapper/device identity after libiio lookup

## Verification
- `pytest -q --emu test/test_cn0565.py test/test_ad5940.py test/test_adg2128.py test/test_refactored_devices_unit.py` (62 passed, 14 skipped)
- `pytest -q` (76 passed, 2051 skipped)
- pre-commit on changed files
- compileall and `git diff --check`