### PR TITLE
Migrate DAQ2 and DAQ3 converters to common parents

### DIFF
--- a/adi/ad9144.py
+++ b/adi/ad9144.py
@@ -2,25 +2,19 @@
 #
 # SPDX short identifier: ADIBSD
 
-from adi.context_manager import context_manager
-from adi.rx_tx import tx
+from adi.device_base import tx_def
 from adi.sync_start import sync_start
 
 
-class ad9144(tx, context_manager, sync_start):
+class ad9144(tx_def, sync_start):
     """ AD9144 High-Speed DAC """
 
     _complex_data = False
     _tx_channel_names = ["voltage0", "voltage1"]
     _device_name = ""
-
-    def __init__(self, uri=""):
-
-        context_manager.__init__(self, uri, self._device_name)
-
-        self._txdac = self._ctx.find_device("axi-ad9144-hpc")
-
-        tx.__init__(self)
+    _control_device_name = None
+    _tx_data_device_name = "axi-ad9144-hpc"
+    compatible_parts = ["axi-ad9144-hpc"]
 
     @property
     def sample_rate(self):

--- a/adi/ad9152.py
+++ b/adi/ad9152.py
@@ -2,25 +2,19 @@
 #
 # SPDX short identifier: ADIBSD
 
-from adi.context_manager import context_manager
-from adi.rx_tx import tx
+from adi.device_base import tx_def
 from adi.sync_start import sync_start
 
 
-class ad9152(tx, context_manager, sync_start):
+class ad9152(tx_def, sync_start):
     """ AD9152 High-Speed DAC """
 
     _complex_data = False
     _tx_channel_names = ["voltage0", "voltage1"]
     _device_name = ""
-
-    def __init__(self, uri=""):
-
-        context_manager.__init__(self, uri, self._device_name)
-
-        self._txdac = self._ctx.find_device("axi-ad9152-hpc")
-
-        tx.__init__(self)
+    _control_device_name = None
+    _tx_data_device_name = "axi-ad9152-hpc"
+    compatible_parts = ["axi-ad9152-hpc"]
 
     @property
     def sample_rate(self):

--- a/adi/ad9680.py
+++ b/adi/ad9680.py
@@ -2,25 +2,19 @@
 #
 # SPDX short identifier: ADIBSD
 
-from adi.context_manager import context_manager
-from adi.rx_tx import rx
+from adi.device_base import rx_def
 from adi.sync_start import sync_start
 
 
-class ad9680(rx, context_manager, sync_start):
+class ad9680(rx_def, sync_start):
     """ AD9680 High-Speed ADC """
 
     _complex_data = False
     _rx_channel_names = ["voltage0", "voltage1"]
     _device_name = ""
-
-    def __init__(self, uri=""):
-
-        context_manager.__init__(self, uri, self._device_name)
-
-        self._rxadc = self._ctx.find_device("axi-ad9680-hpc")
-
-        rx.__init__(self)
+    _control_device_name = None
+    _rx_data_device_name = "axi-ad9680-hpc"
+    compatible_parts = ["axi-ad9680-hpc"]
 
     @property
     def test_mode(self):

--- a/test/test_refactored_devices_unit.py
+++ b/test/test_refactored_devices_unit.py
@@ -9,8 +9,9 @@ from unittest.mock import MagicMock, Mock, call, patch
 import pytest
 
 import adi
-from adi.device_base import device_base, rx_chan_comp
+from adi.device_base import device_base, rx_chan_comp, rx_def, tx_def
 from adi.rx_tx import shared_def
+from adi.sync_start import sync_start
 
 
 class _SharedDefTestDevice(shared_def):
@@ -307,6 +308,94 @@ def test_ad5940_bia_wrapper_preserves_raw_conversions():
 
     parent.impedance_mode = False
     assert channel.raw == complex(1065353216, 1073741824)
