### PR TITLE
adi: cn0540: Re-add calibration procedure

### DIFF
--- a/adi/cn0540.py
+++ b/adi/cn0540.py
@@ -49,6 +49,43 @@ class cn0540(rx_def):
         self._gpio = self._ctx.find_device("one-bit-adc-dac")
         self._ltc2308 = self._ctx.find_device("ltc2308")
 
+    @reset_buffer
+    def calibrate(self):
+        """Tune the LTC2606 until the AD7768-1 ADC codes approach zero mean."""
+        adc_chan = self._rxadc
+        dac_chan = self._ltc2606
+        adc_scale = float(self._get_iio_attr("voltage0", "scale", False, adc_chan))
+        dac_scale = float(self._get_iio_attr("voltage0", "scale", True, dac_chan))
+
+        for _ in range(20):
+            raw = self._get_iio_attr("voltage0", "raw", False, adc_chan)
+            adc_voltage = raw * adc_scale
+
+            raw = self._get_iio_attr("voltage0", "raw", True, dac_chan)
+            dac_voltage = (raw * dac_scale - adc_voltage) / dac_scale
+
+            e = int(dac_voltage * dac_scale)
+
+            if int(dac_voltage) > 2 ** 16 - 1:
+                print(
+                    "Warning: DAC voltage at upper limit, "
+                    + f"calibration may not converge (Error: {e - (2**16 - 1)} codes).\n"
+                    + "Make sure sensor is connected."
+                )
+                dac_voltage = 2 ** 16 - 1
+            elif int(dac_voltage) < 0:
+                print(
+                    "Warning: DAC voltage at lower limit, "
+                    + f"calibration may not converge (Error: {e} codes).\n"
+                    + "Make sure sensor is connected."
+                )
+                dac_voltage = 0
+
+            self._set_iio_attr_float(
+                "voltage0", "raw", True, int(dac_voltage), dac_chan
+            )
+            time.sleep(0.01)
+
     @property
     def sample_rate(self):
         """Sample rate in samples per second."""


### PR DESCRIPTION
# Description

CN0540 calibration procedure was removed in February, 2022. However, costumers reported missing that feature in August, 2023. The same commit that removed the calibrate function from CN0540 also added a slightly updated version of the calibrate function to CN0532. Re-introduce the calibration feature to CN0540 on same updated form that is available in CN0532.

Link: https://ez.analog.com/linux-software-drivers/f/q-a/572902/trouble-calibrating-cn0540-using-pyadi-iio?queryID=411c40aa86081da8ea48e1c6bad51858&objectId=82ecfad5-7016-4bd9-b5f2-74ffcddb4450&eztype=Forum%20Thread

Fixes: eaad1fabe809 ("[cn0540] Update calibration routine")

Fixes # (issue)

## Type of change

- [ ] Bug fix
- [ ] New device class interface
- [ ] New feature on an existing class
- [ ] Breaking change
- [ ] Documentation only
- [ ] Test or CI only

# How has this been tested?

State explicitly whether this was tested against **real hardware**, an **emulated context** (iio-emu), or **not run**. Name the part(s) and the context URI or board used.

- Hardware / emulation:
- Commands run (e.g. `python3 -m pytest -k ad4080 --adi-hw-map`):
- Result:

**Test configuration**
* Kernel / libiio version:
* OS:
* FPGA carrier (if applicable):

# Documentation

- [x] No documentation change needed
- [ ] Updated existing docs under `doc/source/`
- [ ] Added a new device page and linked it from the relevant toctree

# Checklist

- [ ] `invoke precommit` passes locally
- [x] All commits are signed off (`Signed-off-by: Name <email>`)
- [ ] No new warnings from the build or doc generation
- [ ] Dependent changes in libiio, kernel, or HDL are merged and referenced
