### PR TITLE
Migrate ADIS16550 to common RX parent

### DIFF
--- a/adi/adis16550.py
+++ b/adi/adis16550.py
@@ -3,11 +3,10 @@
 # SPDX short identifier: ADIBSD
 
 from adi.attribute import attribute
-from adi.context_manager import context_manager
-from adi.rx_tx import rx
+from adi.device_base import rx_def
 
 
-class adis16550(rx, context_manager):
+class adis16550(rx_def):
     _complex_data = False
 
     _rx_channel_names = [
@@ -27,13 +26,13 @@ class adis16550(rx, context_manager):
     ]
 
     _device_name = ""
+    _control_device_name = None
+    _rx_data_device_name = None
 
     """Disable mapping of trigger to RX device."""
     disable_trigger = False
 
     def __init__(self, uri="", device_name=None, trigger_name=None):
-        context_manager.__init__(self, uri, self._device_name)
-
         compatible_parts = ["adis16550"]
 
         if not device_name:
@@ -46,27 +45,17 @@ class adis16550(rx, context_manager):
                 + ".Please select from:"
                 + str(compatible_parts)
             )
-        else:
-            self._ctrl = self._ctx.find_device(device_name)
-            self._rxadc = self._ctx.find_device(device_name)
-            if not trigger_name:
-                trigger_name = device_name + "-dev0"
 
-        if self._ctrl is None:
-            print(
-                "No device found with device_name = "
-                + device_name
-                + ". Searching for a device found in the compatible list."
-            )
-            for i in compatible_parts:
-                self._ctrl = self._ctx.find_device(i)
-                self._rxadc = self._ctx.find_device(i)
-                if self._ctrl is not None:
-                    print("Found device = " + i + ". Will use this device instead.")
-                    break
-            if self._ctrl is None:
-                raise Exception("No compatible device found")
+        if not trigger_name:
+            trigger_name = device_name + "-dev0"
 
+        self._control_device_name = device_name
+        self._rx_data_device_name = device_name
+        self._trigger_name = trigger_name
+        super().__init__(uri=uri)
+
+    def __post_init__(self):
+        """Create channel wrappers and configure the trigger and RX buffer."""
         self.anglvel_x = self._anglvel_accel_channels(self._ctrl, "anglvel_x")
         self.anglvel_y = self._anglvel_accel_channels(self._ctrl, "anglvel_y")
         self.anglvel_z = self._anglvel_accel_channels(self._ctrl, "anglvel_z")
@@ -83,10 +72,9 @@ class adis16550(rx, context_manager):
 
         # Set default trigger
         if not self.disable_trigger:
-            self._trigger = self._ctx.find_device(trigger_name)
+            self._trigger = self._ctx.find_device(self._trigger_name)
             self._rxadc._set_trigger(self._trigger)
 
-        rx.__init__(self)
         self.rx_buffer_size = 16  # Make default buffer smaller
 
     def __get_scaled_sensor(self, channel_name: str) -> float:

--- a/test/test_adis16550.py
+++ b/test/test_adis16550.py
@@ -1,7 +1,9 @@
 import iio
+import numpy as np
 import pytest
 
 import adi
+from adi.device_base import rx_def
 
 hardware = "adis16550"
 classname = "adi.adis16550"
@@ -78,3 +80,89 @@ def test_adis16550_attr_multiple_val(
 ):
     do_mock()
     test_attribute_multiple_values(iio_uri, classname, attr, values, tol, repeats)