+
+
+def test_ad9680_inherited_constructor_preserves_rx_and_sync_contract(monkeypatch):
+    """AD9680 uses shared RX setup without adding a control-device assignment."""
+    device = _mock_context(monkeypatch, "axi-ad9680-hpc", ["voltage0", "voltage1"])
+
+    with adi.ad9680(uri="local:") as dev:
+        assert "__init__" not in adi.ad9680.__dict__
+        assert isinstance(dev, rx_def)
+        assert isinstance(dev, sync_start)
+        assert dev._rxadc is device
+        assert dev._rx_channel_names == ["voltage0", "voltage1"]
+        assert dev.rx_enabled_channels == [0, 1]
+        assert "_ctrl" not in dev.__dict__
+
+
+@pytest.mark.parametrize("composite", [adi.DAQ2, adi.DAQ3])
+def test_ad9680_common_parent_keeps_composite_mro(composite):
+    """DAQ2 and DAQ3 retain a valid MRO with AD9680's shared RX parent."""
+    assert issubclass(composite, adi.ad9680)
+    assert composite.__mro__.count(rx_def) == 1
+
+
+@pytest.mark.parametrize(
+    "device_class,device_name",
+    [(adi.ad9144, "axi-ad9144-hpc"), (adi.ad9152, "axi-ad9152-hpc"),],
+)
+def test_daq_dac_classes_use_inherited_tx_initialization(
+    monkeypatch, device_class, device_name
+):
+    """DAQ DAC halves use shared TX setup without introducing `_ctrl`."""
+    device = _mock_context(monkeypatch, device_name, ["voltage0", "voltage1"])
+
+    with device_class(uri="local:") as dev:
+        assert "__init__" not in device_class.__dict__
+        assert isinstance(dev, tx_def)
+        assert isinstance(dev, sync_start)
+        assert dev._txdac is device
+        assert dev._tx_channel_names == ["voltage0", "voltage1"]
+        assert dev.tx_enabled_channels == [0, 1]
+        assert "_ctrl" not in dev.__dict__
+
+
+@pytest.mark.parametrize(
+    "composite,tx_name", [(adi.DAQ2, "axi-ad9144-hpc"), (adi.DAQ3, "axi-ad9152-hpc"),],
+)
+def test_daq_composites_preserve_both_converter_devices(
+    monkeypatch, composite, tx_name
+):
+    """The shared TX/RX parents initialize both halves of each DAQ board."""
+
+    def make_device(name):
+        device = MagicMock()
+        device.name = name
+        channels = []
+        for channel_name in ("voltage0", "voltage1"):
+            channel = MagicMock()
+            channel.id = channel_name
+            channel.scan_element = True
+            channels.append(channel)
+        device.channels = channels
+        return device
+
+    tx_device = make_device(tx_name)
+    rx_device = make_device("axi-ad9680-hpc")
+
+    class FakeContext:
+        devices = [tx_device, rx_device]
+
+        @staticmethod
+        def find_device(name):
+            return next(
+                (device for device in FakeContext.devices if device.name == name), None
+            )
+
+    context = FakeContext()
+
+    def init_context(self, uri="", device_name=""):
+        self._ctx = context
+        self.uri = uri
+
+    monkeypatch.setattr("adi.rx_tx.context_manager.__init__", init_context)
+
+    with composite(uri="local:") as dev:
+        assert dev._txdac is tx_device
+        assert dev._rxadc is rx_device
+        assert dev.tx_enabled_channels == [0, 1]
+        assert dev.rx_enabled_channels == [0, 1]
 
 
 @pytest.mark.parametrize("device_name", ["ad7745", "ad7746", "ad7747"])

--- a/test/test_refactored_devices_unit.py
+++ b/test/test_refactored_devices_unit.py
@@ -398,6 +398,36 @@ def test_daq_composites_preserve_both_converter_devices(
         assert dev.rx_enabled_channels == [0, 1]
 
 
+def test_daq_converter_properties_preserve_attribute_forwarding():
+    """Retained converter properties forward to the correct IIO devices."""
+    for device_class in (adi.ad9144, adi.ad9152):
+        dev = object.__new__(device_class)
+        dev._txdac = Mock()
+        dev._get_iio_attr = Mock(return_value=1_000_000)
+        dev._set_iio_attr = Mock()
+
+        assert dev.sample_rate == 1_000_000
+        dev.sample_rate = 2_000_000
+        dev._get_iio_attr.assert_called_once_with(
+            "voltage0", "sampling_frequency", True, dev._txdac
+        )
+        dev._set_iio_attr.assert_called_once_with(
+            "voltage0", "sampling_frequency", True, 2_000_000, dev._txdac
+        )
+
+    adc = object.__new__(adi.ad9680)
+    adc._rxadc = Mock()
+    adc._get_iio_attr = Mock(return_value="ramp")
+    adc._set_iio_attr = Mock()
+
+    assert adc.test_mode == "ramp"
+    adc.test_mode = "pn_long"
+    adc._get_iio_attr.assert_called_once_with("voltage0", "test_mode", False)
+    adc._set_iio_attr.assert_called_once_with(
+        "voltage0", "test_mode", False, "pn_long", adc._rxadc
+    )
+
+
 @pytest.mark.parametrize("device_name", ["ad7745", "ad7746", "ad7747"])
 def test_ad7746_common_parent_preserves_order_and_wrapper_subtypes(
     monkeypatch, device_name


### PR DESCRIPTION
## Summary
- migrate AD9144 and AD9152 to the shared `tx_def` parent
- migrate AD9680 to the shared `rx_def` parent
- remove all three redundant subclass constructors
- preserve DAQ2/DAQ3 dual-converter MRO, device selection, sync-start support, and enabled-channel defaults

## Verification
- focused common-parent tests: 7 passed
- complete refactor unit suite: 45 passed, 29 skipped
- full local suite: 83 passed, 2051 skipped
- focused DAQ emulator/driver collection: 63 passed, 52 skipped
- pre-commit, compileall, and `git diff --check` passed