### PR TITLE
Use genalyzer for SFDR measurements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,9 @@ ignore_missing_imports="true"
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "--custom-hw-map=test/emu/hardware_map.yml --emu-xml-dir=test/emu/devices"
+# genalyzer ships a pytest reporter plugin which requires its optional
+# reporting dependencies. Only the analysis API is used here so it is disabled
+addopts = "--custom-hw-map=test/emu/hardware_map.yml --emu-xml-dir=test/emu/devices -p no:genalyzer"
 testpaths = [
     "test",
 ]

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -16,3 +16,4 @@ pyvisa
 matplotlib
 pytoml
 pytest-xdist
+genalyzer

--- a/requirements_prod_test.txt
+++ b/requirements_prod_test.txt
@@ -14,3 +14,4 @@ pytest-html
 plotly-express
 pyvisa
 tk
+genalyzer

--- a/test/dma_tests.py
+++ b/test/dma_tests.py
@@ -10,6 +10,14 @@ from scipy import signal
 import adi
 
 try:
+    # Requires the genalyzer C library (libgenalyzer) to be installed as well
+    import genalyzer as gn
+
+    have_genalyzer = True
+except (ImportError, OSError):
+    have_genalyzer = False
+
+try:
     from .plot_logger import gen_line_plot_html
 
     do_html_log = True