+
+
+@pytest.mark.iio_hardware(hardware)
+def test_adis16550_common_parent_preserves_structure(iio_uri, monkeypatch):
+    """The shared RX parent retains device, channel, and trigger state."""
+    trigger_calls = []
+
+    def record_trigger(device, trigger):
+        trigger_calls.append((device, trigger))
+
+    monkeypatch.setattr(iio.Device, "_set_trigger", record_trigger)
+
+    with adi.adis16550(uri=iio_uri) as imu:
+        assert isinstance(imu, rx_def)
+        assert imu._rx_channel_names == [
+            "anglvel_x",
+            "anglvel_y",
+            "anglvel_z",
+            "accel_x",
+            "accel_y",
+            "accel_z",
+            "temp0",
+            "deltaangl_x",
+            "deltaangl_y",
+            "deltaangl_z",
+            "deltavelocity_x",
+            "deltavelocity_y",
+            "deltavelocity_z",
+        ]
+        assert imu.rx_enabled_channels == list(range(13))
+        assert imu.rx_buffer_size == 16
+        assert imu._ctrl.name == "adis16550"
+        assert imu._rxadc.name == "adis16550"
+        assert imu._ctrl is not imu._rxadc
+        assert imu._trigger.name == "adis16550-dev0"
+        assert trigger_calls == [(imu._rxadc, imu._trigger)]
+
+        expected_wrappers = {
+            "anglvel_x": adi.adis16550._anglvel_accel_channels,
+            "accel_z": adi.adis16550._anglvel_accel_channels,
+            "temp": adi.adis16550._temp_channel,
+            "deltaangl_y": adi.adis16550._delta_channels,
+            "deltavelocity_z": adi.adis16550._delta_channels,
+        }
+        for name, wrapper_type in expected_wrappers.items():
+            wrapper = getattr(imu, name)
+            assert isinstance(wrapper, wrapper_type)
+            assert wrapper._ctrl is imu._ctrl
+
+
+@pytest.mark.iio_hardware(hardware)
+def test_adis16550_custom_constructor_and_disabled_trigger(iio_uri, monkeypatch):
+    """Custom device selection and trigger disabling remain supported."""
+    trigger_calls = []
+    monkeypatch.setattr(
+        iio.Device,
+        "_set_trigger",
+        lambda device, trigger: trigger_calls.append((device, trigger)),
+    )
+    monkeypatch.setattr(adi.adis16550, "disable_trigger", True)
+
+    with adi.adis16550(
+        uri=iio_uri, device_name="adis16550", trigger_name="custom-trigger"
+    ) as imu:
+        assert imu._control_device_name == "adis16550"
+        assert imu._rx_data_device_name == "adis16550"
+        assert imu._trigger_name == "custom-trigger"
+        assert not hasattr(imu, "_trigger")
+        assert trigger_calls == []
+
+    with pytest.raises(Exception, match="Not a compatible device"):
+        adi.adis16550(uri=iio_uri, device_name="not-adis16550")
+
+
+@pytest.mark.iio_hardware(hardware)
+def test_adis16550_buffered_read_preserves_all_data_channels(iio_uri, monkeypatch):
+    """Buffered reads continue to return all 13 configured data channels."""
+    monkeypatch.setattr(iio.Device, "_set_trigger", lambda device, trigger: None)
+
+    with adi.adis16550(uri=iio_uri) as imu:
+        imu.rx_buffer_size = 8
+        data = imu.rx()
+        assert isinstance(data, list)
+        assert len(data) == 13
+        assert all(isinstance(channel, np.ndarray) for channel in data)
+        assert all(channel.shape == (8,) for channel in data)


### PR DESCRIPTION
## Summary
- migrate ADIS16550 from direct `rx`/`context_manager` inheritance to `rx_def`
- preserve the public device/trigger constructor and configure dynamic names before common-parent discovery
- move channel wrappers, trigger routing, and the 16-sample default buffer into `__post_init__`
- add emulator-backed regressions for all 13 channels, wrapper types, trigger disablement, device identity, and buffered reads

## Verification
- `pytest -q --emu test/test_adis16550.py test/test_adis16507.py test/test_refactored_devices_unit.py` (73 passed, 28 skipped)
- `pytest -q` (85 passed, 2060 skipped)
- pre-commit on changed files
- compileall and `git diff --check`