### PR TITLE
Migrate AD6676 to common RX parent

### DIFF
--- a/adi/ad6676.py
+++ b/adi/ad6676.py
@@ -2,25 +2,21 @@
 #
 # SPDX short identifier: ADIBSD
 
-from adi.context_manager import context_manager
-from adi.rx_tx import rx
+from adi.device_base import rx_def
 
 
-class ad6676(rx, context_manager):
+class ad6676(rx_def):
     """ AD6676 Wideband IF Receiver Subsystem """
 
     _complex_data = True
     _rx_channel_names = ["voltage0", "voltage1"]
     _device_name = ""
+    _control_device_name = "axi-ad6676-hpc"
+    _rx_data_device_name = "axi-ad6676-hpc"
 
-    def __init__(self, uri=""):
-
-        context_manager.__init__(self, uri, self._device_name)
-
-        self._rxadc = self._ctx.find_device("axi-ad6676-hpc")
+    def __post_init__(self):
+        """Preserve the legacy shared control and RX device identity."""
         self._ctrl = self._rxadc
-
-        rx.__init__(self)
 
     @property
     def adc_frequency(self):

--- a/test/test_ad6676.py
+++ b/test/test_ad6676.py
@@ -1,0 +1,54 @@
+from unittest.mock import Mock, call
+
+import pytest
+
+import adi
+from adi.device_base import rx_def
+
+hardware = "ad6676"
+
+
+@pytest.mark.iio_hardware(hardware)
+def test_ad6676_common_parent_preserves_rx_contract(iio_uri):
+    """AD6676 retains complex channel pairing and shared device identity."""
+    with adi.ad6676(uri=iio_uri) as dev:
+        assert "__init__" not in adi.ad6676.__dict__
+        assert isinstance(dev, rx_def)
+        assert dev._ctrl is dev._rxadc
+        assert dev._rxadc.name == "axi-ad6676-hpc"
+        assert dev._rx_channel_names == ["voltage0", "voltage1"]
+        assert dev.rx_enabled_channels == [0]
+        assert dev._num_rx_channels == 2
+        assert dev.rx_buffer_size == 1024
+        assert dev._complex_data is True
+
+
+def test_ad6676_properties_preserve_attribute_forwarding():
+    """Representative retained properties route through the legacy helpers."""
+    dev = object.__new__(adi.ad6676)
+    dev._rxadc = Mock()
+    dev._get_iio_attr_str = Mock(return_value="value")
+    dev._set_iio_attr = Mock()
+    dev._get_iio_attr = Mock(return_value="ramp")
+
+    assert dev.adc_frequency == "value"
+    assert dev.bandwidth == "value"
+    assert dev.sampling_frequency == "value"
+    assert dev.test_mode == "ramp"
+
+    dev.adc_frequency = 3_000_000_000
+    dev.bandwidth = 100_000_000
+    dev.sampling_frequency = 200_000_000
+    dev.test_mode = "pn_long"
+
+    assert dev._get_iio_attr_str.call_args_list == [
+        call("voltage0", "adc_frequency", False),
+        call("voltage0", "bandwidth", False),
+        call("voltage0", "sampling_frequency", False),
+    ]
+    assert dev._set_iio_attr.call_args_list == [
+        call("voltage0", "adc_frequency", False, 3_000_000_000),
+        call("voltage0", "bandwidth", False, 100_000_000),
+        call("voltage0", "sampling_frequency", False, 200_000_000),
+        call("voltage0", "test_mode", False, "pn_long", dev._rxadc),
+    ]


### PR DESCRIPTION
## Summary
- migrate AD6676 from direct `rx`/`context_manager` inheritance to `rx_def`
- remove the redundant subclass constructor
- preserve complex I/Q pairing and exact `_ctrl is _rxadc` identity
- add emulator-backed RX-state and property-forwarding regressions

## Verification
- `pytest -q --emu test/test_ad6676.py test/test_refactored_devices_unit.py` (68 passed, 9 skipped)
- `pytest -q` (85 passed, 2052 skipped)
- pre-commit on changed files
- compileall and `git diff --check`