### PR TITLE
Migrate ADIS16507 to common RX parent

### DIFF
--- a/adi/adis16507.py
+++ b/adi/adis16507.py
@@ -4,11 +4,10 @@
 
 import numpy as np
 
-from adi.context_manager import context_manager
-from adi.rx_tx import rx
+from adi.device_base import rx_def
 
 
-class adis16507(rx, context_manager):
+class adis16507(rx_def):
     """ ADIS16507 Precision, Miniature MEMS IMU """
 
     _complex_data = False
@@ -21,20 +20,22 @@ class adis16507(rx, context_manager):
         "accel_z",
     ]
     _device_name = ""
+    _control_device_name = None
+    _rx_data_device_name = None
     _rx_data_si_type = float
 
     def __init__(
         self, uri="", imu_dev_name="adis16507-3", trigger_name="adis16507-3-dev0"
     ):
+        self._control_device_name = imu_dev_name
+        self._rx_data_device_name = imu_dev_name
+        self._trigger_name = trigger_name
+        super().__init__(uri=uri)
 
-        context_manager.__init__(self, uri, self._device_name)
-
-        self._ctrl = self._ctx.find_device(imu_dev_name)
-        self._rxadc = self._ctx.find_device(imu_dev_name)
-        # Set default trigger
-        self._trigger = self._ctx.find_device(trigger_name)
+    def __post_init__(self):
+        """Set the requested trigger and the legacy default buffer size."""
+        self._trigger = self._ctx.find_device(self._trigger_name)
         self._rxadc._set_trigger(self._trigger)
-        rx.__init__(self)
         self.rx_buffer_size = 16  # Make default buffer smaller
 
     @property

--- a/test/emu/devices/adis16507.xml
+++ b/test/emu/devices/adis16507.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE context [
+  <!ELEMENT context (device|context-attribute)*>
+  <!ELEMENT context-attribute EMPTY>
+  <!ELEMENT device (channel|attribute|debug-attribute|buffer-attribute)*>
+  <!ELEMENT channel (scan-element?,attribute*)>
+  <!ELEMENT attribute EMPTY>
+  <!ELEMENT scan-element EMPTY>
+  <!ELEMENT debug-attribute EMPTY>
+  <!ELEMENT buffer-attribute EMPTY>
+  <!ATTLIST context name CDATA #REQUIRED>
+  <!ATTLIST context description CDATA #IMPLIED>
+  <!ATTLIST context-attribute name CDATA #REQUIRED>
+  <!ATTLIST context-attribute value CDATA #REQUIRED>
+  <!ATTLIST device id CDATA #REQUIRED>
+  <!ATTLIST device name CDATA #IMPLIED>
+  <!ATTLIST channel id CDATA #REQUIRED>
+  <!ATTLIST channel type (input|output) #REQUIRED>
+  <!ATTLIST channel name CDATA #IMPLIED>
+  <!ATTLIST scan-element index CDATA #REQUIRED>
+  <!ATTLIST scan-element format CDATA #REQUIRED>
+  <!ATTLIST scan-element scale CDATA #IMPLIED>
+  <!ATTLIST attribute name CDATA #REQUIRED>
+  <!ATTLIST attribute filename CDATA #IMPLIED>
+  <!ATTLIST attribute value CDATA #IMPLIED>
+  <!ATTLIST debug-attribute name CDATA #REQUIRED>
+  <!ATTLIST debug-attribute value CDATA #IMPLIED>
+  <!ATTLIST buffer-attribute name CDATA #REQUIRED>
+  <!ATTLIST buffer-attribute value CDATA #IMPLIED>
+]>
+<context name="network" description="ADIS16507 emulation context">
+  <device id="iio:device0" name="adis16507-3">
+    <channel id="anglvel_x" type="input">
+      <scan-element index="0" format="be:S32/32&gt;&gt;0" scale="0.000000003" />
+      <attribute name="raw" value="294318" />
+      <attribute name="scale" value="0.000000003" />
+    </channel>
+    <channel id="anglvel_y" type="input">
+      <scan-element index="1" format="be:S32/32&gt;&gt;0" scale="0.000000003" />
+      <attribute name="raw" value="-656865" />
+      <attribute name="scale" value="0.000000003" />
+    </channel>
+    <channel id="anglvel_z" type="input">
+      <scan-element index="2" format="be:S32/32&gt;&gt;0" scale="0.000000003" />
+      <attribute name="raw" value="431669" />
+      <attribute name="scale" value="0.000000003" />
+    </channel>
+    <channel id="accel_x" type="input">
+      <scan-element index="3" format="be:S32/32&gt;&gt;0" scale="0.000000095" />
+      <attribute name="raw" value="-210881" />
+      <attribute name="scale" value="0.000000095" />
+    </channel>
+    <channel id="accel_y" type="input">
+      <scan-element index="4" format="be:S32/32&gt;&gt;0" scale="0.000000095" />
+      <attribute name="raw" value="1598455" />
+      <attribute name="scale" value="0.000000095" />
+    </channel>
+    <channel id="accel_z" type="input">
+      <scan-element index="5" format="be:S32/32&gt;&gt;0" scale="0.000000095" />
+      <attribute name="raw" value="103145573" />
+      <attribute name="scale" value="0.000000095" />
+    </channel>
+    <attribute name="current_timestamp_clock" value="realtime" />
+    <attribute name="filter_low_pass_3db_frequency" value="100" />
+    <attribute name="sampling_frequency" value="2000" />
+    <buffer-attribute name="data_available" value="64" />
+    <buffer-attribute name="direction" value="in" />
+  </device>
+  <device id="trigger0" name="adis16507-3-dev0" />
+</context>