@@ -653,12 +661,82 @@ def cw_loopback(uri, classname, channel, param_set, use_tx2=False, use_rx2=False
     # self.assertGreater(fc * 0.01, diff, "Frequency offset")
 
 
+def measure_sfdr(sdr, data, fs, use_obs=False, window=None):
+    """measure_sfdr: Measure SFDR of captured data with genalyzer.
+
+    The FFT is computed from the data format of the receive channel itself and
+    the fundamental is located at the largest tone in the spectrum since the
+    exact received tone frequency is not always known.
+
+    parameters:
+        sdr: type=adi.rx
+            pyadi interface class instance which captured the data
+        data: type=numpy.array
+            Captured data from a single receive channel
+        fs: type=float
+            Sample rate of the receive path in samples per second
+        use_obs: type=bool
+            Data was captured from the observation receiver of the device
+        window: type=genalyzer.Window
+            FFT window applied before analysis. Defaults to Blackman-Harris
+
+    returns:
+        sfdr: type=float
+            Measured SFDR in dBc
+        amp: type=numpy.array
+            FFT magnitudes in dBFS
+        freqs: type=numpy.array
+            Frequency axis of the FFT in Hz
+    """
+    if not have_genalyzer:
+        raise ImportError(
+            "genalyzer is required to measure SFDR. Install the genalyzer python"
+            " package and the genalyzer C library (libgenalyzer)"
+        )
+
+    if window is None:
+        window = gn.Window.BLACKMAN_HARRIS
+
+    rx_device = None
+    if use_obs:
+        rx_device = sdr.obs
+        if not hasattr(rx_device, "rx_sample_rate"):
+            # Observation receivers do not expose their own sample rate
+            rx_device.rx_sample_rate = fs
+
+    # Number of single side bins to cover the spectral leakage of the window
+    ssb_fund = 4
+    ssb_rest = 3
+    if window == gn.Window.NO_WINDOW:
+        ssb_fund = 0
+        ssb_rest = 0
+
+    fft_cplx, amp, freqs = gn.pai.fft(
+        sdr, data, navg=1, window=window, rx_device=rx_device
+    )
+
+    key = "sfdr"
+    gn.mgr_remove(key)
+    gn.fa_create(key)
+    gn.fa_max_tone(key, "A", gn.FaCompTag.SIGNAL, ssb_fund)
+    gn.fa_hd(key, 3)
+    gn.fa_ssb(key, gn.FaSsb.DEFAULT, ssb_rest)
+    gn.fa_ssb(key, gn.FaSsb.DC, -1)
+    gn.fa_ssb(key, gn.FaSsb.SIGNAL, -1)
+    gn.fa_ssb(key, gn.FaSsb.WO, -1)
+    gn.fa_fsample(key, fs)
+    gn.fa_fdata(key, fs)
+
+    results = gn.fft_analysis(key, fft_cplx, len(data), gn.FreqAxisType.DC_CENTER)
+    return results["sfdr"], amp, freqs
+
+
 def t_sfdr(uri, classname, channel, param_set, sfdr_min, use_obs=False, full_scale=0.9):
     """t_sfdr: Test SFDR loopback of tone with connected loopback cables.
     This test requires a devices with TX and RX onboard where the transmit
     signal can be recovered. Sinuoidal data is passed to DMAs which is then
-    estimated on the RX side. The peak and second peak are determined in
-    the received signal to determine the sfdr.
+    estimated on the RX side. The received signal is analyzed with genalyzer
+    to determine the sfdr.
 
     parameters:
         uri: type=string
@@ -721,8 +799,12 @@ def t_sfdr(uri, classname, channel, param_set, sfdr_min, use_obs=False, full_sca
     except Exception as e:
         del sdr
         raise Exception(e)
-    del sdr
-    val, amp, freqs = spec.sfdr(data, fs=RXFS, plot=False)
+
+    try:
+        val, amp, freqs = measure_sfdr(sdr, data, RXFS, use_obs=use_obs)
+    finally:
+        del sdr
+
     if do_html_log:
         pytest.data_log = {
             "html": gen_line_plot_html(
@@ -730,7 +812,7 @@ def t_sfdr(uri, classname, channel, param_set, sfdr_min, use_obs=False, full_sca
                 amp,
                 "Frequency (Hz)",
                 "Amplitude (dBFS)",
-                "SDFR {} dBc ({})".format(val, classname),
+                "SFDR {} dBc ({})".format(val, classname),
             )
         }
     print("SFDR:", val, "dB")

--- a/test/rf/spec.py
+++ b/test/rf/spec.py
@@ -1,26 +1,13 @@
 from __future__ import division
 
 import numpy as np
-from numpy import (
-    absolute,
-    argmax,
-    argsort,
-    cos,
-    exp,
-    floor,
-    linspace,
-    log10,
-    multiply,
-    pi,
-)
+from numpy import absolute, argmax, cos, exp, floor, linspace, log10, multiply, pi
 from numpy.fft import fft, fftfreq, fftshift
 
 try:
     from scipy.signal import kaiser
 except ImportError:
     from scipy.signal.windows import kaiser
-
-from scipy.signal import find_peaks
 
 
 def spec_est(x, fs, ref=2 ** 15, plot=False, useWindow=False):
@@ -136,42 +123,6 @@ def find_harmonics(x, freqs, num_harmonics=6, tolerance=0.01):
             harmonics_vals.append(vals[indx])
             # print("Harmonic",freqs[indxs[indx]])
     return main, main_loc, harmonics_vals, harmonics_locs
-
-
-def sfdr(x, fs=1, ref=2 ** 15, plot=False):
-    amp, freqs = spec_est(x, fs=fs, ref=ref, plot=plot)
-    amp_org = amp
-    amp = fftshift(amp)
-    peak_indxs, _ = find_peaks(amp, distance=floor(len(x) * 0.1))
-
-    # Sort peaks
-    indxs = argsort(amp[peak_indxs])
-    indxs = indxs[::-1]
-    peak_indxs = peak_indxs[indxs]
-    peak_vals = amp[peak_indxs]
-
-    main = peak_vals[0]
-    next = peak_vals[1]
-    sfdr = absolute(main - next)
-
-    if plot:
-        import matplotlib.pyplot as plt
-
-        plt.subplot(2, 1, 1)
-        plt.plot(x, ".-")
-        plt.plot(1, 1, "r.")  # first sample of next chunk
-        plt.margins(0.1, 0.1)
-        plt.xlabel("Time [s]")
-        # Plot shifted data on a shifted axis
-        plt.subplot(2, 1, 2)
-        plt.plot(amp)
-        plt.plot(peak_indxs[0:3], amp[peak_indxs[0:3]], "x")
-        plt.margins(0.1, 0.1)
-        plt.xlabel("Frequency [Hz]")
-        plt.tight_layout()
-        plt.show()
-
-    return sfdr, amp_org, freqs
 
 
 def main():


### PR DESCRIPTION
Replace the custom peak-search SFDR estimator in `test/rf/spec.py` with genalyzer's Fourier analysis.

## Changes

- `test/dma_tests.py`: new `measure_sfdr()` helper computes the FFT with `gn.pai.fft()`, which derives scaling from the receive channel's data format, then runs a Fourier analysis (fundamental located as the largest tone, HD through 3, Blackman-Harris window with 4/3 single side bins) and returns the reported SFDR along with the dBFS magnitudes and frequency axis for the HTML plot log. `t_sfdr()` now measures before releasing the device since the FFT needs the live interface.
- `test/rf/spec.py`: drop the now unused custom `sfdr()` and its dead imports. `spec_est()` and the harmonic helpers remain in use by other DMA tests.
- `requirements_dev.txt`, `requirements_prod_test.txt`: add `genalyzer`.
- `pyproject.toml`: add `-p no:genalyzer` to the pytest `addopts`.

## Notes

The `-p no:genalyzer` option is required. The genalyzer wheel registers a `pytest11` entry point whose plugin imports `ansi2html`, `docutils`, `jinja2` and friends, all of which live only in its optional `[pytest]` extra. Without the option, installing `genalyzer` makes every pytest run in this repo fail at startup. Only the analysis API is used here.

The python package needs the genalyzer C library (`libgenalyzer`) installed as well; it is not bundled in the wheel. The import is guarded so test collection still works without it, and only the SFDR tests fail, with a message describing what to install.

Behavior difference: genalyzer excludes DC from spur consideration, per the standard SFDR definition, while the old peak search could report a DC offset as the worst spur. Boards with significant LO leakage may report a higher SFDR than before, so existing `sfdr_min` thresholds remain valid but are effectively looser on those parts.

## Testing

- Synthetic captures through `measure_sfdr()` with a stubbed pyadi interface: a tone with a -65 dBc spur reads 65.00 dB on both the normal and `use_obs` paths, and stays at 65 dB with a -41 dBFS DC offset added.
- `test/rf/test_spec_est.py` passes (4/4).
- Collection of the hardware test modules verified with the updated pytest config.
- The live hardware path is not exercised here, so the channel lookup in `gn.pai.fft` against a real device is unverified.