--- a/test/emu/hardware_map.yml
+++ b/test/emu/hardware_map.yml
@@ -745,6 +745,15 @@ adis16550:
   - pyadi_iio_class_support:
       - adis16550
 
+adis16507-3:
+  - adis16507-3
+  - emulate:
+      - filename: adis16507.xml
+      - data_devices:
+        - iio:device0
+  - pyadi_iio_class_support:
+      - adis16507
+
 ad7124-8:
   - ad7124
   - pyadi_iio_class_support:

--- a/test/test_adis16507.py
+++ b/test/test_adis16507.py
@@ -1,0 +1,74 @@
+import iio
+import numpy as np
+import pytest
+
+import adi
+from adi.device_base import rx_def
+
+hardware = "adis16507-3"
+
+
+@pytest.fixture
+def trigger_calls(monkeypatch):
+    """Record trigger assignments unsupported by iio-emu."""
+    calls = []
+
+    def record_trigger(device, trigger):
+        calls.append((device, trigger))
+
+    monkeypatch.setattr(iio.Device, "_set_trigger", record_trigger)
+    return calls
+
+
+@pytest.mark.iio_hardware(hardware)
+def test_adis16507_common_parent_preserves_rx_and_trigger_state(iio_uri, trigger_calls):
+    """The common RX parent retains the IMU's legacy construction contract."""
+    with adi.adis16507(uri=iio_uri) as imu:
+        assert isinstance(imu, rx_def)
+        assert list(imu._rx_channel_names) == [
+            "anglvel_x",
+            "anglvel_y",
+            "anglvel_z",
+            "accel_x",
+            "accel_y",
+            "accel_z",
+        ]
+        assert imu.rx_enabled_channels == [0, 1, 2, 3, 4, 5]
+        assert imu._num_rx_channels == 6
+        assert imu.rx_buffer_size == 16
+        assert imu._complex_data is False
+        assert imu._rx_data_si_type is float
+        assert imu._ctrl.name == "adis16507-3"
+        assert imu._rxadc.name == "adis16507-3"
+        assert imu._ctrl is not imu._rxadc
+        assert imu._trigger.name == "adis16507-3-dev0"
+        assert trigger_calls == [(imu._rxadc, imu._trigger)]
+
+
+@pytest.mark.iio_hardware(hardware)
+def test_adis16507_properties_forward_to_the_control_device(iio_uri, trigger_calls):
+    """Device properties remain readable and writable after migration."""
+    with adi.adis16507(uri=iio_uri) as imu:
+        imu.sample_rate = 1000
+        assert float(imu.sample_rate) == 1000
+
+        imu.filter_low_pass_3db_frequency = 50
+        assert float(imu.filter_low_pass_3db_frequency) == 50
+
+        imu.current_timestamp_clock = "monotonic"
+        assert imu._ctrl.attrs["current_timestamp_clock"].value == "monotonic"
+        assert imu.current_timestamp_clock == []
+
+
+@pytest.mark.iio_hardware(hardware)
+def test_adis16507_rx_data(iio_uri, trigger_calls):
+    """Each legacy IMU channel remains independently readable."""
+    with adi.adis16507(uri=iio_uri) as imu:
+        imu.rx_buffer_size = 8
+        for channel in range(6):
+            imu.rx_enabled_channels = [channel]
+            data = imu.rx()
+            assert isinstance(data, np.ndarray)
+            assert data.shape == (8,)
+            assert data.dtype == np.int32
+            imu.rx_destroy_buffer()


### PR DESCRIPTION
## Summary
- migrate ADIS16507 from direct `rx`/`context_manager` inheritance to `rx_def`
- preserve the public IMU/trigger constructor and move trigger plus buffer setup into `__post_init__`
- add a dedicated ADIS16507-3 emulation fixture and hardware-map entry
- cover exact channel order, enabled defaults, trigger routing, properties, and per-channel buffered reads

## Verification
- `pytest -q --emu test/test_adis16507.py test/test_adis16507_p.py test/test_refactored_devices_unit.py` (69 passed, 16 skipped)
- `pytest -q` (85 passed, 2057 skipped)
- pre-commit on changed files
- compileall and `git diff --check`